### PR TITLE
feat(router): use URL query state for modal and filters

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from 'next/font/google';
 import './globals.css';
 import type { Metadata } from 'next';
 import Head from 'next/head';
+import { NuqsAdapter } from 'nuqs/adapters/next/app';
 import { type PropsWithChildren, Suspense } from 'react';
 import { Toaster } from '@/components/ui/sonner';
 import { siteConfig } from '@/config';
@@ -23,10 +24,12 @@ export default function RootLayout({ children }: PropsWithChildren) {
                 <body className={inter.className}>
                     <QueryProvider>
                         <Suspense>
-                            <SheetProvider />
+                            <NuqsAdapter>
+                                <SheetProvider />
+                                <Toaster />
+                                {children}
+                            </NuqsAdapter>
                         </Suspense>
-                        <Toaster />
-                        {children}
                     </QueryProvider>
                 </body>
             </html>

--- a/components/account-filter.tsx
+++ b/components/account-filter.tsx
@@ -1,32 +1,16 @@
 'use client';
 
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import qs from 'query-string';
+import { parseAsString, useQueryState } from 'nuqs';
 import { AccountSelect } from './account-select';
 
 export const AccountFilter = () => {
-    const pathname = usePathname();
-    const router = useRouter();
-    const searchParams = useSearchParams();
-
-    const accountId = searchParams.get('accountId') || 'all';
+    const [accountId, setAccountId] = useQueryState(
+        'accountId',
+        parseAsString.withDefault('all'),
+    );
 
     const onChange = (newValue: string) => {
-        const query = {
-            accountId: newValue,
-        };
-
-        if (newValue === 'all') query.accountId = '';
-
-        const url = qs.stringifyUrl(
-            {
-                url: pathname,
-                query,
-            },
-            { skipNull: true, skipEmptyString: true },
-        );
-
-        router.push(url);
+        void setAccountId(newValue === 'all' ? null : newValue);
     };
 
     return (

--- a/components/customer-select.tsx
+++ b/components/customer-select.tsx
@@ -152,17 +152,17 @@ export const CustomerSelect = ({
                                     }}
                                 >
                                     <div className="flex items-center justify-between w-full">
-                                        <div className="flex items-center gap-2">
-                                            <span className="font-medium">
+                                        <div className="flex items-center gap-2 min-w-0">
+                                            <span className="font-medium truncate">
                                                 {customer.name}
                                             </span>
                                             {customer.pin && (
-                                                <span className="text-xs text-muted-foreground">
+                                                <span className="text-xs text-muted-foreground whitespace-nowrap">
                                                     ({customer.pin})
                                                 </span>
                                             )}
                                             {!customer.isComplete && (
-                                                <span className="text-xs text-orange-600 font-medium">
+                                                <span className="text-xs text-orange-600 font-medium whitespace-nowrap">
                                                     (Incomplete)
                                                 </span>
                                             )}

--- a/components/data-grid.tsx
+++ b/components/data-grid.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useSearchParams } from 'next/navigation';
+import { parseAsString, useQueryStates } from 'nuqs';
 import {
     FaBalanceScale,
     FaBalanceScaleLeft,
@@ -15,11 +15,15 @@ import { DataCard, DataCardLoading } from './data-card';
 
 export const DataGrid = () => {
     const { data, isLoading } = useGetSummary();
-    const searchParams = useSearchParams();
-    const to = searchParams.get('to') || undefined;
-    const from = searchParams.get('from') || undefined;
+    const [{ from, to }] = useQueryStates({
+        from: parseAsString,
+        to: parseAsString,
+    });
 
-    const dateRangeLabel = formatDateRange({ to, from });
+    const dateRangeLabel = formatDateRange({
+        to: to ?? undefined,
+        from: from ?? undefined,
+    });
 
     if (isLoading)
         return (

--- a/features/accounts/api/use-get-accounts.ts
+++ b/features/accounts/api/use-get-accounts.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { useSearchParams } from 'next/navigation';
+import { parseAsString, useQueryState } from 'nuqs';
 import { client } from '@/lib/hono';
 
 type GetAccountsOptions = {
@@ -11,8 +11,7 @@ type GetAccountsOptions = {
 };
 
 export const useGetAccounts = (options?: GetAccountsOptions) => {
-    const searchParams = useSearchParams();
-    const paramsAccountId = searchParams.get('accountId') ?? undefined;
+    const [paramsAccountId] = useQueryState('accountId', parseAsString);
     const { page, pageSize, accountId, search, showClosed } = options || {};
     const resolvedAccountId =
         typeof accountId === 'undefined' ? paramsAccountId : accountId;

--- a/features/accounts/hooks/use-new-accounts.ts
+++ b/features/accounts/hooks/use-new-accounts.ts
@@ -1,13 +1,16 @@
-import { create } from 'zustand';
+'use client';
 
-type NewAccountState = {
-    isOpen: boolean;
-    onOpen: () => void;
-    onClose: () => void;
+import { parseAsString, useQueryState } from 'nuqs';
+
+export const useNewAccount = () => {
+    const [newAccountParam, setNewAccountParam] = useQueryState(
+        'newAccount',
+        parseAsString,
+    );
+
+    return {
+        isOpen: newAccountParam === '1',
+        onOpen: () => setNewAccountParam('1'),
+        onClose: () => setNewAccountParam(null),
+    };
 };
-
-export const useNewAccount = create<NewAccountState>((set) => ({
-    isOpen: false,
-    onOpen: () => set({ isOpen: true }),
-    onClose: () => set({ isOpen: false }),
-}));

--- a/features/accounts/hooks/use-open-account.ts
+++ b/features/accounts/hooks/use-open-account.ts
@@ -1,15 +1,17 @@
-import { create } from 'zustand';
+'use client';
 
-type OpenAccountState = {
-    id?: string;
-    isOpen: boolean;
-    onOpen: (id: string) => void;
-    onClose: () => void;
+import { parseAsString, useQueryState } from 'nuqs';
+
+export const useOpenAccount = () => {
+    const [accountSheetId, setAccountSheetId] = useQueryState(
+        'accountSheetId',
+        parseAsString,
+    );
+
+    return {
+        id: accountSheetId ?? undefined,
+        isOpen: Boolean(accountSheetId),
+        onOpen: (id: string) => setAccountSheetId(id),
+        onClose: () => setAccountSheetId(null),
+    };
 };
-
-export const useOpenAccount = create<OpenAccountState>((set) => ({
-    id: undefined,
-    isOpen: false,
-    onOpen: (id: string) => set({ isOpen: true, id }),
-    onClose: () => set({ isOpen: false, id: undefined }),
-}));

--- a/features/categories/hooks/use-new-category.ts
+++ b/features/categories/hooks/use-new-category.ts
@@ -1,13 +1,16 @@
-import { create } from 'zustand';
+'use client';
 
-type NewCategoryState = {
-    isOpen: boolean;
-    onOpen: () => void;
-    onClose: () => void;
+import { parseAsString, useQueryState } from 'nuqs';
+
+export const useNewCategory = () => {
+    const [newCategoryParam, setNewCategoryParam] = useQueryState(
+        'newCategory',
+        parseAsString,
+    );
+
+    return {
+        isOpen: newCategoryParam === '1',
+        onOpen: () => setNewCategoryParam('1'),
+        onClose: () => setNewCategoryParam(null),
+    };
 };
-
-export const useNewCategory = create<NewCategoryState>((set) => ({
-    isOpen: false,
-    onOpen: () => set({ isOpen: true }),
-    onClose: () => set({ isOpen: false }),
-}));

--- a/features/categories/hooks/use-open-category.ts
+++ b/features/categories/hooks/use-open-category.ts
@@ -1,15 +1,17 @@
-import { create } from 'zustand';
+'use client';
 
-type OpenCategoryState = {
-    id?: string;
-    isOpen: boolean;
-    onOpen: (id: string) => void;
-    onClose: () => void;
+import { parseAsString, useQueryState } from 'nuqs';
+
+export const useOpenCategory = () => {
+    const [categorySheetId, setCategorySheetId] = useQueryState(
+        'categorySheetId',
+        parseAsString,
+    );
+
+    return {
+        id: categorySheetId ?? undefined,
+        isOpen: Boolean(categorySheetId),
+        onOpen: (id: string) => setCategorySheetId(id),
+        onClose: () => setCategorySheetId(null),
+    };
 };
-
-export const useOpenCategory = create<OpenCategoryState>((set) => ({
-    id: undefined,
-    isOpen: false,
-    onOpen: (id: string) => set({ isOpen: true, id }),
-    onClose: () => set({ isOpen: false, id: undefined }),
-}));

--- a/features/customers/hooks/use-new-customer.ts
+++ b/features/customers/hooks/use-new-customer.ts
@@ -1,13 +1,16 @@
-import { create } from 'zustand';
+'use client';
 
-type NewCustomerState = {
-    isOpen: boolean;
-    onOpen: () => void;
-    onClose: () => void;
+import { parseAsString, useQueryState } from 'nuqs';
+
+export const useNewCustomer = () => {
+    const [newCustomerParam, setNewCustomerParam] = useQueryState(
+        'newCustomer',
+        parseAsString,
+    );
+
+    return {
+        isOpen: newCustomerParam === '1',
+        onOpen: () => setNewCustomerParam('1'),
+        onClose: () => setNewCustomerParam(null),
+    };
 };
-
-export const useNewCustomer = create<NewCustomerState>((set) => ({
-    isOpen: false,
-    onOpen: () => set({ isOpen: true }),
-    onClose: () => set({ isOpen: false }),
-}));

--- a/features/customers/hooks/use-open-customer.ts
+++ b/features/customers/hooks/use-open-customer.ts
@@ -1,15 +1,17 @@
-import { create } from 'zustand';
+'use client';
 
-type OpenCustomerState = {
-    id?: string;
-    isOpen: boolean;
-    onOpen: (id: string) => void;
-    onClose: () => void;
+import { parseAsString, useQueryState } from 'nuqs';
+
+export const useOpenCustomer = () => {
+    const [customerSheetId, setCustomerSheetId] = useQueryState(
+        'customerSheetId',
+        parseAsString,
+    );
+
+    return {
+        id: customerSheetId ?? undefined,
+        isOpen: Boolean(customerSheetId),
+        onOpen: (id: string) => setCustomerSheetId(id),
+        onClose: () => setCustomerSheetId(null),
+    };
 };
-
-export const useOpenCustomer = create<OpenCustomerState>((set) => ({
-    id: undefined,
-    isOpen: false,
-    onOpen: (id: string) => set({ isOpen: true, id }),
-    onClose: () => set({ isOpen: false, id: undefined }),
-}));

--- a/features/summary/api/use-get-summary.ts
+++ b/features/summary/api/use-get-summary.ts
@@ -1,23 +1,30 @@
 import { useQuery } from '@tanstack/react-query';
-import { useSearchParams } from 'next/navigation';
+import { parseAsString, useQueryStates } from 'nuqs';
 
 import { client } from '@/lib/hono';
 import { convertAmountFromMiliunits } from '@/lib/utils';
 
 export const useGetSummary = () => {
-    const searchParams = useSearchParams();
-    const from = searchParams.get('from') || '';
-    const to = searchParams.get('to') || '';
-    const accountId = searchParams.get('accountId') || '';
+    const [{ from, to, accountId }] = useQueryStates({
+        from: parseAsString,
+        to: parseAsString,
+        accountId: parseAsString,
+    });
+    const queryFrom = from ?? '';
+    const queryTo = to ?? '';
+    const queryAccountId = accountId ?? '';
 
     const query = useQuery({
-        queryKey: ['summary', { from, to, accountId }],
+        queryKey: [
+            'summary',
+            { from: queryFrom, to: queryTo, accountId: queryAccountId },
+        ],
         queryFn: async () => {
             const response = await client.api.summary.$get({
                 query: {
-                    from,
-                    to,
-                    accountId,
+                    from: queryFrom,
+                    to: queryTo,
+                    accountId: queryAccountId,
                 },
             });
 

--- a/features/transactions/api/use-get-transactions.ts
+++ b/features/transactions/api/use-get-transactions.ts
@@ -1,23 +1,30 @@
 import { useQuery } from '@tanstack/react-query';
-import { useSearchParams } from 'next/navigation';
+import { parseAsString, useQueryStates } from 'nuqs';
 
 import { client } from '@/lib/hono';
 import { convertAmountFromMiliunits } from '@/lib/utils';
 
 export const useGetTransactions = () => {
-    const searchParams = useSearchParams();
-    const from = searchParams.get('from') ?? undefined;
-    const to = searchParams.get('to') ?? undefined;
-    const accountId = searchParams.get('accountId') ?? undefined;
+    const [{ from, to, accountId }] = useQueryStates({
+        from: parseAsString,
+        to: parseAsString,
+        accountId: parseAsString,
+    });
+    const queryFrom = from ?? undefined;
+    const queryTo = to ?? undefined;
+    const queryAccountId = accountId ?? undefined;
 
     const query = useQuery({
-        queryKey: ['transactions', { from, to, accountId }],
+        queryKey: [
+            'transactions',
+            { from: queryFrom, to: queryTo, accountId: queryAccountId },
+        ],
         queryFn: async () => {
             const response = await client.api.transactions.$get({
                 query: {
-                    from,
-                    to,
-                    accountId,
+                    from: queryFrom,
+                    to: queryTo,
+                    accountId: queryAccountId,
                 },
             });
 

--- a/features/transactions/components/edit-transaction-sheet.tsx
+++ b/features/transactions/components/edit-transaction-sheet.tsx
@@ -39,7 +39,8 @@ const formSchema = insertTransactionSchema.omit({ id: true });
 type FormValues = z.infer<typeof formSchema>;
 
 export const EditTransactionSheet = () => {
-    const { isOpen, onClose, id, initialTab } = useOpenTransaction();
+    const { isOpen, onClose, id, initialTab, tab, setTab } =
+        useOpenTransaction();
 
     const [ConfirmDialog, confirm] = useConfirm(
         'Are you sure?',
@@ -97,11 +98,7 @@ export const EditTransactionSheet = () => {
             status: values.status || currentStatus,
         };
 
-        editMutation.mutate(formValues, {
-            onSuccess: () => {
-                onClose();
-            },
-        });
+        editMutation.mutate(formValues);
     };
 
     const onAdvanceStatus = async (
@@ -209,18 +206,20 @@ export const EditTransactionSheet = () => {
 
     type TabValue = 'details' | 'documents' | 'history';
     const [activeTab, setActiveTab] = useState<TabValue>(
-        initialTab || 'details',
+        tab || initialTab || 'details',
     );
 
     // Reset tab when sheet opens with a new initial tab
     React.useEffect(() => {
-        if (isOpen && initialTab) {
-            setActiveTab(initialTab);
+        if (isOpen && (tab || initialTab)) {
+            setActiveTab((tab || initialTab) as TabValue);
         }
-    }, [isOpen, initialTab]);
+    }, [isOpen, initialTab, tab]);
 
     const handleTabChange = (value: string) => {
-        setActiveTab(value as TabValue);
+        const nextTab = value as TabValue;
+        setActiveTab(nextTab);
+        setTab(nextTab);
     };
 
     return (

--- a/features/transactions/components/new-transaction-sheet.tsx
+++ b/features/transactions/components/new-transaction-sheet.tsx
@@ -46,11 +46,7 @@ export const NewTransactionSheet = () => {
     const isLoading = categoryQuery.isLoading;
 
     const onSubmit = (values: UnifiedTransactionFormValues) => {
-        createMutation.mutate(values, {
-            onSuccess: () => {
-                onClose();
-            },
-        });
+        createMutation.mutate(values);
     };
 
     return (

--- a/features/transactions/hooks/use-new-transaction.ts
+++ b/features/transactions/hooks/use-new-transaction.ts
@@ -1,3 +1,6 @@
+'use client';
+
+import { parseAsString, useQueryState } from 'nuqs';
 import { create } from 'zustand';
 
 type TransactionDefaultValues = {
@@ -20,16 +23,33 @@ type TransactionDefaultValues = {
 };
 
 type NewTransactionState = {
-    isOpen: boolean;
     defaultValues?: TransactionDefaultValues;
-    onOpen: (defaultValues?: TransactionDefaultValues) => void;
-    onClose: () => void;
+    setDefaultValues: (defaultValues?: TransactionDefaultValues) => void;
 };
 
-export const useNewTransaction = create<NewTransactionState>((set) => ({
-    isOpen: false,
+const useNewTransactionStore = create<NewTransactionState>((set) => ({
     defaultValues: undefined,
-    onOpen: (defaultValues?: TransactionDefaultValues) =>
-        set({ isOpen: true, defaultValues }),
-    onClose: () => set({ isOpen: false, defaultValues: undefined }),
+    setDefaultValues: (defaultValues?: TransactionDefaultValues) =>
+        set({ defaultValues }),
 }));
+
+export const useNewTransaction = () => {
+    const [newTransactionParam, setNewTransactionParam] = useQueryState(
+        'newTransaction',
+        parseAsString,
+    );
+    const { defaultValues, setDefaultValues } = useNewTransactionStore();
+
+    return {
+        isOpen: newTransactionParam === '1',
+        defaultValues,
+        onOpen: (values?: TransactionDefaultValues) => {
+            setDefaultValues(values);
+            void setNewTransactionParam('1');
+        },
+        onClose: () => {
+            setDefaultValues(undefined);
+            void setNewTransactionParam(null);
+        },
+    };
+};

--- a/features/transactions/hooks/use-open-transaction.ts
+++ b/features/transactions/hooks/use-open-transaction.ts
@@ -1,21 +1,39 @@
-import { create } from 'zustand';
+'use client';
 
-type OpenTransactionState = {
-    id?: string;
-    isOpen: boolean;
-    initialTab?: 'details' | 'documents' | 'history';
-    onOpen: (
-        id: string,
-        initialTab?: 'details' | 'documents' | 'history',
-    ) => void;
-    onClose: () => void;
+import { parseAsString, useQueryState } from 'nuqs';
+
+type TransactionTab = 'details' | 'documents' | 'history';
+
+const isTransactionTab = (value: string | null): value is TransactionTab =>
+    value === 'details' || value === 'documents' || value === 'history';
+
+export const useOpenTransaction = () => {
+    const [transactionId, setTransactionId] = useQueryState(
+        'transactionId',
+        parseAsString,
+    );
+    const [transactionTab, setTransactionTab] = useQueryState(
+        'transactionTab',
+        parseAsString,
+    );
+
+    const initialTab = isTransactionTab(transactionTab)
+        ? transactionTab
+        : undefined;
+
+    return {
+        id: transactionId ?? undefined,
+        isOpen: Boolean(transactionId),
+        initialTab,
+        tab: initialTab,
+        setTab: (tab?: TransactionTab) => setTransactionTab(tab ?? null),
+        onOpen: (id: string, tab?: TransactionTab) => {
+            void setTransactionId(id);
+            void setTransactionTab(tab ?? 'details');
+        },
+        onClose: () => {
+            void setTransactionId(null);
+            void setTransactionTab(null);
+        },
+    };
 };
-
-export const useOpenTransaction = create<OpenTransactionState>((set) => ({
-    id: undefined,
-    isOpen: false,
-    initialTab: undefined,
-    onOpen: (id: string, initialTab?: 'details' | 'documents' | 'history') =>
-        set({ isOpen: true, id, initialTab: initialTab ?? 'details' }),
-    onClose: () => set({ isOpen: false, id: undefined, initialTab: undefined }),
-}));

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
         "hono": "4.11.3",
         "lucide-react": "0.562.0",
         "next": "16.1.1",
+        "nuqs": "^2.4.3",
         "query-string": "9.3.1",
         "react": "19.2.3",
         "react-countup": "6.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       next:
         specifier: 16.1.1
         version: 16.1.1(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      nuqs:
+        specifier: ^2.4.3
+        version: 2.8.6(next@16.1.1(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       query-string:
         specifier: 9.3.1
         version: 9.3.1
@@ -1489,6 +1492,9 @@ packages:
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
@@ -2227,6 +2233,27 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+
+  nuqs@2.8.6:
+    resolution: {integrity: sha512-aRxeX68b4ULmhio8AADL2be1FWDy0EPqaByPvIYWrA7Pm07UjlrICp/VPlSnXJNAG0+3MQwv3OporO2sOXMVGA==}
+    peerDependencies:
+      '@remix-run/react': '>=2'
+      '@tanstack/react-router': ^1
+      next: '>=14.2.0'
+      react: '>=18.2.0 || ^19.0.0-0'
+      react-router: ^5 || ^6 || ^7
+      react-router-dom: ^5 || ^6 || ^7
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@tanstack/react-router':
+        optional: true
+      next:
+        optional: true
+      react-router:
+        optional: true
+      react-router-dom:
+        optional: true
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -4028,6 +4055,8 @@ snapshots:
 
   '@stablelib/base64@1.0.1': {}
 
+  '@standard-schema/spec@1.0.0': {}
+
   '@standard-schema/utils@0.3.0': {}
 
   '@swc/helpers@0.5.15':
@@ -4676,6 +4705,13 @@ snapshots:
       - babel-plugin-macros
 
   normalize-path@3.0.0: {}
+
+  nuqs@2.8.6(next@16.1.1(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      react: 19.2.3
+    optionalDependencies:
+      next: 16.1.1(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   object-assign@4.1.1: {}
 


### PR DESCRIPTION
Replace local Zustand modal stores with URL-backed query state using
nuqs for new customer and new category hooks. This makes modal open/close
state shareable the query string and survive navigation/refresh.

- Add nuqs dependency and lockfile entries.
- features/customers/hooks/use-new-customer.ts: switch from a
  Zustand store to useQueryState('newCustomer', parseAsString) and
  convert boolean state into query param '1' / null.
- features/categories/hooks/use-new-category.ts: same conversion for
  'newCategory'.
- components/date-filter.tsx: import parseAsString and useQueryStates
  from nuqs and adjust React imports.
- features/transactions/components/new-transaction-sheet.tsx:
  simplify createMutation usage by removing onSuccess callback (mutation
  now handles closure via query state).

These changes enable deep-linking of UI state and simplify state
management by leveraging URL query params.