### PR TITLE
feat(tags): improve tag visuals and contrast for readability

### DIFF
--- a/app/(dashboard)/transactions/tags-column.tsx
+++ b/app/(dashboard)/transactions/tags-column.tsx
@@ -1,5 +1,5 @@
 import { useOpenTransaction } from '@/features/transactions/hooks/use-open-transaction';
-import { cn } from '@/lib/utils';
+import { cn, getContrastingTextColor } from '@/lib/utils';
 
 type Tag = {
     id: string;
@@ -41,18 +41,18 @@ export const TagsColumn = ({ id, tags }: TagsColumnProps) => {
                 <span
                     key={tag.id}
                     className={cn(
-                        'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
+                        'inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium',
                         'border hover:opacity-80 transition-opacity',
+                        'max-w-[100px] overflow-hidden',
                     )}
                     style={{
-                        backgroundColor: tag.color
-                            ? `${tag.color}20`
-                            : '#dbeafe',
+                        backgroundColor: tag.color ?? '#3b82f6',
                         borderColor: tag.color ?? '#3b82f6',
-                        color: tag.color ?? '#1e40af',
+                        color: tag.color ? getContrastingTextColor(tag.color) : '#ffffff',
                     }}
+                    title={tag.name}
                 >
-                    {tag.name}
+                    <span className="truncate">{tag.name}</span>
                 </span>
             ))}
             {tags.length > 3 && (

--- a/features/tags/components/tag-badge.tsx
+++ b/features/tags/components/tag-badge.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@/lib/utils';
+import { cn, getContrastingTextColor } from '@/lib/utils';
 
 type TagBadgeProps = {
     name: string;
@@ -14,14 +14,14 @@ export const TagBadge = ({
     className,
 }: TagBadgeProps) => {
     const baseClasses =
-        'inline-flex items-center rounded-full font-medium whitespace-nowrap';
+        'inline-flex items-center rounded-full font-medium max-w-[120px] overflow-hidden';
     const sizeClasses =
-        size === 'sm' ? 'px-2 py-0.5 text-xs' : 'px-3 py-1 text-sm';
+        size === 'sm' ? 'px-1.5 py-0.5 text-[10px]' : 'px-2 py-0.5 text-xs';
 
     const style = color
         ? {
-              backgroundColor: `${color}20`,
-              color: color,
+              backgroundColor: color,
+              color: getContrastingTextColor(color),
               borderColor: color,
           }
         : {};
@@ -36,8 +36,9 @@ export const TagBadge = ({
                 className,
             )}
             style={style}
+            title={name}
         >
-            {name}
+            <span className="truncate">{name}</span>
         </span>
     );
 };

--- a/features/tags/components/tag-multi-select.tsx
+++ b/features/tags/components/tag-multi-select.tsx
@@ -4,6 +4,8 @@ import { useMemo } from 'react';
 import type { MultiValue } from 'react-select';
 import CreatableSelect from 'react-select/creatable';
 
+import { getContrastingTextColor } from '@/lib/utils';
+
 type TagOption = {
     label: string;
     value: string;
@@ -56,24 +58,26 @@ export const TagMultiSelect = ({
                 }),
                 multiValue: (base, { data }) => ({
                     ...base,
-                    backgroundColor: data.color ? `${data.color}20` : '#dbeafe',
+                    backgroundColor: data.color ?? '#3b82f6',
                     borderColor: data.color ?? '#3b82f6',
                     border: '1px solid',
+                    padding: '1px 4px',
                 }),
                 multiValueLabel: (base, { data }) => ({
                     ...base,
-                    color: data.color ?? '#1e40af',
+                    color: data.color ? getContrastingTextColor(data.color) : '#ffffff',
                     fontWeight: 500,
+                    fontSize: '11px',
+                    padding: '0 2px',
                 }),
                 multiValueRemove: (base, { data }) => ({
                     ...base,
-                    color: data.color ?? '#1e40af',
+                    color: data.color ? getContrastingTextColor(data.color) : '#ffffff',
                     ':hover': {
-                        backgroundColor: data.color
-                            ? `${data.color}40`
-                            : '#bfdbfe',
-                        color: data.color ?? '#1e3a8a',
+                        backgroundColor: 'rgba(0, 0, 0, 0.1)',
+                        color: data.color ? getContrastingTextColor(data.color) : '#ffffff',
                     },
+                    padding: '0 2px',
                 }),
             }}
             value={formattedValue}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -100,3 +100,27 @@ export function formatPercentage(
 
     return result;
 }
+
+/**
+ * Calculate contrasting text color (black or white) based on background color
+ * Uses relative luminance calculation from WCAG guidelines
+ */
+export function getContrastingTextColor(hexColor: string): string {
+    // Remove # if present
+    const hex = hexColor.replace('#', '');
+
+    // Convert to RGB
+    const r = parseInt(hex.substring(0, 2), 16) / 255;
+    const g = parseInt(hex.substring(2, 4), 16) / 255;
+    const b = parseInt(hex.substring(4, 6), 16) / 255;
+
+    // Calculate relative luminance
+    const luminance = (c: number) =>
+        c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+
+    const L =
+        0.2126 * luminance(r) + 0.7152 * luminance(g) + 0.0722 * luminance(b);
+
+    // Return black for light backgrounds, white for dark backgrounds
+    return L > 0.5 ? '#000000' : '#FFFFFF';
+}


### PR DESCRIPTION
Update tag components to improve styling, sizing, truncation, and text
contrast to ensure better readability and consistent appearance across the
app.

- Add getContrastingTextColor helper to lib/utils and export it.
  Implements WCAG-relative-luminance based contrast choice (black or white)
  for dynamic tag colors.

- Tag multi-select:
  - Import and use getContrastingTextColor to pick readable label/remove
    text color for colored tags.
  - Use solid color for background/border when color present; add padding
    and tighten font/size for multi-value labels and remove button.
  - Simplify hover color to a subtle overlay.

- Tag column (transactions):
  - Use getContrastingTextColor for tag text and switch background to
    solid color when provided.
  - Reduce padding/font size, add max width, overflow hidden and title to
    show full name on hover, and truncate inner text.

- Tag badge:
  - Use getContrastingTextColor for badge text color and set background
    to the provided color.
  - Adjust sizing classes, apply max width/overflow, add title, and truncate
    content to avoid layout breakage.

These changes improve accessibility (contrast), visual consistency, and
prevent layout overflow for long tag names.