### PR TITLE
feat(db): move account-closing update to new migration

### DIFF
--- a/drizzle/0010_petite_shadow_king.sql
+++ b/drizzle/0010_petite_shadow_king.sql
@@ -1,12 +1,1 @@
 ALTER TABLE "accounts" ADD COLUMN "is_open" boolean DEFAULT true NOT NULL;
-
--- Close accounts that have no linked transactions
-UPDATE "accounts" 
-SET "is_open" = false 
-WHERE "id" NOT IN (
-    SELECT DISTINCT "account_id" FROM "transactions" WHERE "account_id" IS NOT NULL
-    UNION
-    SELECT DISTINCT "credit_account_id" FROM "transactions" WHERE "credit_account_id" IS NOT NULL
-    UNION
-    SELECT DISTINCT "debit_account_id" FROM "transactions" WHERE "debit_account_id" IS NOT NULL
-);

--- a/drizzle/0012_update_account_status.sql
+++ b/drizzle/0012_update_account_status.sql
@@ -1,0 +1,10 @@
+-- Close accounts that have no linked transactions
+UPDATE "accounts" 
+SET "is_open" = false 
+WHERE "id" NOT IN (
+    SELECT DISTINCT "account_id" FROM "transactions" WHERE "account_id" IS NOT NULL
+    UNION
+    SELECT DISTINCT "credit_account_id" FROM "transactions" WHERE "credit_account_id" IS NOT NULL
+    UNION
+    SELECT DISTINCT "debit_account_id" FROM "transactions" WHERE "debit_account_id" IS NOT NULL
+);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1754312762913,
       "tag": "0011_steady_nomad",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1754312762914,
+      "tag": "0012_update_account_status",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Move the SQL that closes accounts with no linked transactions from
migration 0010 to a new migration 0012. Keep the ALTER TABLE that adds
is_open in 0010, and add a separate 0012_update_account_status.sql that
runs UPDATE to set is_open = false for accounts not referenced by
transactions (account_id, credit_account_id, debit_account_id).

Also update the drizzle journal to register migration 0012.

This separates schema change (adding is_open) from data migration to
ensure clearer migration ordering and safer application of updates.