### PR TITLE
feat(transactions): add customer column and account validation UI

### DIFF
--- a/app/(dashboard)/transactions/TransactionsDataTable.tsx
+++ b/app/(dashboard)/transactions/TransactionsDataTable.tsx
@@ -3,8 +3,9 @@
 import { DataTable } from "@/components/data-table";
 import { useBulkDeleteTransactions } from "@/features/transactions/api/use-bulk-delete-transactions";
 import { useGetTransactions } from "@/features/transactions/api/use-get-transactions";
-import { columns } from "./columns";
+import { columns, ResponseType } from "./columns";
 import { Skeleton } from "@/components/ui/skeleton";
+import { hasValidationIssues } from "./validation";
 
 export function TransactionsDataTable() {
     const deleteTransactions = useBulkDeleteTransactions();
@@ -12,6 +13,10 @@ export function TransactionsDataTable() {
     const transactions = transactionsQuery.data || [];
 
     const isDisabled = transactionsQuery.isLoading || deleteTransactions.isPending;
+
+    const getRowClassName = (transaction: ResponseType) => {
+        return hasValidationIssues(transaction) ? "bg-red-50 hover:bg-red-100" : "";
+    };
 
     return (
         <DataTable
@@ -26,6 +31,7 @@ export function TransactionsDataTable() {
                 const ids = row.map((r) => r.original.id);
                 deleteTransactions.mutate({ ids });
             }}
-            disabled={isDisabled} />
+            disabled={isDisabled}
+            getRowClassName={getRowClassName} />
     );
 }

--- a/app/(dashboard)/transactions/account-column.tsx
+++ b/app/(dashboard)/transactions/account-column.tsx
@@ -2,25 +2,61 @@ import { AccountName } from "@/components/account-name";
 import { Row } from "@signalco/ui-primitives/Row";
 import { Typography } from "@signalco/ui-primitives/Typography";
 import { ChevronRight } from "lucide-react";
+import { ValidationIndicator } from "./validation-indicator";
 
 type AccountColumnProps = {
   account?: string | null;
   accountCode?: string | null;
+  accountIsOpen?: boolean | null;
   creditAccount?: string | null;
   creditAccountCode?: string | null;
+  creditAccountIsOpen?: boolean | null;
   debitAccount?: string | null;
   debitAccountCode?: string | null;
+  debitAccountIsOpen?: boolean | null;
 };
 
-export const AccountColumn = ({ account, accountCode, creditAccount, creditAccountCode, debitAccount, debitAccountCode }: AccountColumnProps) => {
+export const AccountColumn = ({ 
+  account, 
+  accountCode, 
+  accountIsOpen,
+  creditAccount, 
+  creditAccountCode, 
+  creditAccountIsOpen,
+  debitAccount, 
+  debitAccountCode,
+  debitAccountIsOpen 
+}: AccountColumnProps) => {
   if (account)
-    return <AccountName account={account} accountCode={accountCode} />;
+    return (
+      <Row spacing={1}>
+        {accountIsOpen === false && (
+          <ValidationIndicator 
+            message={`Account "${account}" is closed/inactive`}
+            severity="warning"
+          />
+        )}
+        <AccountName account={account} accountCode={accountCode} />
+      </Row>
+    );
 
   if (creditAccount && debitAccount)
   return (
     <Row spacing={1}>
+      {creditAccountIsOpen === false && (
+        <ValidationIndicator 
+          message={`Credit account "${creditAccount}" is closed/inactive`}
+          severity="warning"
+        />
+      )}
       <AccountName account={creditAccount} accountCode={creditAccountCode} />
       <ChevronRight className="size-4 min-w-4" />
+      {debitAccountIsOpen === false && (
+        <ValidationIndicator 
+          message={`Debit account "${debitAccount}" is closed/inactive`}
+          severity="warning"
+        />
+      )}
       <AccountName account={debitAccount} accountCode={debitAccountCode} />
     </Row>
   );

--- a/app/(dashboard)/transactions/columns.tsx
+++ b/app/(dashboard)/transactions/columns.tsx
@@ -12,6 +12,7 @@ import { formatCurrency } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { AccountColumn } from "./account-column";
 import { CategoryColumn } from "./category-column";
+import { CustomerColumn } from "./customer-column";
 
 export type ResponseType = InferResponseType<typeof client.api.transactions.$get, 200>["data"][0];
 
@@ -97,13 +98,11 @@ export const columns: ColumnDef<ResponseType>[] = [
       )
     },
     cell: ({ row }) => {
-      const customerName = row.original.payeeCustomerName;
-      const payee = row.original.payee;
-      // Display customer name if available, otherwise fall back to payee
       return (
-        <span className={!customerName && payee ? "text-red-500 font-bold" : ""}>
-          {customerName || `⚠️ ${payee}` || "⚠️ -"}
-        </span>
+        <CustomerColumn
+          customerName={row.original.payeeCustomerName}
+          payee={row.original.payee}
+        />
       );
     },
   },
