### PR TITLE
feat(settings): add settings API and double-entry UI

### DIFF
--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -9,6 +9,51 @@ import { useGetCategories } from "@/features/categories/api/use-get-categories";
 import { useBulkDeleteCategories } from "@/features/categories/api/use-bulk-delete-categories";
 import { DataTable } from "@/components/data-table";
 import { columns } from "../categories/columns";
+import { useGetSettings } from "@/features/settings/api/use-get-settings";
+import { useUpdateSettings } from "@/features/settings/api/use-update-settings";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+
+function DoubleEntrySettings() {
+    const settingsQuery = useGetSettings();
+    const updateSettings = useUpdateSettings();
+    
+    const isLoading = settingsQuery.isLoading;
+    const doubleEntryMode = settingsQuery.data?.doubleEntryMode ?? false;
+
+    const handleToggle = (checked: boolean) => {
+        updateSettings.mutate({ doubleEntryMode: checked });
+    };
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Accounting Mode</CardTitle>
+                <p className="text-sm text-muted-foreground mt-1">
+                    Configure how transactions are recorded in your system
+                </p>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                <div className="flex items-center justify-between space-x-2">
+                    <div className="flex-1 space-y-1">
+                        <Label htmlFor="double-entry-mode">
+                            Double-Entry Bookkeeping
+                        </Label>
+                        <p className="text-sm text-muted-foreground">
+                            When enabled, all transactions must have both credit and debit accounts
+                        </p>
+                    </div>
+                    <Switch
+                        id="double-entry-mode"
+                        checked={doubleEntryMode}
+                        onCheckedChange={handleToggle}
+                        disabled={isLoading || updateSettings.isPending}
+                    />
+                </div>
+            </CardContent>
+        </Card>
+    );
+}
 
 function CategoriesSection() {
     const newCategory = useNewCategory();
@@ -55,6 +100,7 @@ export default function SettingsPage() {
                     <Loader2 className="size-6 animate-spin text-slate-300" />
                 </div>
             )}>
+                <DoubleEntrySettings />
                 <CategoriesSection />
             </Suspense>
         </div>

--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -10,6 +10,7 @@ import { transactions as transactionSchema } from "@/db/schema";
 import { useSelectAccount } from "@/features/accounts/hooks/use-select-account";
 import { useBulkCreateTransactions } from "@/features/transactions/api/use-bulk-create-transactions";
 import { useNewTransaction } from "@/features/transactions/hooks/use-new-transaction";
+import { useGetSettings } from "@/features/settings/api/use-get-settings";
 
 import { TransactionsDataTable } from "./TransactionsDataTable";
 import { ImportButton } from "@/components/import-button";
