### PR TITLE
feat(transactions): open edit after create and add duplicate action

### DIFF
--- a/features/transactions/components/new-transaction-sheet.tsx
+++ b/features/transactions/components/new-transaction-sheet.tsx
@@ -14,6 +14,7 @@ import { useGetCategories } from '@/features/categories/api/use-get-categories';
 import { useCreateCustomer } from '@/features/customers/api/use-create-customer';
 import { useCreateUnifiedTransaction } from '@/features/transactions/api/use-create-unified-transaction';
 import { useNewTransaction } from '@/features/transactions/hooks/use-new-transaction';
+import { useOpenTransaction } from '@/features/transactions/hooks/use-open-transaction';
 
 import {
     UnifiedTransactionForm,
@@ -22,9 +23,10 @@ import {
 
 export const NewTransactionSheet = () => {
     const { isOpen, onClose, defaultValues } = useNewTransaction();
+    const { onOpen: onOpenEdit } = useOpenTransaction();
     const [activeTab, setActiveTab] = useState('details');
 
-    const createMutation = useCreateUnifiedTransaction();
+    const createMutation = useCreateUnifiedTransaction(onOpenEdit, onClose);
     const categoryMutation = useCreateCategory();
     const categoryQuery = useGetCategories();
     const categoryOptions = (categoryQuery.data ?? []).map((category) => ({


### PR DESCRIPTION
- Pass optional callbacks to useCreateUnifiedTransaction to allow post-
  creation behavior (onOpen, onCloseNew). On success extract the new
  transaction ID (handle single and split transactions), close new
  transaction sheet, and open the edit sheet on the details tab. This
  provides immediate access to the newly created transaction for
  review/editing and improves UX flow.
- Wire the new callbacks into NewTransactionSheet so creating a
  transaction triggers the sheet transitions.
- Add duplicate functionality skeleton in EditTransactionSheet:
  import utilities to convert amounts and prepare defaultValues for a
  duplicated transaction, and add a handleDuplicate handler to open the
  new-transaction sheet prefilled from the current transaction.
- Minor UI/import adjustments in EditTransactionSheet (Copy icon,
  Button component) and reformatting to support the new features.
- Keep existing category and query invalidation behavior on success.

These changes streamline creating and editing transactions and let
users quickly duplicate an existing transaction into a new form.