@@ -150,10 +149,13 @@ export const columns: ColumnDef<ResponseType>[] = [
         <AccountColumn
           account={row.original.account}
           accountCode={row.original.accountCode}
+          accountIsOpen={row.original.accountIsOpen}
           creditAccount={row.original.creditAccount}
           creditAccountCode={row.original.creditAccountCode}
+          creditAccountIsOpen={row.original.creditAccountIsOpen}
           debitAccount={row.original.debitAccount}
           debitAccountCode={row.original.debitAccountCode}
+          debitAccountIsOpen={row.original.debitAccountIsOpen}
         />
       )
     }

--- a/app/(dashboard)/transactions/customer-column.tsx
+++ b/app/(dashboard)/transactions/customer-column.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Row } from "@signalco/ui-primitives/Row";
+import { ValidationIndicator } from "./validation-indicator";
+
+type CustomerColumnProps = {
+  customerName?: string | null;
+  payee?: string | null;
+};
+
+export const CustomerColumn = ({ customerName, payee }: CustomerColumnProps) => {
+  const hasPayee = !!payee;
+  const hasCustomer = !!customerName;
+
+  // No payee and no customer
+  if (!hasPayee && !hasCustomer) {
+    return (
+      <Row spacing={1}>
+        <ValidationIndicator
+          message="No customer information. This transaction has no payee or customer data."
+          severity="warning"
+        />
+        <span>-</span>
+      </Row>
+    );
+  }
+
+  // Has payee but no customer link
+  if (hasPayee && !hasCustomer) {
+    return (
+      <Row spacing={1}>
+        <ValidationIndicator
+          message="Customer not linked. This transaction has a payee but no associated customer record."
+          severity="warning"
+        />
+        <span>{payee}</span>
+      </Row>
+    );
+  }
+
+  // Has customer - all good
+  return <span>{customerName}</span>;
+};

--- a/app/(dashboard)/transactions/validation-indicator.tsx
+++ b/app/(dashboard)/transactions/validation-indicator.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+type ValidationIndicatorProps = {
+  message: string;
+  severity?: "warning" | "error";
+};
+
+export const ValidationIndicator = ({
+  message,
+  severity = "warning",
+}: ValidationIndicatorProps) => {
+  const colorClass = severity === "error" ? "text-red-500" : "text-amber-500";
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <AlertTriangle className={`size-4 min-w-4 ${colorClass} cursor-help`} />
+        </TooltipTrigger>
+        <TooltipContent className="max-w-xs">
+          <p>{message}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};

