### PR TITLE
feat(table,transactions,categories): add pagination, autosize and row actions

### DIFF
--- a/app/(dashboard)/categories/page.tsx
+++ b/app/(dashboard)/categories/page.tsx
@@ -25,6 +25,7 @@ function CategoriesDataTable() {
     return (
         <DataTable
             filterKey="name"
+            paginationKey="categories"
             columns={columns}
             data={categories}
             onDelete={(row) => {

--- a/app/(dashboard)/customers/page.tsx
+++ b/app/(dashboard)/customers/page.tsx
@@ -52,6 +52,7 @@ const CustomersPage = () => {
                 <CardContent>
                     <DataTable
                         filterKey="name"
+                        paginationKey="customers"
                         columns={columns}
                         data={customers}
                         onDelete={() => {}}

--- a/app/(dashboard)/new/page.tsx
+++ b/app/(dashboard)/new/page.tsx
@@ -36,7 +36,15 @@ function NewTransactionContent() {
     const onCreateCategory = (name: string) =>
         categoryMutation.mutate({ name });
     const onCreateCustomer = (name: string) =>
-        customerMutation.mutate({ name });
+        customerMutation
+            .mutateAsync({ name })
+            .then((response) => {
+                if ('data' in response) {
+                    return response.data.id;
+                }
+
+                throw new Error(response.error ?? 'Failed to create customer.');
+            });
 
     const isPending =
         createMutation.isPending ||

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -83,6 +83,7 @@ function CategoriesSection() {
             <CardContent>
                 <DataTable
                     filterKey="name"
+                    paginationKey="settingsCategories"
                     columns={columns}
                     data={categories}
                     onDelete={(row) => {

--- a/app/(dashboard)/transactions/TransactionsDataTable.tsx
+++ b/app/(dashboard)/transactions/TransactionsDataTable.tsx
@@ -5,6 +5,7 @@ import { DataTable } from '@/components/data-table';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useBulkDeleteTransactions } from '@/features/transactions/api/use-bulk-delete-transactions';
 import { useGetTransactions } from '@/features/transactions/api/use-get-transactions';
+import { useOpenTransaction } from '@/features/transactions/hooks/use-open-transaction';
 import { columns, type ResponseType, selectColumn } from './columns';
 import { hasValidationIssues } from './validation';
 
@@ -17,6 +18,7 @@ export function TransactionsDataTable({
 }: TransactionsDataTableProps) {
     const transactionsQuery = useGetTransactions();
     const bulkDeleteMutation = useBulkDeleteTransactions();
+    const { onOpen } = useOpenTransaction();
     const transactions = transactionsQuery.data || [];
     // Use isLoading only for initial load (no cached data)
     // isFetching is true during background refetch but we keep showing cached data
@@ -41,6 +43,10 @@ export function TransactionsDataTable({
         bulkDeleteMutation.mutate({ ids });
     };
 
+    const handleRowClick = (row: Row<ResponseType>) => {
+        onOpen(row.original.id);
+    };
+
     // Add select column when in bulk delete mode
     const tableColumns = bulkDeleteMode ? [selectColumn, ...columns] : columns;
 
@@ -48,6 +54,10 @@ export function TransactionsDataTable({
         <DataTable
             filterKey="payeeCustomerName"
             filterPlaceholder="Filter transactions..."
+            autoPageSize
+            rowHeight={48}
+            paginationKey="transactions"
+            autoResetPageIndex={false}
             columns={
                 isInitialLoading
                     ? tableColumns.map((column) => ({
@@ -62,6 +72,7 @@ export function TransactionsDataTable({
             disabled={isInitialLoading || isDeleting}
             loading={isDeleting}
             onDelete={bulkDeleteMode ? handleBulkDelete : undefined}
+            onRowClick={bulkDeleteMode ? undefined : handleRowClick}
             getRowClassName={getRowClassName}
         />
     );

--- a/app/(dashboard)/transactions/documents-column.tsx
+++ b/app/(dashboard)/transactions/documents-column.tsx
@@ -89,13 +89,17 @@ export const DocumentsColumn = ({
                                     hasAllRequiredDocuments &&
                                     'border-green-300 bg-green-50 text-green-700 hover:bg-green-100',
                             )}
+                            data-row-interactive="true"
                             onClick={handleClick}
                         >
                             <FileText className="h-3 w-3" />
                             {documentCount}
                         </Badge>
                         {showWarning && (
-                            <AlertTriangle className="h-4 w-4 text-amber-500" />
+                            <AlertTriangle
+                                className="h-4 w-4 text-amber-500"
+                                data-row-interactive="true"
+                            />
                         )}
                     </div>
                 </TooltipTrigger>

--- a/app/(dashboard)/transactions/status-column.tsx
+++ b/app/(dashboard)/transactions/status-column.tsx
@@ -161,6 +161,7 @@ export const StatusColumn = ({
         return (
             <Badge
                 variant={statusVariants[currentStatus] || 'outline'}
+                data-row-interactive="true"
                 className={`${statusColors[currentStatus] || ''}`}
             >
                 {currentStatus
@@ -183,6 +184,7 @@ export const StatusColumn = ({
                                 variant={
                                     statusVariants[currentStatus] || 'outline'
                                 }
+                                data-row-interactive="true"
                                 className={cn(
                                     statusColors[currentStatus] || '',
                                     'cursor-pointer hover:opacity-80 transition-opacity',

--- a/app/(dashboard)/transactions/validation-indicator.tsx
+++ b/app/(dashboard)/transactions/validation-indicator.tsx
@@ -25,6 +25,7 @@ export const ValidationIndicator = ({
                 <TooltipTrigger asChild>
                     <AlertTriangle
                         className={`size-4 min-w-4 ${colorClass} cursor-help`}
+                        data-row-interactive="true"
                     />
                 </TooltipTrigger>
                 <TooltipContent className="max-w-xs">

--- a/components/quick-assign-suggestions.tsx
+++ b/components/quick-assign-suggestions.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export type QuickAssignSuggestion = {
+    id: string;
+    label: string;
+};
+
+type QuickAssignSuggestionsProps = {
+    suggestions: QuickAssignSuggestion[];
+    isLoading: boolean;
+    onSelect: (id: string) => void;
+    disabled?: boolean;
+    /** Label shown before suggestions, defaults to "Suggested:" */
+    label?: string;
+};
+
+export const QuickAssignSuggestions = ({
+    suggestions,
+    isLoading,
+    onSelect,
+    disabled,
+    label = 'Suggested:',
+}: QuickAssignSuggestionsProps) => {
+    if (!isLoading && suggestions.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="flex items-center gap-1.5 flex-wrap mt-1.5">
+            {isLoading ? (
+                <span className="text-xs text-muted-foreground flex items-center gap-1">
+                    <Loader2 className="size-3 animate-spin" />
+                    Loading suggestions...
+                </span>
+            ) : (
+                <>
+                    <span className="text-xs text-muted-foreground">
+                        {label}
+                    </span>
+                    {suggestions.map((suggestion) => (
+                        <Button
+                            key={suggestion.id}
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            className="h-6 px-2 text-xs truncate max-w-24 justify-start cursor-pointer"
+                            disabled={disabled}
+                            onMouseDown={(e) => {
+                                // Use mousedown so the selection applies even if the UI unmounts
+                                // or focus changes prevent the click event from firing.
+                                e.preventDefault();
+                                onSelect(suggestion.id);
+                            }}
+                        >
+                            {suggestion.label}
+                        </Button>
+                    ))}
+                </>
+            )}
+        </div>
+    );
+};

--- a/features/customers/api/use-get-customers.ts
+++ b/features/customers/api/use-get-customers.ts
@@ -15,7 +15,15 @@ export const useGetCustomers = (search?: string) => {
             }
 
             const { data } = await response.json();
-            return data;
+            return [...data].sort((a, b) => {
+                const aName = a.name ?? '';
+                const bName = b.name ?? '';
+                const nameCompare = aName.localeCompare(bName, undefined, {
+                    sensitivity: 'base',
+                });
+                if (nameCompare !== 0) return nameCompare;
+                return a.id.localeCompare(b.id);
+            });
         },
     });
 

--- a/features/transactions/api/use-documents.ts
+++ b/features/transactions/api/use-documents.ts
@@ -11,6 +11,7 @@ type DocumentsResponseType = InferResponseType<
 export const useGetDocuments = (transactionId: string) => {
     const query = useQuery<DocumentsResponseType>({
         queryKey: ['documents', transactionId],
+        enabled: Boolean(transactionId),
         queryFn: async () => {
             const response = await client.api.documents.transaction[
                 ':transactionId'

--- a/features/transactions/api/use-get-suggested-customers.ts
+++ b/features/transactions/api/use-get-suggested-customers.ts
@@ -11,26 +11,33 @@ type SuggestedCustomersOptions = {
 
 export const useGetSuggestedCustomers = (
     query?: string,
+    notes?: string,
     options?: SuggestedCustomersOptions,
 ) => {
     const normalizedQuery = query?.trim() ?? '';
+    const normalizedNotes = notes?.trim() ?? '';
 
     const suggestedQuery = useQuery({
-        enabled: normalizedQuery.length > 0 && (options?.enabled ?? true),
+        enabled:
+            (normalizedQuery.length > 0 || normalizedNotes.length > 0) &&
+            (options?.enabled ?? true),
         queryKey: [
             'transactions',
             'suggested-customers',
-            { query: normalizedQuery },
+            { query: normalizedQuery, notes: normalizedNotes },
         ],
         queryFn: async () => {
-            if (!normalizedQuery) {
-                throw new Error('Query is required');
+            if (!normalizedQuery && !normalizedNotes) {
+                throw new Error('Query or notes is required');
             }
 
             const response = await client.api.transactions[
                 'suggested-customers'
             ].$get({
-                query: { query: normalizedQuery },
+                query: {
+                    query: normalizedQuery || undefined,
+                    notes: normalizedNotes || undefined,
+                },
             });
 
             if (!response.ok) {

--- a/features/transactions/api/use-get-transactions.ts
+++ b/features/transactions/api/use-get-transactions.ts
@@ -38,9 +38,16 @@ export const useGetTransactions = () => {
                 amount: convertAmountFromMiliunits(transaction.amount),
             }));
 
+            const sortedByDateDesc = [...converted].sort((a, b) => {
+                const aTime = new Date(a.date).getTime();
+                const bTime = new Date(b.date).getTime();
+                if (aTime !== bTime) return bTime - aTime;
+                return a.id.localeCompare(b.id);
+            });
+
             // Group splits so parent is followed by its children
             const childrenByGroup = new Map<string, typeof converted>();
-            for (const tx of converted) {
+            for (const tx of sortedByDateDesc) {
                 if (tx.splitGroupId && tx.splitType === 'child') {
                     const list = childrenByGroup.get(tx.splitGroupId) ?? [];
                     list.push(tx);
@@ -51,7 +58,7 @@ export const useGetTransactions = () => {
             const ordered: typeof converted = [];
             const seen = new Set<string>();
 
-            for (const tx of converted) {
+            for (const tx of sortedByDateDesc) {
                 if (seen.has(tx.id)) continue;
 
                 if (tx.splitGroupId && tx.splitType === 'parent') {
@@ -71,7 +78,7 @@ export const useGetTransactions = () => {
             }
 
             // Any orphan children (missing parent) get appended at end
-            for (const tx of converted) {
+            for (const tx of sortedByDateDesc) {
                 if (!seen.has(tx.id)) {
                     ordered.push(tx);
                     seen.add(tx.id);

--- a/features/transactions/components/edit-transaction-sheet.tsx
+++ b/features/transactions/components/edit-transaction-sheet.tsx
@@ -73,7 +73,15 @@ export const EditTransactionSheet = () => {
     const onCreateCategory = (name: string) =>
         categoryMutation.mutate({ name });
     const onCreateCustomer = (name: string) =>
-        customerMutation.mutate({ name });
+        customerMutation
+            .mutateAsync({ name })
+            .then((response) => {
+                if ('data' in response) {
+                    return response.data.id;
+                }
+
+                throw new Error(response.error ?? 'Failed to create customer.');
+            });
 
     const isPending =
         editMutation.isPending ||

--- a/features/transactions/components/new-transaction-sheet.tsx
+++ b/features/transactions/components/new-transaction-sheet.tsx
@@ -37,7 +37,15 @@ export const NewTransactionSheet = () => {
     const onCreateCategory = (name: string) =>
         categoryMutation.mutate({ name });
     const onCreateCustomer = (name: string) =>
-        customerMutation.mutate({ name });
+        customerMutation
+            .mutateAsync({ name })
+            .then((response) => {
+                if ('data' in response) {
+                    return response.data.id;
+                }
+
+                throw new Error(response.error ?? 'Failed to create customer.');
+            });
 
     const isPending =
         createMutation.isPending ||

--- a/features/transactions/components/unified-edit-transaction-form.tsx
+++ b/features/transactions/components/unified-edit-transaction-form.tsx
@@ -7,6 +7,10 @@ import { AccountSelect } from '@/components/account-select';
 import { AmountInput } from '@/components/amount-input';
 import { CustomerSelect } from '@/components/customer-select';
 import { DatePicker } from '@/components/date-picker';
+import {
+    type QuickAssignSuggestion,
+    QuickAssignSuggestions,
+} from '@/components/quick-assign-suggestions';
 import { Select } from '@/components/select';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
@@ -20,8 +24,11 @@ import {
 } from '@/components/ui/form';
 import { SheetFooter } from '@/components/ui/sheet';
 import { Textarea } from '@/components/ui/textarea';
+import { useGetAccounts } from '@/features/accounts/api/use-get-accounts';
+import { useGetCustomers } from '@/features/customers/api/use-get-customers';
 import { useGetSuggestedAccounts } from '@/features/transactions/api/use-get-suggested-accounts';
 import { useGetSuggestedCategories } from '@/features/transactions/api/use-get-suggested-categories';
+import { useGetSuggestedCustomers } from '@/features/transactions/api/use-get-suggested-customers';
 
 // Base form schema - accounts are optional, validation depends on status
 const baseFormSchema = z.object({
@@ -67,7 +74,7 @@ type Props = {
     disabled?: boolean;
     categoryOptions: { label: string; value: string }[];
     onCreateCategory: (name: string) => void;
-    onCreateCustomer: (name: string) => void;
+    onCreateCustomer: (name: string) => Promise<string | undefined> | void;
     onSubmit: (values: UnifiedEditTransactionFormValues) => void;
     onDelete?: () => void;
     defaultValues?: Partial<UnifiedEditTransactionFormValues>;
@@ -111,12 +118,68 @@ export const UnifiedEditTransactionForm = ({
         name: 'payeeCustomerId',
     });
 
+    const notesValue = useWatch({
+        control: form.control,
+        name: 'notes',
+    });
+
+    const creditAccountId = useWatch({
+        control: form.control,
+        name: 'creditAccountId',
+    });
+
+    const debitAccountId = useWatch({
+        control: form.control,
+        name: 'debitAccountId',
+    });
+
+    const categoryId = useWatch({
+        control: form.control,
+        name: 'categoryId',
+    });
+
     const [isAccountSelectOpen, setIsAccountSelectOpen] = useState(false);
     const [isCategoryMenuOpen, setIsCategoryMenuOpen] = useState(false);
 
-    const suggestedAccountsQuery = useGetSuggestedAccounts(payeeCustomerId, {
-        enabled: isAccountSelectOpen,
-    });
+    // Fetch customers list for quick-assign display
+    const { data: customers } = useGetCustomers();
+
+    // Fetch accounts list for quick-assign display
+    const { data: accounts } = useGetAccounts({ pageSize: 9999 });
+
+    // Use either watched value or default value for notes (watched value may be empty on first render)
+    const effectiveNotes = notesValue || defaultValues?.notes || '';
+
+    // Customer suggestions - fetch when customer is not set and we have payee text or notes
+    const shouldFetchCustomerSuggestions =
+        !payeeCustomerId && (!!payeeText || !!effectiveNotes);
+    const suggestedCustomersQuery = useGetSuggestedCustomers(
+        payeeText ?? '',
+        effectiveNotes,
+        {
+            enabled: shouldFetchCustomerSuggestions,
+        },
+    );
+
+    // Account suggestions - fetch when customer is selected but accounts are not set
+    // Use defaultValues as fallback for initial render
+    const effectiveCustomerId =
+        payeeCustomerId || defaultValues?.payeeCustomerId || '';
+    const effectiveCreditAccountId =
+        creditAccountId || defaultValues?.creditAccountId || '';
+    const effectiveDebitAccountId =
+        debitAccountId || defaultValues?.debitAccountId || '';
+    const effectiveCategoryId = categoryId || defaultValues?.categoryId || '';
+
+    const shouldFetchAccountSuggestions =
+        !!effectiveCustomerId &&
+        (!effectiveCreditAccountId || !effectiveDebitAccountId);
+    const suggestedAccountsQuery = useGetSuggestedAccounts(
+        effectiveCustomerId,
+        {
+            enabled: shouldFetchAccountSuggestions || isAccountSelectOpen,
+        },
+    );
     const suggestedCreditAccountIds = useMemo(
         () =>
             suggestedAccountsQuery.data?.credit.map(
@@ -132,10 +195,13 @@ export const UnifiedEditTransactionForm = ({
         [suggestedAccountsQuery.data?.debit],
     );
 
+    // Category suggestions - fetch when customer is selected but category is not set
+    const shouldFetchCategorySuggestions =
+        !!effectiveCustomerId && !effectiveCategoryId;
     const suggestedCategoriesQuery = useGetSuggestedCategories(
-        payeeCustomerId,
+        effectiveCustomerId,
         {
-            enabled: isCategoryMenuOpen,
+            enabled: shouldFetchCategorySuggestions || isCategoryMenuOpen,
         },
     );
     const suggestedCategoryIds = useMemo(
@@ -145,6 +211,74 @@ export const UnifiedEditTransactionForm = ({
             ) ?? [],
         [suggestedCategoriesQuery.data],
     );
+
+    // Quick-assign suggestions for customer
+    const customerQuickAssignSuggestions = useMemo<
+        QuickAssignSuggestion[]
+    >(() => {
+        if (!suggestedCustomersQuery.data || effectiveCustomerId) return [];
+        return suggestedCustomersQuery.data
+            .slice(0, 3)
+            .map((suggestion) => {
+                const customer = customers?.find(
+                    (c) => c.id === suggestion.customerId,
+                );
+                return {
+                    id: suggestion.customerId,
+                    label: customer?.name ?? 'Unknown',
+                };
+            })
+            .filter((s) => s.label !== 'Unknown');
+    }, [suggestedCustomersQuery.data, customers, effectiveCustomerId]);
+
+    // Quick-assign suggestions for credit account
+    const creditAccountQuickAssignSuggestions = useMemo<
+        QuickAssignSuggestion[]
+    >(() => {
+        if (effectiveCreditAccountId || !suggestedCreditAccountIds.length)
+            return [];
+        return suggestedCreditAccountIds.slice(0, 3).map((accountId) => {
+            const account = accounts?.find((a) => a.id === accountId);
+            return {
+                id: accountId,
+                label: account
+                    ? `${account.code ? `${account.code} - ` : ''}${account.name}`
+                    : 'Unknown',
+            };
+        });
+    }, [suggestedCreditAccountIds, accounts, effectiveCreditAccountId]);
+
+    // Quick-assign suggestions for debit account
+    const debitAccountQuickAssignSuggestions = useMemo<
+        QuickAssignSuggestion[]
+    >(() => {
+        if (effectiveDebitAccountId || !suggestedDebitAccountIds.length)
+            return [];
+        return suggestedDebitAccountIds.slice(0, 3).map((accountId) => {
+            const account = accounts?.find((a) => a.id === accountId);
+            return {
+                id: accountId,
+                label: account
+                    ? `${account.code ? `${account.code} - ` : ''}${account.name}`
+                    : 'Unknown',
+            };
+        });
+    }, [suggestedDebitAccountIds, accounts, effectiveDebitAccountId]);
+
+    // Quick-assign suggestions for category
+    const categoryQuickAssignSuggestions = useMemo<
+        QuickAssignSuggestion[]
+    >(() => {
+        if (effectiveCategoryId || !suggestedCategoryIds.length) return [];
+        return suggestedCategoryIds.slice(0, 3).map((catId) => {
+            const category = categoryOptions.find((c) => c.value === catId);
+            return {
+                id: catId,
+                label: category?.label ?? 'Unknown',
+            };
+        });
+    }, [suggestedCategoryIds, categoryOptions, effectiveCategoryId]);
+
     const resolvedCategoryOptions = useMemo(() => {
         if (suggestedCategoryIds.length === 0) {
             return categoryOptions;
@@ -242,8 +376,32 @@ export const UnifiedEditTransactionForm = ({
                                         placeholder="Select customer..."
                                         onCreate={onCreateCustomer}
                                         suggestionQuery={payeeText ?? ''}
+                                        suggestionNotes={notesValue ?? ''}
                                     />
                                 </FormControl>
+                                {!field.value && (
+                                    <QuickAssignSuggestions
+                                        suggestions={
+                                            customerQuickAssignSuggestions
+                                        }
+                                        isLoading={
+                                            shouldFetchCustomerSuggestions &&
+                                            suggestedCustomersQuery.isLoading
+                                        }
+                                        onSelect={(id) =>
+                                            form.setValue(
+                                                'payeeCustomerId',
+                                                id,
+                                                {
+                                                    shouldValidate: true,
+                                                    shouldDirty: true,
+                                                    shouldTouch: true,
+                                                },
+                                            )
+                                        }
+                                        disabled={isFinancialFieldsLocked}
+                                    />
+                                )}
                                 {payeeText && !field.value && (
                                     <p className="text-xs text-amber-600 mt-1">
                                         Imported payee:{' '}
@@ -261,7 +419,7 @@ export const UnifiedEditTransactionForm = ({
                 <hr />
 
                 {/* Transaction Entry Section - Credit | Amount | Debit */}
-                <div className="grid grid-cols-[2fr_16px_minmax(min-content,1fr)_16px_2fr] items-center gap-1">
+                <div className="grid grid-cols-[2fr_16px_minmax(min-content,1fr)_16px_2fr] items-start gap-1">
                     {/* Credit Account */}
                     <FormField
                         control={form.control}
@@ -282,12 +440,35 @@ export const UnifiedEditTransactionForm = ({
                                         onOpenChange={setIsAccountSelectOpen}
                                     />
                                 </FormControl>
+                                {!field.value && effectiveCustomerId && (
+                                    <QuickAssignSuggestions
+                                        suggestions={
+                                            creditAccountQuickAssignSuggestions
+                                        }
+                                        isLoading={
+                                            shouldFetchAccountSuggestions &&
+                                            suggestedAccountsQuery.isLoading
+                                        }
+                                        onSelect={(id) =>
+                                            form.setValue(
+                                                'creditAccountId',
+                                                id,
+                                                {
+                                                    shouldValidate: true,
+                                                    shouldDirty: true,
+                                                    shouldTouch: true,
+                                                },
+                                            )
+                                        }
+                                        disabled={isFinancialFieldsLocked}
+                                    />
+                                )}
                                 <FormMessage />
                             </FormItem>
                         )}
                     />
 
-                    <ChevronRight className="size-4 opacity-60" />
+                    <ChevronRight className="size-4 opacity-60 mt-2.5" />
 
                     {/* Amount Column */}
                     <FormField
@@ -309,7 +490,7 @@ export const UnifiedEditTransactionForm = ({
                         )}
                     />
 
-                    <ChevronRight className="size-4 opacity-60" />
+                    <ChevronRight className="size-4 opacity-60 mt-2.5" />
 
                     {/* Debit Account */}
                     <FormField
@@ -331,6 +512,29 @@ export const UnifiedEditTransactionForm = ({
                                         onOpenChange={setIsAccountSelectOpen}
                                     />
                                 </FormControl>
+                                {!field.value && effectiveCustomerId && (
+                                    <QuickAssignSuggestions
+                                        suggestions={
+                                            debitAccountQuickAssignSuggestions
+                                        }
+                                        isLoading={
+                                            shouldFetchAccountSuggestions &&
+                                            suggestedAccountsQuery.isLoading
+                                        }
+                                        onSelect={(id) =>
+                                            form.setValue(
+                                                'debitAccountId',
+                                                id,
+                                                {
+                                                    shouldValidate: true,
+                                                    shouldDirty: true,
+                                                    shouldTouch: true,
+                                                },
+                                            )
+                                        }
+                                        disabled={isFinancialFieldsLocked}
+                                    />
+                                )}
                                 <FormMessage />
                             </FormItem>
                         )}
@@ -364,6 +568,19 @@ export const UnifiedEditTransactionForm = ({
                                         }
                                     />
                                 </FormControl>
+                                {!field.value && effectiveCustomerId && (
+                                    <QuickAssignSuggestions
+                                        suggestions={
+                                            categoryQuickAssignSuggestions
+                                        }
+                                        isLoading={
+                                            shouldFetchCategorySuggestions &&
+                                            suggestedCategoriesQuery.isLoading
+                                        }
+                                        onSelect={field.onChange}
+                                        disabled={isPending}
+                                    />
+                                )}
                                 <FormMessage />
                             </FormItem>
                         )}


### PR DESCRIPTION
- components/data-table: add paginationKey, autoPageSize, rowHeight,
  autoResetPageIndex and onRowClick props; expose refs for wrapper,
  header and pagination; derive page/pageSize query keys from
  paginationKey and wire query-state keys to allow per-table pagination
  state. Add recalcPageSize helper to compute page size from available
  viewport space when autoPageSize is enabled.
- app/(dashboard)/categories/page.tsx: enable DataTable pagination by
  passing paginationKey="categories".
- features/transactions/api/use-get-suggested-customers: accept optional
  notes parameter; normalize notes and include in query key and request;
  enable query when either query or notes exist; update error message to
  require query or notes.
- app/(dashboard)/transactions/status-column.tsx: add
  data-row-interactive="true" attribute to status badges and menu items
  to mark interactive badge elements for row-level interactions.

These changes add per-table pagination state, optional automatic page
sizing to fit the viewport, and a row click hook. They also extend the
suggested-customers API hook to allow searching by notes in addition to
query. The updates enable better UX for large tables and more flexible
customer suggestions.