### PR TITLE
fix(transactions): show cached data during background refetch

### DIFF
--- a/app/(dashboard)/transactions/TransactionsDataTable.tsx
+++ b/app/(dashboard)/transactions/TransactionsDataTable.tsx
@@ -18,11 +18,13 @@ export function TransactionsDataTable({
     const transactionsQuery = useGetTransactions();
     const bulkDeleteMutation = useBulkDeleteTransactions();
     const transactions = transactionsQuery.data || [];
-    const isLoading = transactionsQuery.isLoading;
+    // Use isLoading only for initial load (no cached data)
+    // isFetching is true during background refetch but we keep showing cached data
+    const isInitialLoading = transactionsQuery.isLoading;
     const isDeleting = bulkDeleteMutation.isPending;
 
     const getRowClassName = (transaction: ResponseType) => {
-        if (isLoading) return '';
+        if (isInitialLoading) return '';
         if (transaction.status === 'draft') {
             return 'bg-gray-50 hover:bg-gray-100 opacity-60 italic';
         }
@@ -47,7 +49,7 @@ export function TransactionsDataTable({
             filterKey="payeeCustomerName"
             filterPlaceholder="Filter transactions..."
             columns={
-                transactionsQuery.isLoading
+                isInitialLoading
                     ? tableColumns.map((column) => ({
                           ...column,
                           cell: () => (
@@ -56,10 +58,8 @@ export function TransactionsDataTable({
                       }))
                     : tableColumns
             }
-            data={
-                transactionsQuery.isLoading ? Array(5).fill({}) : transactions
-            }
-            disabled={isLoading || isDeleting}
+            data={isInitialLoading ? Array(5).fill({}) : transactions}
+            disabled={isInitialLoading || isDeleting}
             loading={isDeleting}
             onDelete={bulkDeleteMode ? handleBulkDelete : undefined}
             getRowClassName={getRowClassName}

--- a/features/transactions/api/use-get-transactions.ts
+++ b/features/transactions/api/use-get-transactions.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { parseAsString, useQueryStates } from 'nuqs';
 
 import { client } from '@/lib/hono';
@@ -19,6 +19,7 @@ export const useGetTransactions = () => {
             'transactions',
             { from: queryFrom, to: queryTo, accountId: queryAccountId },
         ],
+        placeholderData: keepPreviousData,
         queryFn: async () => {
             const response = await client.api.transactions.$get({
                 query: {


### PR DESCRIPTION
Use initial loading state for transactions table and keep previous
query data during refetch so the UI remains stable while updating.

- Replace direct use of transactionsQuery.isLoading with a new
  isInitialLoading variable to differentiate initial load from
  background refetches (isFetching). This prevents hiding or
  replacing cached rows when a background refetch occurs.
- Render placeholder rows only on initial load and keep real
  transaction data during background fetches.
- Disable controls only during initial loading or active delete
  operations (not during background refetch).
- Use react-query's keepPreviousData as placeholderData so previous
  results are preserved while the query refetches.

These changes improve UX by avoiding flashy UI updates and keeping
user context during background refreshes.