--- a/app/(dashboard)/transactions/validation.ts
+++ b/app/(dashboard)/transactions/validation.ts
@@ -1,0 +1,77 @@
+import { ResponseType } from "./columns";
+
+export type ValidationIssue = {
+  type: "customer" | "account" | "account-closed";
+  message: string;
+  severity: "warning" | "error";
+};
+
+/**
+ * Validates a transaction and returns any validation issues found.
+ * This centralized validation logic makes it easy to add, update, or adjust validation rules.
+ */
+export function validateTransaction(transaction: ResponseType): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+
+  // Customer validation: Check if transaction has a customer reference but no linked customer
+  const hasPayee = !!transaction.payee;
+  const hasCustomer = !!transaction.payeeCustomerName;
+  
+  if (hasPayee && !hasCustomer) {
+    issues.push({
+      type: "customer",
+      message: "Customer not linked. This transaction has a payee but no associated customer record.",
+      severity: "warning",
+    });
+  } else if (!hasPayee && !hasCustomer) {
+    issues.push({
+      type: "customer",
+      message: "No customer information. This transaction has no payee or customer data.",
+      severity: "warning",
+    });
+  }
+
+  // Account validation: Check if any accounts involved are closed/inactive
+  if (transaction.account && transaction.accountIsOpen === false) {
+    issues.push({
+      type: "account-closed",
+      message: `Account "${transaction.account}" is closed/inactive.`,
+      severity: "warning",
+    });
+  }
+
+  if (transaction.creditAccount && transaction.creditAccountIsOpen === false) {
+    issues.push({
+      type: "account-closed",
+      message: `Credit account "${transaction.creditAccount}" is closed/inactive.`,
+      severity: "warning",
+    });
+  }
+
+  if (transaction.debitAccount && transaction.debitAccountIsOpen === false) {
+    issues.push({
+      type: "account-closed",
+      message: `Debit account "${transaction.debitAccount}" is closed/inactive.`,
+      severity: "warning",
+    });
+  }
+
+  return issues;
+}
+
+/**
+ * Checks if a transaction has any validation issues.
+ */
+export function hasValidationIssues(transaction: ResponseType): boolean {
+  return validateTransaction(transaction).length > 0;
+}
+
+/**
+ * Gets a formatted message for all validation issues.
+ */
+export function getValidationMessage(transaction: ResponseType): string {
+  const issues = validateTransaction(transaction);
+  if (issues.length === 0) return "";
+  
+  return issues.map(issue => issue.message).join("\n");
+}

--- a/app/api/[[...route]]/transactionsRoutes.ts
+++ b/app/api/[[...route]]/transactionsRoutes.ts
@@ -107,12 +107,15 @@ const app = new Hono()
           account: accounts.name,
           accountCode: accounts.code,
           accountId: transactions.accountId,
+          accountIsOpen: accounts.isOpen,
           creditAccount: creditAccounts.name,
           creditAccountCode: creditAccounts.code,
           creditAccountId: transactions.creditAccountId,
+          creditAccountIsOpen: creditAccounts.isOpen,
           debitAccount: debitAccounts.name,
           debitAccountCode: debitAccounts.code,
           debitAccountId: transactions.debitAccountId,
+          debitAccountIsOpen: debitAccounts.isOpen,
         })
         .from(transactions)
         .leftJoin(accounts, eq(transactions.accountId, accounts.id))

--- a/components/data-table.tsx
+++ b/components/data-table.tsx
@@ -26,6 +26,7 @@ import { useConfirm } from "@/hooks/use-confirm"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { ChevronLeft, ChevronRight, Trash } from "lucide-react"
+import { cn } from "@/lib/utils"
 
 interface DataTableProps<TData, TValue> {
     columns: ColumnDef<TData, TValue>[]
@@ -34,6 +35,7 @@ interface DataTableProps<TData, TValue> {
     onDelete: (rows: Row<TData>[]) => void;
     disabled?: boolean;
     loading?: boolean;
+    getRowClassName?: (row: TData) => string;
 }
 
 export function DataTable<TData, TValue>({
@@ -42,7 +44,8 @@ export function DataTable<TData, TValue>({
     filterKey,
     onDelete,
     disabled,
-    loading
+    loading,
+    getRowClassName
 }: DataTableProps<TData, TValue>) {
     const [ConfirmationDialog, confirm] = useConfirm(
         "Are you sure?",
@@ -139,6 +142,9 @@ export function DataTable<TData, TValue>({
                                             <TableRow
                                                 key={row.id}
                                                 data-state={row.getIsSelected() && "selected"}
+                                                className={cn(
+                                                    getRowClassName ? getRowClassName(row.original) : undefined
+                                                )}
                                             >
                                                 {row.getVisibleCells().map((cell) => (
                                                     <TableCell key={cell.id}>


### PR DESCRIPTION
Import and render a dedicated CustomerColumn for the payee/customer
cell, replacing inline rendering logic. This centralizes customer display
and removes ad-hoc fallback/emoji logic in the table column.

ment AccountColumn and props to surface account open/active
state. Pass accountIsOpen/creditAccountIsOpen/debitAccountIsOpen from
transactions columns into AccountColumn. Render ValidationIndicator
warnings next to closed/inactive accounts while preserving existing
account name UI.

Enhance DataTable to accept an optional getRowClassName prop and apply
its result to table rows using cn util. This allows row-level classnames
for conditional styling without changing table consumers.

These changes improve separation of concerns, make customer display
consistent, and surface account validation states for clearer UX.