@@ -70,6 +71,8 @@ export default function TransactionsPage() {
   const [variant, setVariant] = useState<VARIANTS>(VARIANTS.LIST);
 
   const newTransaction = useNewTransaction();
+  const settingsQuery = useGetSettings();
+  const doubleEntryMode = settingsQuery.data?.doubleEntryMode ?? false;
 
   const onUpload = (results: typeof INITIAL_IMPORT_RESULTS) => {
     setImportResults(results);
@@ -97,17 +100,10 @@ export default function TransactionsPage() {
           <div className="flex flex-col items-center gap-x-2 gap-y-2 md:flex-row">
             <Button
               size="sm"
-              onClick={() => newTransaction.onOpen(false)}
+              onClick={() => newTransaction.onOpen(doubleEntryMode)}
               className="w-full lg:w-auto"
             >
               <Plus className="mr-2 size-4" /> Add new
-            </Button>
-            <Button
-              size="sm"
-              onClick={() => newTransaction.onOpen(true)}
-              className="w-full lg:w-auto"
-            >
-              <Plus className="mr-2 size-4" /> Add new double entry
             </Button>
             <ImportButton onUpload={onUpload} />
           </div>

--- a/app/api/[[...route]]/route.ts
+++ b/app/api/[[...route]]/route.ts
@@ -6,6 +6,7 @@ import categoriesRoutes from "./categoriesRoutes";
 import customersRoutes from "./customersRoutes";
 import summaryRoutes from "./summaryRoutes";
 import transactionsRoutes from "./transactionsRoutes";
+import settingsRoutes from "./settingsRoutes";
 
 const app = new Hono().basePath("/api");
 
@@ -14,7 +15,8 @@ const routes = app
   .route("/categories", categoriesRoutes)
   .route("/customers", customersRoutes)
   .route("/summary", summaryRoutes)
-  .route("/transactions", transactionsRoutes);
+  .route("/transactions", transactionsRoutes)
+  .route("/settings", settingsRoutes);
 
 export const GET = handle(app);
 export const POST = handle(app);

--- a/app/api/[[...route]]/settingsRoutes.ts
+++ b/app/api/[[...route]]/settingsRoutes.ts
@@ -1,0 +1,86 @@
+import { clerkMiddleware, getAuth } from "@hono/clerk-auth";
+import { zValidator } from "@hono/zod-validator";
+import { Hono } from "hono";
+import { z } from "zod";
+import { and, eq } from "drizzle-orm";
+
+import { db } from "@/db/drizzle";
+import { settings, insertSettingsSchema } from "@/db/schema";
+
+const app = new Hono()
+  .get(
+    "/",
+    clerkMiddleware(),
+    async (ctx) => {
+      const auth = getAuth(ctx);
+
+      if (!auth?.userId) {
+        return ctx.json({ error: "Unauthorized." }, 401);
+      }
+
+      const [data] = await db
+        .select()
+        .from(settings)
+        .where(eq(settings.userId, auth.userId));
+
+      // Return default settings if none exist
+      if (!data) {
+        return ctx.json({ 
+          data: { 
+            userId: auth.userId, 
+            doubleEntryMode: false 
+          } 
+        });
+      }
+
+      return ctx.json({ data });
+    }
+  )
+  .patch(
+    "/",
+    clerkMiddleware(),
+    zValidator(
+      "json",
+      z.object({
+        doubleEntryMode: z.boolean(),
+      })
+    ),
+    async (ctx) => {
+      const auth = getAuth(ctx);
+      const values = ctx.req.valid("json");
+
+      if (!auth?.userId) {
+        return ctx.json({ error: "Unauthorized." }, 401);
+      }
+
+      // Check if settings exist
+      const [existingSettings] = await db
+        .select()
+        .from(settings)
+        .where(eq(settings.userId, auth.userId));
+
+      let data;
+
+      if (existingSettings) {
+        // Update existing settings
+        [data] = await db
+          .update(settings)
+          .set(values)
+          .where(eq(settings.userId, auth.userId))
+          .returning();
+      } else {
+        // Insert new settings
+        [data] = await db
+          .insert(settings)
+          .values({
+            userId: auth.userId,
+            ...values,
+          })
+          .returning();
+      }
+
+      return ctx.json({ data });
+    }
+  );
+
+export default app;

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import * as React from "react"
+import * as SwitchPrimitives from "@radix-ui/react-switch"
+
+import { cn } from "@/lib/utils"
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+      )}
+    />
+  </SwitchPrimitives.Root>
+))
+Switch.displayName = SwitchPrimitives.Root.displayName
+
+export { Switch }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -63,6 +63,15 @@ export const customersRelations = relations(customers, ({ many }) => ({
 
 export const insertCustomerSchema = createInsertSchema(customers);
 
+export const settings = pgTable("settings", {
+    userId: text("user_id").primaryKey(),
+    doubleEntryMode: boolean("double_entry_mode").notNull().default(false),
+}, (table) => [
+    index('settings_userid_idx').on(table.userId)
+]);
+
+export const insertSettingsSchema = createInsertSchema(settings);
+
 export const transactions = pgTable("transactions", {
     id: text("id").primaryKey(),
     amount: integer("amount").notNull(),

--- a/drizzle/0013_panoramic_wendell_vaughn.sql
+++ b/drizzle/0013_panoramic_wendell_vaughn.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "settings" (
+	"user_id" text PRIMARY KEY NOT NULL,
+	"double_entry_mode" boolean DEFAULT false NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "settings_userid_idx" ON "settings" USING btree ("user_id");

--- a/drizzle/meta/0013_snapshot.json
+++ b/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,508 @@
+{
+  "id": "2b585da1-1da4-40ac-8642-648731b76d2c",
+  "prevId": "2dc43dd7-d053-43bd-b6cf-901f6ff0f655",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plaid_id": {
+          "name": "plaid_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_open": {
+          "name": "is_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "accounts_userid_idx": {
+          "name": "accounts_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plaid_id": {
+          "name": "plaid_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pin": {
+          "name": "pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_telephone": {
+          "name": "contact_telephone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_complete": {
+          "name": "is_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "customers_userid_idx": {
+          "name": "customers_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_name_idx": {
+          "name": "customers_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_pin_idx": {
+          "name": "customers_pin_idx",
+          "columns": [
+            {
+              "expression": "pin",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "double_entry_mode": {
+          "name": "double_entry_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "settings_userid_idx": {
+          "name": "settings_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payee": {
+          "name": "payee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payee_customer_id": {
+          "name": "payee_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_account_id": {
+          "name": "credit_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debit_account_id": {
+          "name": "debit_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "transactions_accountid_idx": {
+          "name": "transactions_accountid_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_creditaccountid_idx": {
+          "name": "transactions_creditaccountid_idx",
+          "columns": [
+            {
+              "expression": "credit_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_debutaccountid_idx": {
+          "name": "transactions_debutaccountid_idx",
+          "columns": [
+            {
+              "expression": "debit_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_categoryid_idx": {
+          "name": "transactions_categoryid_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_payeecustomerid_idx": {
+          "name": "transactions_payeecustomerid_idx",
+          "columns": [
+            {
+              "expression": "payee_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_date_idx": {
+          "name": "transactions_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_payee_customer_id_customers_id_fk": {
+          "name": "transactions_payee_customer_id_customers_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "payee_customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_credit_account_id_accounts_id_fk": {
+          "name": "transactions_credit_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "credit_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_debit_account_id_accounts_id_fk": {
+          "name": "transactions_debit_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "debit_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_category_id_categories_id_fk": {
+          "name": "transactions_category_id_categories_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1754312762914,
       "tag": "0012_update_account_status",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1767669846583,
+      "tag": "0013_panoramic_wendell_vaughn",
+      "breakpoints": true
     }
   ]
 }

--- a/features/settings/api/use-get-settings.ts
+++ b/features/settings/api/use-get-settings.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { client } from "@/lib/hono";
+
+export const useGetSettings = () => {
+  const query = useQuery({
+    queryKey: ["settings"],
+    queryFn: async () => {
+      const response = await client.api.settings.$get();
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch settings");
+      }
+
+      const { data } = await response.json();
+      return data;
+    },
+  });
+
+  return query;
+};

--- a/features/settings/api/use-update-settings.ts
+++ b/features/settings/api/use-update-settings.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { InferRequestType, InferResponseType } from "hono";
+import { toast } from "sonner";
+
+import { client } from "@/lib/hono";
+
+type ResponseType = InferResponseType<typeof client.api.settings.$patch>;
+type RequestType = InferRequestType<typeof client.api.settings.$patch>["json"];
+
+export const useUpdateSettings = () => {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation<ResponseType, Error, RequestType>({
+    mutationFn: async (json) => {
+      const response = await client.api.settings.$patch({ json });
+      if (!response.ok) {
+        throw new Error("Failed to update settings.");
+      }
+      return await response.json();
+    },
+    onSuccess: () => {
+      toast.success("Settings updated.");
+      queryClient.invalidateQueries({ queryKey: ["settings"] });
+    },
+    onError: () => {
+      toast.error("Failed to update settings.");
+    },
+  });
+
+  return mutation;
+};

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@radix-ui/react-select": "2.2.6",
     "@radix-ui/react-separator": "1.1.8",
     "@radix-ui/react-slot": "1.2.4",
+    "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tooltip": "1.2.8",
     "@signalco/ui-primitives": "0.6.5",
     "@signalco/ui-themes-minimal-app": "0.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: 1.2.4
         version: 1.2.4(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-switch':
+        specifier: ^1.2.6
+        version: 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-tooltip':
         specifier: 1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1203,6 +1206,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-switch@1.2.6':
+    resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-tooltip@1.2.8':
@@ -3512,6 +3528,21 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.7
+
+  '@radix-ui/react-switch@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
   '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:


### PR DESCRIPTION
Add a secured settings API route with GET and PATCH handlers
using Clerk auth and Zod validation. The GET endpoint returns the
user's settings or sensible defaults when none exist. The PATCH
endpoint validates incoming payloads, updates existing settings
or inserts new records, and returns the resulting row. Database
operations use Drizzle ORM.

Introduce a DoubleEntrySettings React component to the settings
page. It fetches user settings, shows a toggle for "Double-Entry
Bookkeeping", and updates settings via mutation. The component
includes loading/disabled states and explanatory UI text.

Add a reusable Switch UI primitive (Radix-based) for toggles.

These changes enable storing and toggling accounting mode per
user so the app can support single- vs double-entry workflows.