### PR TITLE
feat(settings): add autoDraftToPending and enforce UI block

### DIFF
--- a/app/(dashboard)/customers/columns.tsx
+++ b/app/(dashboard)/customers/columns.tsx
@@ -2,7 +2,7 @@
 
 import type { ColumnDef } from '@tanstack/react-table';
 import type { InferResponseType } from 'hono';
-import { ArrowUpDown, MoreHorizontal } from 'lucide-react';
+import { ArrowUpDown, MoreHorizontal, TriangleAlert } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -107,12 +107,13 @@ export const columns: ColumnDef<ResponseType>[] = [
         cell: ({ row }) => {
             return (
                 <div className="flex items-center gap-2">
-                    <span>{row.getValue('name')}</span>
                     {!row.original.isComplete && (
-                        <Badge variant="secondary" className="text-xs">
+                        <Badge variant="destructive" className="text-xs">
+                            <TriangleAlert className="size-4 mr-2" />
                             Incomplete
                         </Badge>
                     )}
+                    <span>{row.getValue('name')}</span>
                 </div>
             );
         },

--- a/app/(dashboard)/new/page.tsx
+++ b/app/(dashboard)/new/page.tsx
@@ -36,15 +36,13 @@ function NewTransactionContent() {
     const onCreateCategory = (name: string) =>
         categoryMutation.mutate({ name });
     const onCreateCustomer = (name: string) =>
-        customerMutation
-            .mutateAsync({ name })
-            .then((response) => {
-                if ('data' in response) {
-                    return response.data.id;
-                }
+        customerMutation.mutateAsync({ name }).then((response) => {
+            if ('data' in response) {
+                return response.data.id;
+            }
 
-                throw new Error(response.error ?? 'Failed to create customer.');
-            });
+            throw new Error(response.error ?? 'Failed to create customer.');
+        });
 
     const isPending =
         createMutation.isPending ||

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -63,6 +63,49 @@ function DoubleEntrySettings() {
     );
 }
 
+function TransactionStatusAutomationSettings() {
+    const settingsQuery = useGetSettings();
+    const updateSettings = useUpdateSettings();
+
+    const isLoading = settingsQuery.isLoading;
+    const autoDraftToPending = settingsQuery.data?.autoDraftToPending ?? false;
+
+    const handleToggle = (checked: boolean) => {
+        updateSettings.mutate({ autoDraftToPending: checked });
+    };
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Transaction Status</CardTitle>
+                <p className="text-sm text-muted-foreground">
+                    Configure automatic status changes
+                </p>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                <div className="flex items-center justify-between space-x-2">
+                    <div className="flex-1">
+                        <Label htmlFor="auto-draft-to-pending">
+                            Auto Draft &gt; Pending
+                        </Label>
+                        <p className="text-xs text-muted-foreground">
+                            When enabled, a draft transaction will automatically
+                            move to Pending once required fields are filled and
+                            validation passes.
+                        </p>
+                    </div>
+                    <Switch
+                        id="auto-draft-to-pending"
+                        checked={autoDraftToPending}
+                        onCheckedChange={handleToggle}
+                        disabled={isLoading || updateSettings.isPending}
+                    />
+                </div>
+            </CardContent>
+        </Card>
+    );
+}
+
 function CategoriesSection() {
     const newCategory = useNewCategory();
     const deleteCategories = useBulkDeleteCategories();
@@ -108,6 +151,7 @@ export default function SettingsPage() {
                 }
             >
                 <DoubleEntrySettings />
+                <TransactionStatusAutomationSettings />
                 <DocumentTypesSettingsCard />
                 <ReconciliationSettingsCard />
                 <CategoriesSection />

--- a/app/api/[[...route]]/customersRoutes.ts
+++ b/app/api/[[...route]]/customersRoutes.ts
@@ -206,6 +206,7 @@ const app = new Hono()
     // Add IBAN to customer
     .post(
         '/:id/ibans',
+        clerkMiddleware(),
         zValidator(
             'param',
             z.object({
@@ -219,7 +220,6 @@ const app = new Hono()
                 bankName: z.string().optional(),
             }),
         ),
-        clerkMiddleware(),
         async (ctx) => {
             const auth = getAuth(ctx);
             const { id } = ctx.req.valid('param');

--- a/app/api/[[...route]]/settingsRoutes.ts
+++ b/app/api/[[...route]]/settingsRoutes.ts
@@ -29,6 +29,7 @@ const app = new Hono()
                 data: {
                     userId: auth.userId,
                     doubleEntryMode: false,
+                    autoDraftToPending: false,
                     reconciliationConditions: [],
                     minRequiredDocuments: 0,
                     requiredDocumentTypeIds: [],
@@ -55,6 +56,7 @@ const app = new Hono()
             'json',
             z.object({
                 doubleEntryMode: z.boolean().optional(),
+                autoDraftToPending: z.boolean().optional(),
                 reconciliationConditions:
                     reconciliationConditionsSchema.optional(),
                 minRequiredDocuments: z.number().int().min(0).optional(),
@@ -71,6 +73,7 @@ const app = new Hono()
 
             const updateValues: {
                 doubleEntryMode?: boolean;
+                autoDraftToPending?: boolean;
                 reconciliationConditions?: string;
                 minRequiredDocuments?: number;
                 requiredDocumentTypeIds?: string;
@@ -78,6 +81,10 @@ const app = new Hono()
 
             if (values.doubleEntryMode !== undefined) {
                 updateValues.doubleEntryMode = values.doubleEntryMode;
+            }
+
+            if (values.autoDraftToPending !== undefined) {
+                updateValues.autoDraftToPending = values.autoDraftToPending;
             }
 
             if (values.reconciliationConditions !== undefined) {
@@ -115,6 +122,7 @@ const app = new Hono()
                     .values({
                         userId: auth.userId,
                         doubleEntryMode: values.doubleEntryMode || false,
+                        autoDraftToPending: values.autoDraftToPending || false,
                         reconciliationConditions:
                             values.reconciliationConditions !== undefined
                                 ? JSON.stringify(

--- a/components/data-table.tsx
+++ b/components/data-table.tsx
@@ -116,7 +116,8 @@ export function DataTable<TData, TValue>({
             tableHeaderRef.current.getBoundingClientRect().height;
         const paginationHeight =
             paginationRef.current?.getBoundingClientRect().height ?? 0;
-        const availableHeight = window.innerHeight - tableTop - paginationHeight;
+        const availableHeight =
+            window.innerHeight - tableTop - paginationHeight;
         const nextPageSize = Math.max(
             1,
             Math.floor((availableHeight - headerHeight) / rowHeight),
@@ -273,9 +274,11 @@ export function DataTable<TData, TValue>({
                                             'cursor-pointer',
                                     )}
                                     onClick={(event) => {
-                                        if (shouldIgnoreRowClick(
-                                            event.target as HTMLElement | null,
-                                        )) {
+                                        if (
+                                            shouldIgnoreRowClick(
+                                                event.target as HTMLElement | null,
+                                            )
+                                        ) {
                                             return;
                                         }
                                         if (onDelete) {

--- a/components/quick-assign-suggestions.tsx
+++ b/components/quick-assign-suggestions.tsx
@@ -28,6 +28,11 @@ export const QuickAssignSuggestions = ({
         return null;
     }
 
+    const handleSelect = (id: string) => {
+        if (disabled) return;
+        onSelect(id);
+    };
+
     return (
         <div className="flex items-center gap-1.5 flex-wrap mt-1.5">
             {isLoading ? (
@@ -48,11 +53,21 @@ export const QuickAssignSuggestions = ({
                             size="sm"
                             className="h-6 px-2 text-xs truncate max-w-24 justify-start cursor-pointer"
                             disabled={disabled}
-                            onMouseDown={(e) => {
-                                // Use mousedown so the selection applies even if the UI unmounts
-                                // or focus changes prevent the click event from firing.
-                                e.preventDefault();
-                                onSelect(suggestion.id);
+                            onClick={(event) => {
+                                event.preventDefault();
+                                event.stopPropagation();
+                                handleSelect(suggestion.id);
+                            }}
+                            onKeyDown={(event) => {
+                                if (
+                                    event.key !== 'Enter' &&
+                                    event.key !== ' '
+                                ) {
+                                    return;
+                                }
+                                event.preventDefault();
+                                event.stopPropagation();
+                                handleSelect(suggestion.id);
                             }}
                         >
                             {suggestion.label}

--- a/components/status-progression.tsx
+++ b/components/status-progression.tsx
@@ -46,6 +46,7 @@ interface StatusProgressionProps {
     currentStatus: TransactionStatus;
     onAdvance: (nextStatus: TransactionStatus) => Promise<void>;
     disabled?: boolean;
+    autoDraftToPendingEnabled?: boolean;
     canReconcile?: boolean;
     reconciliationBlockers?: string[];
     // Document validation props
@@ -59,6 +60,7 @@ export function StatusProgression({
     currentStatus,
     onAdvance,
     disabled = false,
+    autoDraftToPendingEnabled = false,
     canReconcile = true,
     reconciliationBlockers = [],
     hasAllRequiredDocuments = true,
@@ -103,8 +105,20 @@ export function StatusProgression({
     const documentBlocker = getDocumentBlocker();
     const isDocumentBlocked = documentBlocker !== null;
 
+    const isAutoDraftToPendingBlocked =
+        autoDraftToPendingEnabled &&
+        currentStatus === 'draft' &&
+        nextStatus === 'pending';
+
     const handleAdvance = async () => {
-        if (!nextStatus || isAdvancing || disabled || isDocumentBlocked) return;
+        if (
+            !nextStatus ||
+            isAdvancing ||
+            disabled ||
+            isDocumentBlocked ||
+            isAutoDraftToPendingBlocked
+        )
+            return;
 
         // Check if trying to advance to reconciled but conditions aren't met
         if (nextStatus === 'reconciled' && !canReconcile) {
@@ -201,7 +215,7 @@ export function StatusProgression({
                                 {STATUS_INFO[currentStatus].description}
                             </p>
                         </div>
-                        {nextStatus && (
+                        {nextStatus && !isAutoDraftToPendingBlocked && (
                             <Button
                                 onClick={handleAdvance}
                                 disabled={
@@ -223,6 +237,13 @@ export function StatusProgression({
                             </Button>
                         )}
                     </div>
+                    {isAutoDraftToPendingBlocked && (
+                        <p className="mt-2 text-xs text-muted-foreground">
+                            Automatic status is enabled: Draft &gt; Pending.
+                            Save the transaction once required fields are
+                            filled.
+                        </p>
+                    )}
                 </div>
 
                 {/* Document Blockers */}

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -130,6 +130,9 @@ export const settings = pgTable(
     {
         userId: text('user_id').primaryKey(),
         doubleEntryMode: boolean('double_entry_mode').notNull().default(false),
+        autoDraftToPending: boolean('auto_draft_to_pending')
+            .notNull()
+            .default(false),
         // Reconciliation conditions - JSON array of conditions
         // e.g., ["hasReceipt", "isReviewed", "isApproved"]
         reconciliationConditions: text('reconciliation_conditions')

--- a/docs/F001-transaction-edit-split.spec.md
+++ b/docs/F001-transaction-edit-split.spec.md
@@ -1,0 +1,73 @@
+# F001: Transaction Edit Split
+
+## Feature Overview
+
+Add the ability to split an existing transaction directly from the edit form, allowing users to break down a single transaction into multiple parts with different categories or accounts.
+
+## User Story
+
+As a user editing a transaction, I want to split it into multiple transactions so that I can accurately categorize different parts of a single payment or receipt.
+
+## Requirements
+
+### UI Components
+
+1. **Split Button**
+   - Location: Directly under the amount field in the transaction edit form
+   - Label: "Split"
+   - Behavior: When clicked, displays the split transaction UI
+
+2. **Split UI**
+   - Should mirror the split UI functionality from the create transaction form
+   - Must support multiple split items
+   - Each split item should include:
+     - Amount field
+     - Category selector
+     - Optional notes/description
+   - Total of split amounts must equal the original transaction amount
+   - Validation to prevent saving if amounts don't match
+
+### Functional Requirements
+
+1. **Splitting Process**
+   - Original transaction is marked as split/archived (not deleted)
+   - New transactions are created for each split item
+   - All split transactions should reference the original transaction ID
+   - Date, payee/customer, and account should be inherited from original transaction
+   - Each split transaction can have its own category
+
+2. **Transaction History**
+   - Original transaction should show "Split" indicator/status
+   - History should track that the transaction was split
+   - Should display link/reference to the resulting split transactions
+   - Maintain audit trail of the split operation
+
+3. **Data Integrity**
+   - Original transaction amount must equal sum of split amounts
+   - All split transactions must maintain the same date as original
+   - Account balance calculations must remain accurate
+   - Split operation should be atomic (all or nothing)
+
+## Acceptance Criteria
+
+- [ ] Split button appears in transaction edit form below amount field
+- [ ] Clicking Split button reveals split UI interface
+- [ ] Split UI allows adding/removing multiple split items
+- [ ] Total validation prevents saving if split amounts don't equal original
+- [ ] Original transaction is marked as split after save
+- [ ] New transactions are created with correct amounts and categories
+- [ ] Transaction history shows split indicator and links to split transactions
+- [ ] Account balances remain accurate after split operation
+
+## Technical Considerations
+
+- Database schema may need updates to track split relationships
+- Consider transaction isolation for atomic split operations
+- Ensure reconciliation logic accounts for split transactions
+- Performance: splitting should not cause UI lag or timeout
+
+## Future Enhancements
+
+- Ability to "unsplit" or merge split transactions back
+- Quick split templates (e.g., 50/50, percentage-based)
+- Visual indication in transaction list for split transactions

--- a/docs/F002-bulk-delete-all-tables.spec.md
+++ b/docs/F002-bulk-delete-all-tables.spec.md
@@ -1,0 +1,186 @@
+# F002: Bulk Delete for All Tables
+
+## Feature Overview
+
+Extend the bulk delete functionality currently implemented in the transactions table to all other data tables (accounts, categories, customers) that already have row selection capabilities but lack bulk delete functionality.
+
+## Current State Analysis
+
+- **Transactions**: ✅ Has full bulk delete implementation with toggle mode
+  - `bulkDeleteMode` state in page component
+  - Select column conditional rendering
+  - `useBulkDeleteTransactions` hook
+  - Backend `/bulk-delete` API endpoint
+  - Proper validation and user authorization
+  
+- **Categories**: ⚠️ Has partial implementation
+  - DataTable with `onDelete` handler
+  - `useBulkDeleteCategories` hook exists
+  - Backend `/bulk-delete` endpoint exists
+  - Missing: Bulk delete mode toggle/UI control
+  
+- **Accounts**: ❌ Missing bulk delete
+  - Has row selection UI (checkboxes visible)
+  - No bulk delete mode toggle
+  - No `useBulkDeleteAccounts` hook
+  - No backend bulk delete endpoint
+  
+- **Customers**: ❌ Missing bulk delete
+  - Has `onDelete={() => {}}` stub
+  - No bulk delete functionality
+  - No backend bulk delete endpoint
+
+## User Story
+
+As a user managing my financial data, I want to delete multiple records at once from any data table (accounts, categories, customers) so that I can efficiently clean up or reorganize my data without having to delete items one by one.
+
+## Requirements
+
+### UI Requirements (All Tables)
+
+1. **Bulk Delete Mode Toggle**
+   - Add a dropdown menu with "Bulk delete" / "Cancel bulk delete" option
+   - Similar to transactions page implementation
+   - Located in CardHeader actions area
+   - Toggle button shows current state
+
+2. **Visual Indicators**
+   - Select column (checkboxes) appears only in bulk delete mode
+   - Selected rows are highlighted
+   - Delete button becomes enabled when rows are selected
+   - Loading state during delete operation
+
+3. **User Confirmation**
+   - Confirmation dialog before executing bulk delete
+   - Show count of items to be deleted
+   - Warning about data loss (especially for accounts with transactions)
+
+### Functional Requirements
+
+#### Accounts Table
+
+1. Create `useBulkDeleteAccounts` hook
+2. Implement backend `/bulk-delete` endpoint in accountsRoutes
+3. Add bulk delete mode state management
+4. Ensure proper cascade handling (accounts may have associated transactions)
+5. Validation: Prevent deletion of accounts with reconciled transactions
+6. Update account balance calculations after deletion
+
+#### Categories Table
+
+1. Complete UI implementation with bulk delete mode toggle
+2. Verify existing `useBulkDeleteCategories` hook functionality
+3. Add bulk delete mode state to page component
+4. Test cascade behavior (transactions with deleted categories should set categoryId to null)
+
+#### Customers Table
+
+1. Create `useBulkDeleteCustomers` hook
+2. Implement backend `/bulk-delete` endpoint in customersRoutes
+3. Replace `onDelete={() => {}}` stub with actual implementation
+4. Add bulk delete mode state management
+5. Handle cascade behavior for transactions linked to customers
+
+### Backend Requirements
+
+All bulk delete endpoints must:
+
+- Accept array of IDs: `{ ids: string[] }`
+- Validate user authorization for each record
+- Use transactions for atomic operations
+- Return deleted record count
+- Implement proper error handling
+- Log bulk delete operations for audit trail
+
+### Data Integrity Requirements
+
+1. **Authorization**: Verify user owns all records before deletion
+2. **Cascading Rules**:
+   - Accounts: Set to null in related transactions, or prevent if reconciled
+   - Categories: Set to null in related transactions
+   - Customers: Set to null in related transactions
+3. **Atomic Operations**: All deletes in a batch succeed or all fail
+4. **Cache Invalidation**: Update all relevant query caches
+5. **Balance Recalculation**: Trigger for accounts and summary data
+
+## Technical Implementation
+
+### Frontend Pattern (Per Table)
+
+```tsx
+const [bulkDeleteMode, setBulkDeleteMode] = useState(false);
+const bulkDeleteMutation = useBulkDelete[Entity]();
+
+// In dropdown menu
+<DropdownMenuItem onClick={() => setBulkDeleteMode(!bulkDeleteMode)}>
+  {bulkDeleteMode ? 'Cancel bulk delete' : 'Bulk delete'}
+</DropdownMenuItem>
+
+// In DataTable
+<DataTable
+  columns={bulkDeleteMode ? [selectColumn, ...columns] : columns}
+  onDelete={bulkDeleteMode ? handleBulkDelete : undefined}
+  // ... other props
+/>
+```
+
+### Backend Pattern (Per Entity)
+
+```typescript
+.post('/bulk-delete',
+  clerkMiddleware(),
+  zValidator('json', z.object({ ids: z.array(z.string()) })),
+  async (ctx) => {
+    // 1. Authenticate
+    // 2. Validate ownership
+    // 3. Execute delete with CTE for authorization
+    // 4. Return results
+  }
+)
+```
+
+## Acceptance Criteria
+
+- [ ] Accounts page has bulk delete mode toggle
+- [ ] Accounts can be bulk deleted with proper validation
+- [ ] Accounts with reconciled transactions cannot be deleted
+- [ ] Categories page has bulk delete mode toggle UI
+- [ ] Categories can be bulk deleted (existing hook integrated)
+- [ ] Customers page has bulk delete mode toggle
+- [ ] Customers can be bulk deleted
+- [ ] All tables show select column only in bulk delete mode
+- [ ] Confirmation dialog appears before deletion
+- [ ] Error messages are clear and specific
+- [ ] Success toasts show number of items deleted
+- [ ] Related transactions properly handle null foreign keys
+- [ ] All query caches are invalidated appropriately
+- [ ] Bulk delete operations are atomic (all or nothing)
+- [ ] Unauthorized deletion attempts are blocked
+
+## Testing Checklist
+
+- [ ] Delete single item in bulk mode
+- [ ] Delete multiple items in bulk mode
+- [ ] Attempt to delete items from another user (should fail)
+- [ ] Cancel bulk delete mode without deleting
+- [ ] Verify cascade behavior for each entity type
+- [ ] Test error handling for failed deletions
+- [ ] Verify UI state during loading
+- [ ] Check that summary data updates correctly
+- [ ] Test with items that have dependencies
+- [ ] Verify audit trail / logging
+
+## Migration Notes
+
+- No database schema changes required
+- Implement accounts and customers endpoints first
+- Complete categories UI to match transactions pattern
+- Consider adding soft delete in future for better audit trail
+
+## Future Enhancements
+
+- Undo/restore recently deleted items
+- Bulk archive instead of delete for better data retention
+- Bulk operations menu (edit, export, etc.)
+- Advanced filtering before bulk delete
+- Keyboard shortcuts for bulk operations

--- a/docs/F003-accounts-income-expense.spec.md
+++ b/docs/F003-accounts-income-expense.spec.md
@@ -1,0 +1,420 @@
+# F003: Double-Entry Bookkeeping - Income & Expense Accounts
+
+## Overview
+
+Accounts in double-bookkeeping systems must accurately track income and expenses to ensure financial integrity and compliance. This specification analyzes the current implementation and outlines what's needed for fully functional double-entry bookkeeping with proper account types.
+
+## User Story
+
+As a user managing my finances, I want to create and manage accounts specifically for income and expenses so that I can accurately track my financial transactions and generate reports for budgeting and tax purposes using proper double-entry accounting principles.
+
+---
+
+## Current Implementation Analysis
+
+### ✅ What We Have (Implemented)
+
+#### 1. **Basic Double-Entry Infrastructure**
+
+- Toggle in settings to enable/disable double-entry mode (`doubleEntryMode` setting)
+- Transactions support both `creditAccountId` and `debitAccountId` fields
+- Validation enforces both accounts when double-entry mode is enabled (except for drafts)
+- Account type field: `credit`, `debit`, or `neutral`
+- Account type validation prevents misuse (e.g., credit account can't be debit)
+
+#### 2. **Account Structure**
+
+- Hierarchical account structure using `code` field
+- Code-based parent-child relationships (e.g., "1" → "11" → "111")
+- Visual hierarchy in accounts page with expand/collapse
+- Account status: `isOpen` (active/inactive)
+- Account protection: `isReadOnly` (prevents transactions)
+- Account filtering by type in selectors
+
+#### 3. **Transaction Support**
+
+- Single-entry mode: uses `accountId` + positive/negative amounts
+- Double-entry mode: uses `creditAccountId` + `debitAccountId` + positive amounts
+- Automatic account opening when used in transactions (including parents)
+- Split transactions support double-entry
+- Import supports both single and double-entry modes
+- Validation warnings for missing credit/debit accounts in UI
+
+#### 4. **Reporting & Summary**
+
+- Income/expense calculation based on amount sign (positive = income, negative = expense)
+- Summary queries handle both single and double-entry transactions
+- Account balances aggregate across transaction types
+- Charts display income vs expenses
+
+---
+
+## ❌ What's Missing for Full Double-Entry Bookkeeping
+
+### 1. **Standard Account Types/Classes**
+
+**Issue**: Only has generic `credit`/`debit`/`neutral` types, not proper accounting categories.
+
+**What's Needed**:
+
+- Account classification following standard accounting equation:
+  - **Assets** (Debit normal balance)
+  - **Liabilities** (Credit normal balance)
+  - **Equity** (Credit normal balance)
+  - **Income/Revenue** (Credit normal balance)
+  - **Expenses** (Debit normal balance)
+  - **Cost of Goods Sold (COGS)** (optional)
+  
+**Implementation**:
+
+```typescript
+// Update schema.ts
+accountClass: text('account_class', {
+  enum: ['asset', 'liability', 'equity', 'income', 'expense', 'cogs']
+}).notNull()
+
+// Derived from class
+normalBalance: 'debit' | 'credit' // auto-determined by class
+```
+
+### 2. **Normal Balance Logic**
+
+**Issue**: System doesn't understand normal balance behavior for different account types.
+
+**What's Needed**:
+
+- Each account class should have a normal balance (debit or credit)
+- Debits increase assets & expenses, decrease liabilities, equity & income
+- Credits increase liabilities, equity & income, decrease assets & expenses
+- Account balances should reflect proper accounting signs
+
+**Implementation**:
+
+```typescript
+const NORMAL_BALANCES = {
+  asset: 'debit',
+  expense: 'debit',
+  liability: 'credit',
+  equity: 'credit',
+  income: 'credit',
+  cogs: 'debit'
+} as const;
+
+function calculateAccountBalance(account, transactions) {
+  const normalBalance = NORMAL_BALANCES[account.accountClass];
+  // Sum debits and credits, apply sign based on normal balance
+}
+```
+
+### 3. **Chart of Accounts (COA) Management**
+
+**Issue**: No standard COA template or structure enforcement.
+
+**What's Needed**:
+
+- Predefined COA templates (Small Business, Freelance, etc.)
+- Industry-standard account numbering (e.g., 1000-1999 = Assets, 2000-2999 = Liabilities)
+- Account code validation ensuring proper hierarchy
+- Prevent users from creating invalid account structures
+
+**Implementation**:
+
+- COA template seeding on user setup
+- Account code regex validation: `/^[1-9]\d{0,3}$/`
+- Parent account must exist before creating child
+- Standard account codes:
+  - 1000-1999: Assets
+  - 2000-2999: Liabilities
+  - 3000-3999: Equity
+  - 4000-4999: Income/Revenue
+  - 5000-5999: Cost of Goods Sold
+  - 6000-6999: Expenses
+
+### 4. **Mandatory Accounts**
+
+**Issue**: No system accounts that must exist for proper operations.
+
+**What's Needed**:
+
+- Required accounts that cannot be deleted:
+  - **Owner's Equity** (3000) - starting capital
+  - **Retained Earnings** (3999) - accumulated profit/loss
+  - **Opening Balances** (special equity account)
+- Automatic end-of-year closing entries
+- Income summary account for closing
+
+### 5. **Transaction Journal Entry View**
+
+**Issue**: No proper journal entry format showing debits and credits side-by-side.
+
+**What's Needed**:
+
+- Traditional journal entry display format:
+
+  ```
+  Date: 2026-01-08
+  Description: Office supplies purchase
+  
+  Debit:  Expenses - Office Supplies    $500.00
+  Credit:   Assets - Cash                      $500.00
+  ```
+
+- Ability to create multi-line journal entries
+- Journal entry validation (total debits = total credits)
+- Transaction history in journal format
+
+### 6. **Trial Balance Report**
+
+**Issue**: No trial balance report to verify debits equal credits.
+
+**What's Needed**:
+
+- Trial Balance report showing:
+  - All accounts with balances
+  - Debit column vs Credit column
+  - Total debits = Total credits verification
+  - Date range filtering
+  - Export capability
+
+### 7. **Financial Statements**
+
+**Issue**: No proper financial statement generation.
+
+**What's Needed**:
+
+- **Balance Sheet** (Assets = Liabilities + Equity)
+  - Assets section (by normal balance)
+  - Liabilities section
+  - Equity section
+  - Date-specific (point in time)
+  
+- **Income Statement** (Profit & Loss)
+  - Revenue section
+  - COGS section
+  - Gross Profit
+  - Expenses section
+  - Net Income/Loss
+  - Date range (period)
+  
+- **Cash Flow Statement** (optional, future)
+
+### 8. **Account Balance Calculation**
+
+**Issue**: Current balance calculations don't respect double-entry principles.
+
+**What's Needed**:
+
+```typescript
+// Proper account balance considering:
+// - Account class normal balance
+// - All transactions where account appears as debit OR credit
+// - Opening balance
+// - Date range for period reporting
+
+interface AccountBalance {
+  accountId: string;
+  openingBalance: number;
+  debitTotal: number;
+  creditTotal: number;
+  closingBalance: number;
+  normalBalance: 'debit' | 'credit';
+}
+```
+
+### 9. **Opening Balances**
+
+**Issue**: No way to set initial account balances when starting the system.
+
+**What's Needed**:
+
+- Special "Opening Balances" transaction type
+- Wizard to set up initial balances for all accounts
+- Must balance (total debits = total credits)
+- Linked to Owner's Equity or Opening Balance Equity account
+
+### 10. **Account Restrictions**
+
+**Issue**: Insufficient business rules for account usage.
+
+**What's Needed**:
+
+- Prevent transactions between incompatible account types
+- Validate transaction makes sense:
+  - Income must be credited (not debited)
+  - Expenses must be debited (not credited)
+  - Asset purchases: Debit Asset, Credit Cash/Liability
+- Smart validation messages explaining proper usage
+
+### 11. **Period Closing**
+
+**Issue**: No fiscal year-end or period closing process.
+
+**What's Needed**:
+
+- Fiscal year setup (calendar or custom)
+- Year-end closing wizard:
+  - Close all income accounts to Income Summary
+  - Close all expense accounts to Income Summary
+  - Close Income Summary to Retained Earnings
+  - Prevent modifications to closed periods
+- Period locking mechanism
+
+### 12. **Account Reports**
+
+**Issue**: Limited reporting for accounting analysis.
+
+**What's Needed**:
+
+- **General Ledger** - All transactions per account
+- **Account Statement** - Single account activity
+- **Transaction Listing** - Searchable transaction log
+- **Account Analysis** - Period comparisons
+- **Aging Reports** - For receivables/payables (if applicable)
+
+---
+
+## Implementation Priority
+
+### Phase 1: Foundation (Critical)
+
+1. Add `accountClass` field to schema
+2. Implement normal balance logic
+3. Update account form to select account class
+4. Migrate existing accounts (default to appropriate classes)
+5. Update balance calculation to respect normal balances
+
+### Phase 2: Structure (High Priority)
+
+1. Implement COA templates
+2. Add opening balance feature
+3. Create mandatory system accounts
+4. Enforce account hierarchy validation
+
+### Phase 3: Reporting (High Priority)
+
+1. Build Trial Balance report
+2. Create Balance Sheet
+3. Create Income Statement
+4. Implement General Ledger view
+
+### Phase 4: Advanced (Medium Priority)
+
+1. Journal entry view/creation
+2. Period closing functionality
+3. Enhanced account restrictions
+4. Account analysis reports
+
+### Phase 5: Polish (Low Priority)
+
+1. COA import/export
+2. Multi-currency support
+3. Tax reporting features
+4. Advanced reconciliation
+
+---
+
+## Database Schema Changes Required
+
+```sql
+-- Add account class field
+ALTER TABLE accounts ADD COLUMN account_class TEXT;
+ALTER TABLE accounts ADD CONSTRAINT account_class_check 
+  CHECK (account_class IN ('asset', 'liability', 'equity', 'income', 'expense', 'cogs'));
+
+-- Add normal balance (computed from class but cached for performance)
+ALTER TABLE accounts ADD COLUMN normal_balance TEXT;
+ALTER TABLE accounts ADD CONSTRAINT normal_balance_check 
+  CHECK (normal_balance IN ('debit', 'credit'));
+
+-- Add opening balance field
+ALTER TABLE accounts ADD COLUMN opening_balance INTEGER DEFAULT 0;
+
+-- Add account flags
+ALTER TABLE accounts ADD COLUMN is_system_account BOOLEAN DEFAULT FALSE;
+ALTER TABLE accounts ADD COLUMN allow_transactions BOOLEAN DEFAULT TRUE;
+
+-- Create fiscal periods table (future)
+CREATE TABLE fiscal_periods (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  start_date TIMESTAMP NOT NULL,
+  end_date TIMESTAMP NOT NULL,
+  is_closed BOOLEAN DEFAULT FALSE,
+  closed_at TIMESTAMP,
+  closed_by TEXT
+);
+
+-- Update account type to be more specific
+-- Note: Keep accountType for backward compatibility during migration
+```
+
+---
+
+## Configuration Examples
+
+### Standard Account Classes with Codes
+
+```typescript
+const STANDARD_ACCOUNTS = {
+  // Assets (1000-1999)
+  '1000': { name: 'Assets', class: 'asset' },
+  '1100': { name: 'Current Assets', class: 'asset', parent: '1000' },
+  '1110': { name: 'Cash', class: 'asset', parent: '1100' },
+  '1120': { name: 'Bank Account', class: 'asset', parent: '1100' },
+  '1200': { name: 'Accounts Receivable', class: 'asset', parent: '1100' },
+  
+  // Liabilities (2000-2999)
+  '2000': { name: 'Liabilities', class: 'liability' },
+  '2100': { name: 'Current Liabilities', class: 'liability', parent: '2000' },
+  '2110': { name: 'Accounts Payable', class: 'liability', parent: '2100' },
+  '2120': { name: 'Credit Card', class: 'liability', parent: '2100' },
+  
+  // Equity (3000-3999)
+  '3000': { name: 'Owner\'s Equity', class: 'equity' },
+  '3999': { name: 'Retained Earnings', class: 'equity', parent: '3000' },
+  
+  // Income (4000-4999)
+  '4000': { name: 'Income', class: 'income' },
+  '4100': { name: 'Sales Revenue', class: 'income', parent: '4000' },
+  '4200': { name: 'Service Revenue', class: 'income', parent: '4000' },
+  
+  // Expenses (6000-6999)
+  '6000': { name: 'Expenses', class: 'expense' },
+  '6100': { name: 'Operating Expenses', class: 'expense', parent: '6000' },
+  '6110': { name: 'Office Supplies', class: 'expense', parent: '6100' },
+  '6120': { name: 'Rent', class: 'expense', parent: '6100' },
+};
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] Account class field added to schema and UI
+- [ ] Normal balance logic implemented in balance calculations
+- [ ] COA template can be applied on setup
+- [ ] Opening balances can be set and balance
+- [ ] System accounts created and protected
+- [ ] Trial Balance report shows correct debits/credits
+- [ ] Balance Sheet generates from account balances
+- [ ] Income Statement shows revenue minus expenses
+- [ ] General Ledger view shows account transactions
+- [ ] Account hierarchy enforces valid parent-child relationships
+- [ ] Transaction validation respects account classes
+- [ ] All reports export to PDF/Excel
+- [ ] Existing data migrates without loss
+- [ ] Documentation updated with accounting principles
+
+---
+
+## Future Enhancements
+
+- Multi-entity/company support
+- Budget vs actual reporting
+- Consolidated financial statements
+- International Financial Reporting Standards (IFRS) compliance
+- Generally Accepted Accounting Principles (GAAP) compliance
+- Tax form generation (1099, W-2, etc.)
+- Audit trail with immutable transaction history
+- Role-based access (accountant, bookkeeper, viewer)
+- API for accounting software integration

--- a/drizzle/0021_light_ironclad.sql
+++ b/drizzle/0021_light_ironclad.sql
@@ -1,4 +1,4 @@
-CREATE TABLE "customer_ibans" (
+CREATE TABLE IF NOT EXISTS "customer_ibans" (
 	"id" text PRIMARY KEY NOT NULL,
 	"customer_id" text NOT NULL,
 	"iban" text NOT NULL,
@@ -6,6 +6,16 @@ CREATE TABLE "customer_ibans" (
 	"created_at" timestamp DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
-ALTER TABLE "customer_ibans" ADD CONSTRAINT "customer_ibans_customer_id_customers_id_fk" FOREIGN KEY ("customer_id") REFERENCES "public"."customers"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-CREATE INDEX "customer_ibans_customerid_idx" ON "customer_ibans" USING btree ("customer_id");--> statement-breakpoint
-CREATE INDEX "customer_ibans_iban_idx" ON "customer_ibans" USING btree ("iban");
+DO $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT 1
+		FROM pg_constraint
+		WHERE conname = 'customer_ibans_customer_id_customers_id_fk'
+	) THEN
+		ALTER TABLE "customer_ibans" ADD CONSTRAINT "customer_ibans_customer_id_customers_id_fk" FOREIGN KEY ("customer_id") REFERENCES "public"."customers"("id") ON DELETE cascade ON UPDATE no action;
+	END IF;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "customer_ibans_customerid_idx" ON "customer_ibans" USING btree ("customer_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "customer_ibans_iban_idx" ON "customer_ibans" USING btree ("iban");

--- a/drizzle/0022_public_living_tribunal.sql
+++ b/drizzle/0022_public_living_tribunal.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "settings" ADD COLUMN IF NOT EXISTS "auto_draft_to_pending" boolean DEFAULT false NOT NULL;

--- a/drizzle/meta/0022_snapshot.json
+++ b/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,1080 @@
+{
+    "id": "7e81d8f9-73d7-451c-af4a-edf98f1c0f07",
+    "prevId": "b27ef736-f066-4d12-aee9-11c3184059cf",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.accounts": {
+            "name": "accounts",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "plaid_id": {
+                    "name": "plaid_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "code": {
+                    "name": "code",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "is_open": {
+                    "name": "is_open",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": true
+                },
+                "is_read_only": {
+                    "name": "is_read_only",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "account_type": {
+                    "name": "account_type",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'neutral'"
+                }
+            },
+            "indexes": {
+                "accounts_userid_idx": {
+                    "name": "accounts_userid_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "accounts_isopen_idx": {
+                    "name": "accounts_isopen_idx",
+                    "columns": [
+                        {
+                            "expression": "is_open",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "accounts_code_idx": {
+                    "name": "accounts_code_idx",
+                    "columns": [
+                        {
+                            "expression": "code",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.categories": {
+            "name": "categories",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "plaid_id": {
+                    "name": "plaid_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {
+                "categories_userid_idx": {
+                    "name": "categories_userid_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.customer_ibans": {
+            "name": "customer_ibans",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "customer_id": {
+                    "name": "customer_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "iban": {
+                    "name": "iban",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "bank_name": {
+                    "name": "bank_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "customer_ibans_customerid_idx": {
+                    "name": "customer_ibans_customerid_idx",
+                    "columns": [
+                        {
+                            "expression": "customer_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "customer_ibans_iban_idx": {
+                    "name": "customer_ibans_iban_idx",
+                    "columns": [
+                        {
+                            "expression": "iban",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "customer_ibans_customer_id_customers_id_fk": {
+                    "name": "customer_ibans_customer_id_customers_id_fk",
+                    "tableFrom": "customer_ibans",
+                    "tableTo": "customers",
+                    "columnsFrom": ["customer_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.customers": {
+            "name": "customers",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "pin": {
+                    "name": "pin",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "vat_number": {
+                    "name": "vat_number",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "address": {
+                    "name": "address",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "contact_email": {
+                    "name": "contact_email",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "contact_telephone": {
+                    "name": "contact_telephone",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "is_complete": {
+                    "name": "is_complete",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                }
+            },
+            "indexes": {
+                "customers_userid_idx": {
+                    "name": "customers_userid_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "customers_name_idx": {
+                    "name": "customers_name_idx",
+                    "columns": [
+                        {
+                            "expression": "name",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "customers_pin_idx": {
+                    "name": "customers_pin_idx",
+                    "columns": [
+                        {
+                            "expression": "pin",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "customers_iscomplete_idx": {
+                    "name": "customers_iscomplete_idx",
+                    "columns": [
+                        {
+                            "expression": "is_complete",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.document_types": {
+            "name": "document_types",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description": {
+                    "name": "description",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "document_types_userid_idx": {
+                    "name": "document_types_userid_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "document_types_name_idx": {
+                    "name": "document_types_name_idx",
+                    "columns": [
+                        {
+                            "expression": "name",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.documents": {
+            "name": "documents",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "file_name": {
+                    "name": "file_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "file_size": {
+                    "name": "file_size",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "mime_type": {
+                    "name": "mime_type",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "document_type_id": {
+                    "name": "document_type_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "transaction_id": {
+                    "name": "transaction_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "storage_path": {
+                    "name": "storage_path",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "uploaded_by": {
+                    "name": "uploaded_by",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "uploaded_at": {
+                    "name": "uploaded_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "is_deleted": {
+                    "name": "is_deleted",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                }
+            },
+            "indexes": {
+                "documents_transactionid_idx": {
+                    "name": "documents_transactionid_idx",
+                    "columns": [
+                        {
+                            "expression": "transaction_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "documents_documenttypeid_idx": {
+                    "name": "documents_documenttypeid_idx",
+                    "columns": [
+                        {
+                            "expression": "document_type_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "documents_uploadedby_idx": {
+                    "name": "documents_uploadedby_idx",
+                    "columns": [
+                        {
+                            "expression": "uploaded_by",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "documents_isdeleted_idx": {
+                    "name": "documents_isdeleted_idx",
+                    "columns": [
+                        {
+                            "expression": "is_deleted",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "documents_document_type_id_document_types_id_fk": {
+                    "name": "documents_document_type_id_document_types_id_fk",
+                    "tableFrom": "documents",
+                    "tableTo": "document_types",
+                    "columnsFrom": ["document_type_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "restrict",
+                    "onUpdate": "no action"
+                },
+                "documents_transaction_id_transactions_id_fk": {
+                    "name": "documents_transaction_id_transactions_id_fk",
+                    "tableFrom": "documents",
+                    "tableTo": "transactions",
+                    "columnsFrom": ["transaction_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.settings": {
+            "name": "settings",
+            "schema": "",
+            "columns": {
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "double_entry_mode": {
+                    "name": "double_entry_mode",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "auto_draft_to_pending": {
+                    "name": "auto_draft_to_pending",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "reconciliation_conditions": {
+                    "name": "reconciliation_conditions",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'[\"hasReceipt\"]'"
+                },
+                "min_required_documents": {
+                    "name": "min_required_documents",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": 0
+                },
+                "required_document_type_ids": {
+                    "name": "required_document_type_ids",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'[]'"
+                }
+            },
+            "indexes": {
+                "settings_userid_idx": {
+                    "name": "settings_userid_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.transaction_status_history": {
+            "name": "transaction_status_history",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "transaction_id": {
+                    "name": "transaction_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "from_status": {
+                    "name": "from_status",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "to_status": {
+                    "name": "to_status",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "changed_at": {
+                    "name": "changed_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "changed_by": {
+                    "name": "changed_by",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "notes": {
+                    "name": "notes",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "transaction_status_history_transactionid_idx": {
+                    "name": "transaction_status_history_transactionid_idx",
+                    "columns": [
+                        {
+                            "expression": "transaction_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "transaction_status_history_changedat_idx": {
+                    "name": "transaction_status_history_changedat_idx",
+                    "columns": [
+                        {
+                            "expression": "changed_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "transaction_status_history_transaction_id_transactions_id_fk": {
+                    "name": "transaction_status_history_transaction_id_transactions_id_fk",
+                    "tableFrom": "transaction_status_history",
+                    "tableTo": "transactions",
+                    "columnsFrom": ["transaction_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.transactions": {
+            "name": "transactions",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "amount": {
+                    "name": "amount",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "payee": {
+                    "name": "payee",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "payee_customer_id": {
+                    "name": "payee_customer_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "notes": {
+                    "name": "notes",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "date": {
+                    "name": "date",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "account_id": {
+                    "name": "account_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "credit_account_id": {
+                    "name": "credit_account_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "debit_account_id": {
+                    "name": "debit_account_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "category_id": {
+                    "name": "category_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "status": {
+                    "name": "status",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'pending'"
+                },
+                "status_changed_at": {
+                    "name": "status_changed_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "status_changed_by": {
+                    "name": "status_changed_by",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "split_group_id": {
+                    "name": "split_group_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "split_type": {
+                    "name": "split_type",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "transactions_accountid_idx": {
+                    "name": "transactions_accountid_idx",
+                    "columns": [
+                        {
+                            "expression": "account_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "transactions_creditaccountid_idx": {
+                    "name": "transactions_creditaccountid_idx",
+                    "columns": [
+                        {
+                            "expression": "credit_account_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "transactions_debutaccountid_idx": {
+                    "name": "transactions_debutaccountid_idx",
+                    "columns": [
+                        {
+                            "expression": "debit_account_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "transactions_categoryid_idx": {
+                    "name": "transactions_categoryid_idx",
+                    "columns": [
+                        {
+                            "expression": "category_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "transactions_payeecustomerid_idx": {
+                    "name": "transactions_payeecustomerid_idx",
+                    "columns": [
+                        {
+                            "expression": "payee_customer_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "transactions_date_idx": {
+                    "name": "transactions_date_idx",
+                    "columns": [
+                        {
+                            "expression": "date",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "transactions_status_idx": {
+                    "name": "transactions_status_idx",
+                    "columns": [
+                        {
+                            "expression": "status",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "transactions_splitgroupid_idx": {
+                    "name": "transactions_splitgroupid_idx",
+                    "columns": [
+                        {
+                            "expression": "split_group_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "transactions_splittype_idx": {
+                    "name": "transactions_splittype_idx",
+                    "columns": [
+                        {
+                            "expression": "split_type",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "transactions_payee_customer_id_customers_id_fk": {
+                    "name": "transactions_payee_customer_id_customers_id_fk",
+                    "tableFrom": "transactions",
+                    "tableTo": "customers",
+                    "columnsFrom": ["payee_customer_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                },
+                "transactions_account_id_accounts_id_fk": {
+                    "name": "transactions_account_id_accounts_id_fk",
+                    "tableFrom": "transactions",
+                    "tableTo": "accounts",
+                    "columnsFrom": ["account_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                },
+                "transactions_credit_account_id_accounts_id_fk": {
+                    "name": "transactions_credit_account_id_accounts_id_fk",
+                    "tableFrom": "transactions",
+                    "tableTo": "accounts",
+                    "columnsFrom": ["credit_account_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                },
+                "transactions_debit_account_id_accounts_id_fk": {
+                    "name": "transactions_debit_account_id_accounts_id_fk",
+                    "tableFrom": "transactions",
+                    "tableTo": "accounts",
+                    "columnsFrom": ["debit_account_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                },
+                "transactions_category_id_categories_id_fk": {
+                    "name": "transactions_category_id_categories_id_fk",
+                    "tableFrom": "transactions",
+                    "tableTo": "categories",
+                    "columnsFrom": ["category_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        }
+    },
+    "enums": {},
+    "schemas": {},
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
             "when": 1767829221639,
             "tag": "0021_light_ironclad",
             "breakpoints": true
+        },
+        {
+            "idx": 22,
+            "version": "7",
+            "when": 1767903829536,
+            "tag": "0022_public_living_tribunal",
+            "breakpoints": true
         }
     ]
 }

--- a/features/accounts/api/use-get-account.ts
+++ b/features/accounts/api/use-get-account.ts
@@ -2,9 +2,13 @@ import { useQuery } from '@tanstack/react-query';
 
 import { client } from '@/lib/hono';
 
-export const useGetAccount = (id?: string) => {
+type GetAccountOptions = {
+    enabled?: boolean;
+};
+
+export const useGetAccount = (id?: string, options?: GetAccountOptions) => {
     const query = useQuery({
-        enabled: !!id,
+        enabled: !!id && (options?.enabled ?? true),
         queryKey: ['account', { id }],
         queryFn: async () => {
             const response = await client.api.accounts[':id'].$get({

--- a/features/customers/api/use-get-customer.ts
+++ b/features/customers/api/use-get-customer.ts
@@ -2,9 +2,13 @@ import { useQuery } from '@tanstack/react-query';
 
 import { client } from '@/lib/hono';
 
-export const useGetCustomer = (id?: string) => {
+type GetCustomerOptions = {
+    enabled?: boolean;
+};
+
+export const useGetCustomer = (id?: string, options?: GetCustomerOptions) => {
     const query = useQuery({
-        enabled: !!id,
+        enabled: !!id && (options?.enabled ?? true),
         queryKey: ['customer', { id }],
         queryFn: async () => {
             const response = await client.api.customers[':id'].$get({

--- a/features/transactions/components/new-transaction-sheet.tsx
+++ b/features/transactions/components/new-transaction-sheet.tsx
@@ -37,15 +37,13 @@ export const NewTransactionSheet = () => {
     const onCreateCategory = (name: string) =>
         categoryMutation.mutate({ name });
     const onCreateCustomer = (name: string) =>
-        customerMutation
-            .mutateAsync({ name })
-            .then((response) => {
-                if ('data' in response) {
-                    return response.data.id;
-                }
+        customerMutation.mutateAsync({ name }).then((response) => {
+            if ('data' in response) {
+                return response.data.id;
+            }
 
-                throw new Error(response.error ?? 'Failed to create customer.');
-            });
+            throw new Error(response.error ?? 'Failed to create customer.');
+        });
 
     const isPending =
         createMutation.isPending ||


### PR DESCRIPTION
Add a new boolean setting autoDraftToPending on the Settings table
(schema and migration) to support automatic Draft→Pending transitions.
Expose the flag to the status progression UI and prevent user-triggered
advances from Draft to Pending when the automatic flow is enabled.

- DB: add auto_draft_to_pending boolean NOT NULL DEFAULT false to
  settings (drizzle migration and schema type).
- UI (status-progression): accept autoDraftToPendingEnabled prop,
  compute isAutoDraftToPendingBlocked and block the Advance action and
  Advance button when the auto-transition is active; show an inline
  helper message explaining that saving will trigger the automatic
  transition.
- Account select: improve account resolution logic to fetch and merge a
  selected account if it's not present in the initial list and
  normalize hasInvalidConfig for accounts to avoid undefined values.

These changes ensure the new automatic draft-to-pending behavior is
stored in the DB and enforced in the client, preventing duplicate or
conflicting manual advances and providing clearer UX.