### PR TITLE
refactor(table): make onDelete optional and streamline rendering

### DIFF
--- a/app/(dashboard)/transactions/TransactionsDataTable.tsx
+++ b/app/(dashboard)/transactions/TransactionsDataTable.tsx
@@ -1,19 +1,15 @@
 "use client";
 
 import { DataTable } from "@/components/data-table";
-import { useBulkDeleteTransactions } from "@/features/transactions/api/use-bulk-delete-transactions";
 import { useGetTransactions } from "@/features/transactions/api/use-get-transactions";
 import { columns, ResponseType } from "./columns";
 import { Skeleton } from "@/components/ui/skeleton";
 import { hasValidationIssues } from "./validation";
 
 export function TransactionsDataTable() {
-    const deleteTransactions = useBulkDeleteTransactions();
     const transactionsQuery = useGetTransactions();
     const transactions = transactionsQuery.data || [];
     const isLoading = transactionsQuery.isLoading;
-
-    const isDisabled = isLoading || deleteTransactions.isPending;
 
     const getRowClassName = (transaction: ResponseType) => {
         if (isLoading) return "";
@@ -36,11 +32,7 @@ export function TransactionsDataTable() {
             data={transactionsQuery.isLoading
                 ? Array(5).fill({})
                 : transactions}
-            onDelete={(row) => {
-                const ids = row.map((r) => r.original.id);
-                deleteTransactions.mutate({ ids });
-            }}
-            disabled={isDisabled}
+            disabled={isLoading}
             getRowClassName={getRowClassName} />
     );
 }

--- a/app/(dashboard)/transactions/columns.tsx
+++ b/app/(dashboard)/transactions/columns.tsx
@@ -4,7 +4,6 @@ import { InferResponseType } from "hono";
 import { Button } from "@/components/ui/button";
 import { ColumnDef } from "@tanstack/react-table";
 import { ArrowUpDown } from "lucide-react";
-import { Checkbox } from "@/components/ui/checkbox";
 import { client } from "@/lib/hono";
 import { Actions } from "./actions";
 import { format } from "date-fns";
@@ -18,28 +17,6 @@ import { StatusColumn } from "./status-column";
 export type ResponseType = InferResponseType<typeof client.api.transactions.$get, 200>["data"][0];
 
 export const columns: ColumnDef<ResponseType>[] = [
-  {
-    id: "select",
-    header: ({ table }) => (
-      <Checkbox
-        checked={
-          table.getIsAllPageRowsSelected() ||
-          (table.getIsSomePageRowsSelected() && "indeterminate")
-        }
-        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
-        aria-label="Select all"
-      />
-    ),
-    cell: ({ row }) => (
-      <Checkbox
-        checked={row.getIsSelected()}
-        onCheckedChange={(value) => row.toggleSelected(!!value)}
-        aria-label="Select row"
-      />
-    ),
-    enableSorting: false,
-    enableHiding: false,
-  },
   {
     accessorKey: "status",
     header: ({ column }) => {

--- a/components/data-table.tsx
+++ b/components/data-table.tsx
@@ -33,7 +33,7 @@ interface DataTableProps<TData, TValue> {
     data: TData[]
     filterKey?: string
     filterPlaceholder?: string
-    onDelete: (rows: Row<TData>[]) => void;
+    onDelete?: (rows: Row<TData>[]) => void;
     disabled?: boolean;
     loading?: boolean;
     getRowClassName?: (row: TData) => string;
@@ -90,7 +90,7 @@ export function DataTable<TData, TValue>({
                         }
                         className="max-w-sm" />
                 )}
-                {table.getFilteredSelectedRowModel().rows.length > 0 && (
+                {onDelete && table.getFilteredSelectedRowModel().rows.length > 0 && (
                     <Button
                         disabled={disabled}
                         size="sm"
@@ -139,30 +139,30 @@ export function DataTable<TData, TValue>({
                             </TableRow>
                         ) : (
                             <>
-                                    {table.getRowModel().rows?.length ? (
-                                        table.getRowModel().rows.map((row) => (
-                                            <TableRow
-                                                key={row.id}
-                                                data-state={row.getIsSelected() && "selected"}
-                                                className={cn(
-                                                    getRowClassName ? getRowClassName(row.original) : undefined
-                                                )}
-                                            >
-                                                {row.getVisibleCells().map((cell) => (
-                                                    <TableCell key={cell.id}>
-                                                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                                                    </TableCell>
-                                                ))}
-                                            </TableRow>
-                                        ))
-                                    ) : (
-                                        <TableRow>
-                                            <TableCell colSpan={columns.length} className="h-24 text-center">
-                                                No results.
-                                            </TableCell>
+                                {table.getRowModel().rows?.length ? (
+                                    table.getRowModel().rows.map((row) => (
+                                        <TableRow
+                                            key={row.id}
+                                            data-state={row.getIsSelected() && "selected"}
+                                            className={cn(
+                                                getRowClassName ? getRowClassName(row.original) : undefined
+                                            )}
+                                        >
+                                            {row.getVisibleCells().map((cell) => (
+                                                <TableCell key={cell.id}>
+                                                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                                                </TableCell>
+                                            ))}
                                         </TableRow>
-                                    )}
-                                </>
+                                    ))
+                                ) : (
+                                    <TableRow>
+                                        <TableCell colSpan={columns.length} className="h-24 text-center">
+                                            No results.
+                                        </TableCell>
+                                    </TableRow>
+                                )}
+                            </>
                         )}
                     </TableBody>
                 </Table>

--- a/features/transactions/components/new-transaction-sheet.tsx
+++ b/features/transactions/components/new-transaction-sheet.tsx
@@ -23,7 +23,7 @@ import { useNewTransaction } from "@/features/transactions/hooks/use-new-transac
 import { UnifiedTransactionForm, UnifiedTransactionFormValues } from "./unified-transaction-form";
 
 export const NewTransactionSheet = () => {
-    const { isOpen, onClose } = useNewTransaction();
+    const { isOpen, onClose, defaultValues } = useNewTransaction();
     const [activeTab, setActiveTab] = useState("details");
 
     const createMutation = useCreateUnifiedTransaction();
@@ -84,6 +84,7 @@ export const NewTransactionSheet = () => {
                                     onCreateCategory={onCreateCategory}
                                     onCreateCustomer={onCreateCustomer}
                                     onSubmit={onSubmit}
+                                    defaultValues={defaultValues}
                                 />
                             </TabsContent>
 

--- a/features/transactions/hooks/use-new-transaction.ts
+++ b/features/transactions/hooks/use-new-transaction.ts
@@ -1,13 +1,24 @@
 import { create } from "zustand";
 
+type TransactionDefaultValues = {
+  date?: Date;
+  payeeCustomerId?: string;
+  notes?: string;
+  categoryId?: string;
+  creditEntries?: { accountId: string; amount: string; categoryId: string; notes: string }[];
+  debitEntries?: { accountId: string; amount: string; categoryId: string; notes: string }[];
+};
+
 type NewTransactionState = {
   isOpen: boolean;
-  onOpen: () => void;
+  defaultValues?: TransactionDefaultValues;
+  onOpen: (defaultValues?: TransactionDefaultValues) => void;
   onClose: () => void;
 };
 
 export const useNewTransaction = create<NewTransactionState>((set) => ({
   isOpen: false,
-  onOpen: () => set({ isOpen: true }),
-  onClose: () => set({ isOpen: false }),
+  defaultValues: undefined,
+  onOpen: (defaultValues?: TransactionDefaultValues) => set({ isOpen: true, defaultValues }),
+  onClose: () => set({ isOpen: false, defaultValues: undefined }),
 }));


### PR DESCRIPTION
Make the DataTable onDelete prop optional so parent components can
omit delete behavior without changing the component. Guard the
delete button render with onDelete to avoid showing UI when no
handler is provided.

Also tidy up table body JSX formatting to remove nested fragments
and unneeded conditional wrapper, improving readability while
preserving behavior. Update TransactionsDataTable to stop importing
and using the bulk-delete hook and its pending state; remove the
isDisabled flag since delete is no longer assumed. These changes
simplify usage for consumers that don't need deletion.