### PR TITLE
fix: tighten types and handle optional payload values

### DIFF
--- a/app/(dashboard)/accounts/page.tsx
+++ b/app/(dashboard)/accounts/page.tsx
@@ -153,7 +153,7 @@ function AccountsDataTable() {
                                     const accountsWithChildren = allAccounts
                                         .filter(account => hasChildren(account))
                                         .map(account => account.code)
-                                        .filter(Boolean) as string[];
+                                        .filter((code): code is string => Boolean(code));
                                     setExpandedAccounts(new Set(accountsWithChildren));
                                 }}
                                 disabled={isDisabled}

--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -41,7 +41,7 @@ function TransactionsImportView({ importResults, onDone }: { importResults: type
 
     const data = values.map((value) => ({
       ...value,
-      accountId: accountId as string,
+      accountId,
     }));
 
     createTransactions.mutate(data, {

--- a/components/pie-variant.tsx
+++ b/components/pie-variant.tsx
@@ -5,6 +5,7 @@ import {
   PieChart,
   ResponsiveContainer,
   Tooltip,
+  type LegendProps,
 } from "recharts";
 
 import { formatPercentage } from "@/lib/utils";
@@ -17,8 +18,11 @@ type PieVariantProps = {
   data: {
     name: string;
     value: number;
+    percent?: number;
   }[];
 };
+
+type PieChartLegendPayload = NonNullable<LegendProps["payload"]>[number];
 
 export const PieVariant = ({ data }: PieVariantProps) => {
   return (
@@ -32,33 +36,35 @@ export const PieVariant = ({ data }: PieVariantProps) => {
           content={({ payload }) => {
             return (
               <ul className="flex flex-col space-y-2">
-                {payload?.map((entry, index) => (
-                  <li
-                    key={`item-${index}`}
-                    className="flex items-center space-x-2"
-                  >
-                    <span
-                      className="size-2 rounded-full"
-                      style={{
-                        backgroundColor: entry.color,
-                      }}
-                      aria-hidden
-                    />
+                {payload?.map((entry: PieChartLegendPayload, index) => {
+                  const payloadData = entry.payload as { percent?: number };
+                  return (
+                    <li
+                      key={`item-${index}`}
+                      className="flex items-center space-x-2"
+                    >
+                      <span
+                        className="size-2 rounded-full"
+                        style={{
+                          backgroundColor: entry.color,
+                        }}
+                        aria-hidden
+                      />
 
-                    <div className="space-x-1">
-                      <span className="text-sm text-muted-foreground">
-                        {entry.value}
-                      </span>
+                      <div className="space-x-1">
+                        <span className="text-sm text-muted-foreground">
+                          {entry.value}
+                        </span>
 
-                      <span className="text-sm">
-                        {formatPercentage(
-                          (entry.payload as unknown as { percent: number })
-                            .percent * 100
-                        )}
-                      </span>
-                    </div>
-                  </li>
-                ))}
+                        <span className="text-sm">
+                          {formatPercentage(
+                            ((payloadData.percent ?? 0) * 100)
+                          )}
+                        </span>
+                      </div>
+                    </li>
+                  );
+                })}
               </ul>
             );
           }}

--- a/features/accounts/hooks/use-select-account.tsx
+++ b/features/accounts/hooks/use-select-account.tsx
@@ -15,7 +15,7 @@ import { useGetAccounts } from "@/features/accounts/api/use-get-accounts";
 
 export const useSelectAccount = (): [
   () => ReactNode,
-  () => Promise<unknown>,
+  () => Promise<string | undefined>,
 ] => {
   const accountQuery = useGetAccounts();
   const accountMutation = useCreateAccount();
@@ -34,9 +34,9 @@ export const useSelectAccount = (): [
     resolve: (value: string | undefined) => void;
   } | null>(null);
 
-  const selectValue = useRef<string>(undefined);
+  const selectValue = useRef<string | undefined>(undefined);
 
-  const confirm = () =>
+  const confirm = (): Promise<string | undefined> =>
     new Promise((resolve) => {
       setPromise({ resolve });
     });

--- a/features/customers/api/use-delete-customer.ts
+++ b/features/customers/api/use-delete-customer.ts
@@ -15,8 +15,9 @@ export const useDeleteCustomer = (id?: string) => {
                 param: { id },
             });
             if (!response.ok) {
-                const errorData = await response.json();
-                throw new Error((errorData as any).error || "Failed to delete customer.");
+                const errorData = await response.json() as ResponseType;
+                const errorMessage = 'error' in errorData ? errorData.error : "Failed to delete customer.";
+                throw new Error(errorMessage);
             }
             return await response.json();
         },

--- a/features/transactions/components/edit-transaction-sheet.tsx
+++ b/features/transactions/components/edit-transaction-sheet.tsx
@@ -31,7 +31,7 @@ type TransactionFormValues = {
   accountId: string;
   categoryId?: string | null;
   payeeCustomerId?: string;
-  payee?: string | null;
+  payee?: string;
   amount: string;
   notes?: string | null;
 };
@@ -119,8 +119,8 @@ export const EditTransactionSheet = () => {
         ? new Date(transactionQuery.data.date)
         : new Date(),
       payeeCustomerId: transactionQuery.data.payeeCustomerId ?? undefined,
-      payee: transactionQuery.data.payee,
-      notes: transactionQuery.data.notes,
+      payee: transactionQuery.data.payee ?? undefined,
+      notes: transactionQuery.data.notes ?? undefined,
     }
     : {
       accountId: undefined,
@@ -130,8 +130,8 @@ export const EditTransactionSheet = () => {
       amount: "0",
       date: new Date(),
       payeeCustomerId: undefined,
-      payee: "",
-      notes: null,
+      payee: undefined,
+      notes: undefined,
     };
 
   const onDelete = async () => {
@@ -168,7 +168,7 @@ export const EditTransactionSheet = () => {
               {transactionQuery.data && transactionQuery.data.accountId ? (
                 <TransactionForm
                   id={id}
-                  defaultValues={defaultValuesForForm as any}
+                  defaultValues={defaultValuesForForm as TransactionFormValues}
                   onSubmit={onSubmit}
                   disabled={isPending}
                   categoryOptions={categoryOptions}
@@ -180,7 +180,7 @@ export const EditTransactionSheet = () => {
               ) : (
                 <TransactionDoubleEntryForm
                   id={id}
-                  defaultValues={defaultValuesForForm as any}
+                  defaultValues={defaultValuesForForm as TransactionDoubleEntryFormValues}
                   onSubmit={onSubmit}
                   disabled={isPending}
                   categoryOptions={categoryOptions}


### PR DESCRIPTION
Improve type safety and runtime handling across several components.

- features/accounts/hooks/use-select-account.tsx
  - Narrow the select promise return type to Promise<string | undefined>.
  - Allow selectValue ref to hold string | undefined.
  - Add explicit return type for confirm() to ensure callers know it may
    resolve to undefined.

- app/(dashboard)/transactions/page.tsx
  - Stop force-casting accountId; pass through possibly-undefined value to
    transaction payload so types reflect runtime possibilities.

- components/pie-variant.tsx
  - Import LegendProps type and declare PieChartLegendPayload for clearer
    typing of legend entries.
  - Make data percent optional and guard when reading payload percent to
    avoid runtime errors; default missing percentages to 0 before
    formatting.

- features/transactions/components/edit-transaction-sheet.tsx
  - Normalize payee and notes to be optional (string | undefined)
    throughout form defaults and types instead of nullable values.
  - Use concrete TransactionFormValues type for defaultValues to avoid
    any-casts.

These changes are done to reduce unsafe any/casts, reflect optional
values accurately, and prevent runtime exceptions when fields or payload
properties are absent.