### PR TITLE
feat(accounts): add suggested account ordering and use in forms

### DIFF
--- a/app/api/[[...route]]/transactionsRoutes.ts
+++ b/app/api/[[...route]]/transactionsRoutes.ts
@@ -10,6 +10,7 @@ import {
     eq,
     gte,
     inArray,
+    isNotNull,
     isNull,
     lte,
     or,
@@ -367,6 +368,205 @@ const app = new Hono()
             });
 
             return ctx.json({ data: dataWithDocs });
+        },
+    )
+    .get(
+        '/suggested-accounts',
+        zValidator(
+            'query',
+            z.object({
+                customerId: z.string().min(1),
+            }),
+        ),
+        clerkMiddleware(),
+        async (ctx) => {
+            const auth = getAuth(ctx);
+            const { customerId } = ctx.req.valid('query');
+
+            if (!auth?.userId) {
+                return ctx.json({ error: 'Unauthorized.' }, 401);
+            }
+
+            const [customer] = await db
+                .select({ id: customers.id })
+                .from(customers)
+                .where(
+                    and(
+                        eq(customers.id, customerId),
+                        eq(customers.userId, auth.userId),
+                    ),
+                );
+
+            if (!customer) {
+                return ctx.json({ error: 'Not found.' }, 404);
+            }
+
+            const suggestionLimit = 5;
+
+            const creditUsage = await db
+                .select({
+                    accountId: transactions.creditAccountId,
+                    usageCount: sql<number>`count(*)`.as('usageCount'),
+                    lastUsed: sql<Date>`max(${transactions.date})`.as(
+                        'lastUsed',
+                    ),
+                })
+                .from(transactions)
+                .leftJoin(
+                    customers,
+                    eq(transactions.payeeCustomerId, customers.id),
+                )
+                .leftJoin(
+                    accounts,
+                    eq(transactions.creditAccountId, accounts.id),
+                )
+                .where(
+                    and(
+                        eq(transactions.payeeCustomerId, customerId),
+                        eq(customers.userId, auth.userId),
+                        eq(accounts.userId, auth.userId),
+                        isNotNull(transactions.creditAccountId),
+                    ),
+                )
+                .groupBy(transactions.creditAccountId)
+                .orderBy(
+                    desc(sql`count(*)`),
+                    desc(sql`max(${transactions.date})`),
+                )
+                .limit(suggestionLimit);
+
+            const debitUsage = await db
+                .select({
+                    accountId: transactions.debitAccountId,
+                    usageCount: sql<number>`count(*)`.as('usageCount'),
+                    lastUsed: sql<Date>`max(${transactions.date})`.as(
+                        'lastUsed',
+                    ),
+                })
+                .from(transactions)
+                .leftJoin(
+                    customers,
+                    eq(transactions.payeeCustomerId, customers.id),
+                )
+                .leftJoin(
+                    accounts,
+                    eq(transactions.debitAccountId, accounts.id),
+                )
+                .where(
+                    and(
+                        eq(transactions.payeeCustomerId, customerId),
+                        eq(customers.userId, auth.userId),
+                        eq(accounts.userId, auth.userId),
+                        isNotNull(transactions.debitAccountId),
+                    ),
+                )
+                .groupBy(transactions.debitAccountId)
+                .orderBy(
+                    desc(sql`count(*)`),
+                    desc(sql`max(${transactions.date})`),
+                )
+                .limit(suggestionLimit);
+
+            const singleAccountUsage = await db
+                .select({
+                    accountId: transactions.accountId,
+                    usageCount: sql<number>`count(*)`.as('usageCount'),
+                    lastUsed: sql<Date>`max(${transactions.date})`.as(
+                        'lastUsed',
+                    ),
+                })
+                .from(transactions)
+                .leftJoin(
+                    customers,
+                    eq(transactions.payeeCustomerId, customers.id),
+                )
+                .leftJoin(accounts, eq(transactions.accountId, accounts.id))
+                .where(
+                    and(
+                        eq(transactions.payeeCustomerId, customerId),
+                        eq(customers.userId, auth.userId),
+                        eq(accounts.userId, auth.userId),
+                        isNotNull(transactions.accountId),
+                    ),
+                )
+                .groupBy(transactions.accountId)
+                .orderBy(
+                    desc(sql`count(*)`),
+                    desc(sql`max(${transactions.date})`),
+                )
+                .limit(suggestionLimit);
+
+            const mergeUsage = (
+                primary: {
+                    accountId: string | null;
+                    usageCount: number;
+                    lastUsed: Date | null;
+                }[],
+                fallback: {
+                    accountId: string | null;
+                    usageCount: number;
+                    lastUsed: Date | null;
+                }[],
+            ) => {
+                const merged = new Map<
+                    string,
+                    {
+                        accountId: string;
+                        usageCount: number;
+                        lastUsed: Date | null;
+                    }
+                >();
+
+                const addUsage = (usageList: typeof primary) => {
+                    for (const usage of usageList) {
+                        if (!usage.accountId) continue;
+                        const existing = merged.get(usage.accountId);
+                        if (!existing) {
+                            merged.set(usage.accountId, {
+                                accountId: usage.accountId,
+                                usageCount: usage.usageCount,
+                                lastUsed: usage.lastUsed,
+                            });
+                            continue;
+                        }
+                        existing.usageCount += usage.usageCount;
+                        if (
+                            usage.lastUsed &&
+                            (!existing.lastUsed ||
+                                usage.lastUsed > existing.lastUsed)
+                        ) {
+                            existing.lastUsed = usage.lastUsed;
+                        }
+                    }
+                };
+
+                addUsage(primary);
+                addUsage(fallback);
+
+                return [...merged.values()]
+                    .sort((a, b) => {
+                        if (a.usageCount !== b.usageCount) {
+                            return b.usageCount - a.usageCount;
+                        }
+                        const aTime = a.lastUsed?.getTime() ?? 0;
+                        const bTime = b.lastUsed?.getTime() ?? 0;
+                        return bTime - aTime;
+                    })
+                    .slice(0, suggestionLimit);
+            };
+
+            const creditSuggestions = mergeUsage(
+                creditUsage,
+                singleAccountUsage,
+            );
+            const debitSuggestions = mergeUsage(debitUsage, singleAccountUsage);
+
+            return ctx.json({
+                data: {
+                    credit: creditSuggestions,
+                    debit: debitSuggestions,
+                },
+            });
         },
     )
     .get(

--- a/components/account-select.tsx
+++ b/components/account-select.tsx
@@ -24,6 +24,7 @@ export type AccountSelectProps = {
     showClosed?: boolean;
     excludeReadOnly?: boolean;
     allowedTypes?: Array<'credit' | 'debit' | 'neutral'>;
+    suggestedAccountIds?: string[];
 };
 
 export const AccountSelect = ({
@@ -36,6 +37,7 @@ export const AccountSelect = ({
     showClosed = false,
     excludeReadOnly = false,
     allowedTypes,
+    suggestedAccountIds,
 }: AccountSelectProps) => {
     const [open, setOpen] = useState(false);
     const [accountsFilter, setAccountsFilter] = useState('');
@@ -65,6 +67,25 @@ export const AccountSelect = ({
             });
         }
 
+        const suggestedIdOrder = new Map(
+            (suggestedAccountIds ?? [])
+                .filter(Boolean)
+                .map((accountId, index) => [accountId, index]),
+        );
+        if (suggestedIdOrder.size > 0) {
+            const suggested = result
+                .filter((account) => suggestedIdOrder.has(account.id))
+                .sort(
+                    (a, b) =>
+                        (suggestedIdOrder.get(a.id) ?? 0) -
+                        (suggestedIdOrder.get(b.id) ?? 0),
+                );
+            const remaining = result.filter(
+                (account) => !suggestedIdOrder.has(account.id),
+            );
+            result = [...suggested, ...remaining];
+        }
+
         // Add "all" option if needed
         if (selectAll) {
             result = [
@@ -82,7 +103,13 @@ export const AccountSelect = ({
         }
 
         return result;
-    }, [accounts, selectAll, excludeReadOnly, allowedTypes]);
+    }, [
+        accounts,
+        selectAll,
+        excludeReadOnly,
+        allowedTypes,
+        suggestedAccountIds,
+    ]);
     const filteredAccounts = useMemo(
         () =>
             resolvedAccounts?.filter((account) => {

--- a/features/transactions/api/use-get-suggested-accounts.ts
+++ b/features/transactions/api/use-get-suggested-accounts.ts
@@ -1,0 +1,40 @@
+import { useQuery } from '@tanstack/react-query';
+import { client } from '@/lib/hono';
+
+export type SuggestedAccount = {
+    accountId: string;
+    usageCount: number;
+    lastUsed: string | null;
+};
+
+type SuggestedAccountsResponse = {
+    credit: SuggestedAccount[];
+    debit: SuggestedAccount[];
+};
+
+export const useGetSuggestedAccounts = (customerId?: string) => {
+    const query = useQuery({
+        enabled: !!customerId,
+        queryKey: ['transactions', 'suggested-accounts', { customerId }],
+        queryFn: async () => {
+            if (!customerId) {
+                throw new Error('Customer ID is required');
+            }
+
+            const response = await client.api.transactions[
+                'suggested-accounts'
+            ].$get({
+                query: { customerId },
+            });
+
+            if (!response.ok) {
+                throw new Error('Failed to fetch suggested accounts.');
+            }
+
+            const { data } = await response.json();
+            return data as SuggestedAccountsResponse;
+        },
+    });
+
+    return query;
+};

--- a/features/transactions/components/unified-transaction-form.tsx
+++ b/features/transactions/components/unified-transaction-form.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/components/ui/form';
 import { SheetFooter } from '@/components/ui/sheet';
 import { Textarea } from '@/components/ui/textarea';
+import { useGetSuggestedAccounts } from '@/features/transactions/api/use-get-suggested-accounts';
 import { cn } from '@/lib/utils';
 
 // Schema for individual credit/debit entries
@@ -133,6 +134,26 @@ export const UnifiedTransactionForm = ({
         control: form.control,
         name: 'debitEntries',
     });
+    const payeeCustomerId = useWatch({
+        control: form.control,
+        name: 'payeeCustomerId',
+    });
+
+    const suggestedAccountsQuery = useGetSuggestedAccounts(payeeCustomerId);
+    const suggestedCreditAccountIds = useMemo(
+        () =>
+            suggestedAccountsQuery.data?.credit.map(
+                (suggestion) => suggestion.accountId,
+            ) ?? [],
+        [suggestedAccountsQuery.data?.credit],
+    );
+    const suggestedDebitAccountIds = useMemo(
+        () =>
+            suggestedAccountsQuery.data?.debit.map(
+                (suggestion) => suggestion.accountId,
+            ) ?? [],
+        [suggestedAccountsQuery.data?.debit],
+    );
 
     const creditTotal = useMemo(
         () =>
@@ -259,6 +280,9 @@ export const UnifiedTransactionForm = ({
                                                                 'credit',
                                                                 'neutral',
                                                             ]}
+                                                            suggestedAccountIds={
+                                                                suggestedCreditAccountIds
+                                                            }
                                                         />
                                                     </FormControl>
                                                     <FormMessage />
@@ -394,6 +418,9 @@ export const UnifiedTransactionForm = ({
                                                                 'debit',
                                                                 'neutral',
                                                             ]}
+                                                            suggestedAccountIds={
+                                                                suggestedDebitAccountIds
+                                                            }
                                                         />
                                                     </FormControl>
                                                     <FormMessage />


### PR DESCRIPTION
Add optional suggestedAccountIds prop to AccountSelect and order
results so suggested accounts appear first (maintaining given order).
Include suggestedAccountIds in the component's memo deps to ensure
updates trigger recalculation.

Introduce useGetSuggestedAccounts consumption in transaction forms.
Watch payeeCustomerId to fetch suggestions, derive arrays of suggested
credit/debit account IDs with useMemo, and pass them into AccountSelect
for credit and debit fields so the UI surfaces relevant accounts to the
user.

These changes improve UX by prioritizing contextually suggested
accounts and ensure suggestion updates are reflected in the selects.