### PR TITLE
feat(dropzone): add InvoiceZipDropzone component

### DIFF
--- a/app/(dashboard)/new/page.tsx
+++ b/app/(dashboard)/new/page.tsx
@@ -8,20 +8,24 @@ import {
 } from '@signalco/ui-primitives/Card';
 import { ArrowLeft, Loader2 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { Suspense } from 'react';
+import { Suspense, useState } from 'react';
+import { InvoiceImport } from '@/components/invoice-import';
 import { Button } from '@/components/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useCreateCustomer } from '@/features/customers/api/use-create-customer';
 import { useCreateTag } from '@/features/tags/api/use-create-tag';
 import { useGetTags } from '@/features/tags/api/use-get-tags';
 import { useCreateUnifiedTransaction } from '@/features/transactions/api/use-create-unified-transaction';
-
 import {
     UnifiedTransactionForm,
     type UnifiedTransactionFormValues,
 } from '@/features/transactions/components/unified-transaction-form';
+import { useOpenTransaction } from '@/features/transactions/hooks/use-open-transaction';
 
 function NewTransactionContent() {
     const router = useRouter();
+    const [activeTab, setActiveTab] = useState('details');
+    const { onOpen: onOpenTransaction } = useOpenTransaction();
 
     const createMutation = useCreateUnifiedTransaction();
     const tagMutation = useCreateTag();
@@ -58,6 +62,10 @@ function NewTransactionContent() {
         });
     };
 
+    const handleImportComplete = () => {
+        router.push('/transactions');
+    };
+
     return (
         <div className="mx-auto -mt-12 lg:-mt-24 w-full max-w-screen-2xl pb-10">
             <Card>
@@ -81,13 +89,37 @@ function NewTransactionContent() {
                             <Loader2 className="size-6 animate-spin text-slate-300" />
                         </div>
                     ) : (
-                        <UnifiedTransactionForm
-                            disabled={isPending}
-                            tagOptions={tagOptions}
-                            onCreateTag={onCreateTag}
-                            onCreateCustomer={onCreateCustomer}
-                            onSubmit={onSubmit}
-                        />
+                        <Tabs
+                            value={activeTab}
+                            onValueChange={setActiveTab}
+                            className="w-full"
+                        >
+                            <TabsList className="w-full max-w-md">
+                                <TabsTrigger value="details" className="flex-1">
+                                    Manual Entry
+                                </TabsTrigger>
+                                <TabsTrigger value="import" className="flex-1">
+                                    Import from ZIP
+                                </TabsTrigger>
+                            </TabsList>
+
+                            <TabsContent value="details" className="mt-6">
+                                <UnifiedTransactionForm
+                                    disabled={isPending}
+                                    tagOptions={tagOptions}
+                                    onCreateTag={onCreateTag}
+                                    onCreateCustomer={onCreateCustomer}
+                                    onSubmit={onSubmit}
+                                />
+                            </TabsContent>
+
+                            <TabsContent value="import" className="mt-6">
+                                <InvoiceImport
+                                    onComplete={handleImportComplete}
+                                    onOpenTransaction={onOpenTransaction}
+                                />
+                            </TabsContent>
+                        </Tabs>
                     )}
                 </CardContent>
             </Card>

--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -6,7 +6,7 @@ import {
     CardHeader,
     CardTitle,
 } from '@signalco/ui-primitives/Card';
-import { Loader2, MoreHorizontal, Plus } from 'lucide-react';
+import { Archive, Loader2, MoreHorizontal, Plus } from 'lucide-react';
 import { Suspense, useState } from 'react';
 import { toast } from 'sonner';
 import { ImportCard } from '@/components/import/import-card';
@@ -16,6 +16,7 @@ import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
+    DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useSelectImportAccounts } from '@/features/accounts/hooks/use-select-import-accounts';
@@ -364,10 +365,22 @@ export default function TransactionsPage() {
                                 </Button>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="end">
+                                <DropdownMenuItem
+                                    onClick={() =>
+                                        newTransaction.onOpen(
+                                            undefined,
+                                            'import',
+                                        )
+                                    }
+                                >
+                                    <Archive className="mr-2 h-4 w-4" />
+                                    Import from ZIP
+                                </DropdownMenuItem>
                                 <ImportButton
                                     onUpload={onUpload}
                                     variant="menu"
                                 />
+                                <DropdownMenuSeparator />
                                 <DropdownMenuItem
                                     onClick={() =>
                                         setBulkDeleteMode(!bulkDeleteMode)

--- a/app/(dashboard)/transactions/tags-column.tsx
+++ b/app/(dashboard)/transactions/tags-column.tsx
@@ -48,7 +48,9 @@ export const TagsColumn = ({ id, tags }: TagsColumnProps) => {
                     style={{
                         backgroundColor: tag.color ?? '#3b82f6',
                         borderColor: tag.color ?? '#3b82f6',
-                        color: tag.color ? getContrastingTextColor(tag.color) : '#ffffff',
+                        color: tag.color
+                            ? getContrastingTextColor(tag.color)
+                            : '#ffffff',
                     }}
                     title={tag.name}
                 >

--- a/app/api/[[...route]]/documentsRoutes.ts
+++ b/app/api/[[...route]]/documentsRoutes.ts
@@ -363,7 +363,10 @@ const app = new Hono()
 
             // Verify ownership through transaction
             if (!doc.transactionId) {
-                return ctx.json({ error: 'Document not linked to a transaction.' }, 400);
+                return ctx.json(
+                    { error: 'Document not linked to a transaction.' },
+                    400,
+                );
             }
 
             const transaction = await getAuthorizedTransaction(
@@ -422,7 +425,10 @@ const app = new Hono()
 
                 // Verify ownership through transaction
                 if (!doc.transactionId) {
-                    return ctx.json({ error: 'Document not linked to a transaction.' }, 400);
+                    return ctx.json(
+                        { error: 'Document not linked to a transaction.' },
+                        400,
+                    );
                 }
 
                 const transaction = await getAuthorizedTransaction(

--- a/app/api/[[...route]]/transactionsRoutes.ts
+++ b/app/api/[[...route]]/transactionsRoutes.ts
@@ -2309,7 +2309,8 @@ const app = new Hono()
                         id: createId(),
                         date: parentTransactionValues.date,
                         payee: parentTransactionValues.payee,
-                        payeeCustomerId: parentTransactionValues.payeeCustomerId,
+                        payeeCustomerId:
+                            parentTransactionValues.payeeCustomerId,
                         amount: split.amount,
                         accountId: split.accountId,
                         creditAccountId: split.creditAccountId,

--- a/components/import-button.tsx
+++ b/components/import-button.tsx
@@ -59,7 +59,7 @@ export const ImportButton = ({
                             }}
                         >
                             <Import className="size-4" />
-                            Import
+                            Import from CSV
                         </DropdownMenuItem>
                     );
                 }}

--- a/components/invoice-import.tsx
+++ b/components/invoice-import.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { Check, Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import { InvoiceZipDropzone } from '@/components/invoice-zip-dropzone';
+import { Button } from '@/components/ui/button';
+import {
+    type ImportedInvoiceResult,
+    useImportInvoiceZip,
+} from '@/features/transactions/api/use-import-invoice-zip';
+import { cn } from '@/lib/utils';
+
+interface InvoiceImportProps {
+    onComplete?: () => void;
+    onOpenTransaction?: (
+        id: string,
+        tab?: 'details' | 'documents' | 'history',
+    ) => void;
+}
+
+type ImportStep = 'select-file' | 'importing' | 'complete';
+
+export function InvoiceImport({
+    onComplete,
+    onOpenTransaction,
+}: InvoiceImportProps) {
+    const [step, setStep] = useState<ImportStep>('select-file');
+    const [results, setResults] = useState<ImportedInvoiceResult[]>([]);
+
+    const importMutation = useImportInvoiceZip(onOpenTransaction, () => {
+        setStep('complete');
+        if (onComplete) {
+            onComplete();
+        }
+    });
+
+    const handleZipAccepted = async (file: File) => {
+        setStep('importing');
+        const result = await importMutation.mutateAsync({
+            zipFile: file,
+        });
+        setResults(result);
+    };
+
+    const handleReset = () => {
+        setStep('select-file');
+        setResults([]);
+    };
+
+    // Render based on current step
+    if (step === 'select-file') {
+        return (
+            <div className="space-y-4">
+                <InvoiceZipDropzone
+                    onZipAccepted={handleZipAccepted}
+                    isProcessing={false}
+                />
+            </div>
+        );
+    }
+
+    if (step === 'importing') {
+        return (
+            <div className="flex flex-col items-center justify-center py-12 space-y-4">
+                <Loader2 className="h-12 w-12 animate-spin text-primary" />
+                <div className="text-center">
+                    <p className="text-sm font-medium">Importing invoices...</p>
+                    <p className="text-xs text-muted-foreground">
+                        This may take a moment
+                    </p>
+                </div>
+            </div>
+        );
+    }
+
+    if (step === 'complete') {
+        const successCount = results.filter((r) => r.success).length;
+        const errorCount = results.filter((r) => !r.success).length;
+
+        return (
+            <div className="space-y-6">
+                {/* Summary */}
+                <div
+                    className={cn(
+                        'rounded-md p-4 text-center',
+                        successCount > 0 && errorCount === 0
+                            ? 'bg-green-50 dark:bg-green-950'
+                            : errorCount > 0 && successCount === 0
+                              ? 'bg-red-50 dark:bg-red-950'
+                              : 'bg-yellow-50 dark:bg-yellow-950',
+                    )}
+                >
+                    <Check
+                        className={cn(
+                            'mx-auto h-8 w-8 mb-2',
+                            successCount > 0 && errorCount === 0
+                                ? 'text-green-600'
+                                : errorCount > 0 && successCount === 0
+                                  ? 'text-red-600'
+                                  : 'text-yellow-600',
+                        )}
+                    />
+                    <p className="font-medium">
+                        {successCount > 0 && errorCount === 0
+                            ? `Successfully imported ${successCount} invoice${successCount > 1 ? 's' : ''}`
+                            : errorCount > 0 && successCount === 0
+                              ? 'Failed to import invoices'
+                              : `Imported ${successCount}, failed ${errorCount}`}
+                    </p>
+                </div>
+
+                {/* Results list */}
+                <div className="space-y-2 max-h-60 overflow-y-auto">
+                    {results.map((result) => (
+                        <div
+                            key={result.invoiceNumber}
+                            className={cn(
+                                'flex items-center justify-between rounded-md border p-3',
+                                result.success
+                                    ? 'border-green-200 bg-green-50/50 dark:border-green-900 dark:bg-green-950/50'
+                                    : 'border-red-200 bg-red-50/50 dark:border-red-900 dark:bg-red-950/50',
+                            )}
+                        >
+                            <div>
+                                <p className="text-sm font-medium">
+                                    {result.invoiceNumber}
+                                </p>
+                                {result.success ? (
+                                    <p className="text-xs text-muted-foreground">
+                                        {result.documentsUploaded} document
+                                        {result.documentsUploaded !== 1
+                                            ? 's'
+                                            : ''}{' '}
+                                        attached
+                                    </p>
+                                ) : (
+                                    <p className="text-xs text-red-600">
+                                        {result.error}
+                                    </p>
+                                )}
+                            </div>
+                            {result.success && result.transactionId && (
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => {
+                                        if (result.transactionId) {
+                                            onOpenTransaction?.(
+                                                result.transactionId,
+                                                'details',
+                                            );
+                                        }
+                                    }}
+                                >
+                                    View
+                                </Button>
+                            )}
+                        </div>
+                    ))}
+                </div>
+
+                {/* Actions */}
+                <div className="flex justify-end gap-2">
+                    <Button variant="outline" onClick={handleReset}>
+                        Import More
+                    </Button>
+                    <Button onClick={onComplete}>Done</Button>
+                </div>
+            </div>
+        );
+    }
+
+    return null;
+}

--- a/components/invoice-zip-dropzone.tsx
+++ b/components/invoice-zip-dropzone.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { Archive, FileText, Loader2, Upload } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import {
+    type DropzoneOptions,
+    type FileRejection,
+    useDropzone,
+} from 'react-dropzone';
+import { cn } from '@/lib/utils';
+
+interface InvoiceZipDropzoneProps {
+    onZipAccepted: (file: File) => void;
+    isProcessing?: boolean;
+    disabled?: boolean;
+    className?: string;
+}
+
+const ZIP_ACCEPT: DropzoneOptions['accept'] = {
+    'application/zip': ['.zip'],
+    'application/x-zip-compressed': ['.zip'],
+};
+
+const MAX_SIZE = 50 * 1024 * 1024; // 50MB
+
+export function InvoiceZipDropzone({
+    onZipAccepted,
+    isProcessing = false,
+    disabled = false,
+    className,
+}: InvoiceZipDropzoneProps) {
+    const [rejectedFiles, setRejectedFiles] = useState<FileRejection[]>([]);
+
+    const onDrop = useCallback(
+        (acceptedFiles: File[], fileRejections: FileRejection[]) => {
+            setRejectedFiles(fileRejections);
+
+            if (acceptedFiles.length > 0) {
+                // Only accept one ZIP file
+                onZipAccepted(acceptedFiles[0]);
+            }
+        },
+        [onZipAccepted],
+    );
+
+    const { getRootProps, getInputProps, isDragActive, isDragReject } =
+        useDropzone({
+            onDrop,
+            accept: ZIP_ACCEPT,
+            maxFiles: 1,
+            maxSize: MAX_SIZE,
+            disabled: disabled || isProcessing,
+            multiple: false,
+        });
+
+    const formatFileSize = (bytes: number) => {
+        if (bytes < 1024) return `${bytes} B`;
+        if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+        return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+    };
+
+    return (
+        <div className={cn('space-y-4', className)}>
+            {/* Dropzone area */}
+            <div
+                {...getRootProps()}
+                className={cn(
+                    'relative flex flex-col items-center justify-center rounded-lg border-2 border-dashed p-8 transition-colors cursor-pointer',
+                    isDragActive &&
+                        !isDragReject &&
+                        'border-primary bg-primary/5',
+                    isDragReject && 'border-destructive bg-destructive/5',
+                    !isDragActive &&
+                        'border-muted-foreground/25 hover:border-muted-foreground/50',
+                    (disabled || isProcessing) &&
+                        'cursor-not-allowed opacity-60',
+                )}
+            >
+                <input {...getInputProps()} />
+
+                {isProcessing ? (
+                    <div className="flex flex-col items-center gap-3 text-muted-foreground">
+                        <Loader2 className="h-12 w-12 animate-spin" />
+                        <div className="text-center">
+                            <p className="text-sm font-medium">
+                                Processing ZIP file...
+                            </p>
+                            <p className="text-xs text-muted-foreground/70">
+                                Extracting and parsing invoices
+                            </p>
+                        </div>
+                    </div>
+                ) : (
+                    <div className="flex flex-col items-center gap-3 text-muted-foreground">
+                        <div className="relative">
+                            <Archive
+                                className={cn(
+                                    'h-12 w-12',
+                                    isDragActive && 'text-primary',
+                                )}
+                            />
+                            <Upload className="absolute -bottom-1 -right-1 h-5 w-5 rounded-full bg-background text-primary" />
+                        </div>
+                        <div className="text-center">
+                            <p className="text-sm font-medium">
+                                {isDragActive
+                                    ? isDragReject
+                                        ? 'Only ZIP files are allowed'
+                                        : 'Drop ZIP file here'
+                                    : 'Import invoices from ZIP'}
+                            </p>
+                            <p className="text-xs text-muted-foreground/70">
+                                Drag & drop or click to browse
+                            </p>
+                        </div>
+                        <div className="flex items-center gap-4 text-xs text-muted-foreground/50">
+                            <span className="flex items-center gap-1">
+                                <FileText className="h-3 w-3" />
+                                XML invoices
+                            </span>
+                            <span>•</span>
+                            <span>Max {formatFileSize(MAX_SIZE)}</span>
+                        </div>
+                    </div>
+                )}
+            </div>
+
+            {/* Info text */}
+            <div className="text-xs text-muted-foreground space-y-1">
+                <p>
+                    <strong>Supported formats:</strong> ZIP files containing UBL
+                    invoice XML files
+                </p>
+                <p>
+                    Embedded PDF attachments will be automatically extracted and
+                    attached to the transaction.
+                </p>
+            </div>
+
+            {/* Rejected files */}
+            {rejectedFiles.length > 0 && (
+                <div className="space-y-2">
+                    <p className="text-sm font-medium text-destructive">
+                        File rejected:
+                    </p>
+                    {rejectedFiles.map(({ file, errors }, index) => (
+                        <div
+                            key={`${file.name}-${index}`}
+                            className="flex items-center gap-2 rounded-md border border-destructive/50 bg-destructive/5 px-3 py-2 text-sm"
+                        >
+                            <Archive className="h-4 w-4 text-destructive" />
+                            <span className="flex-1 truncate">{file.name}</span>
+                            <span className="text-xs text-destructive">
+                                {errors.map((e) => e.message).join(', ')}
+                            </span>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/features/tags/components/tag-multi-select.tsx
+++ b/features/tags/components/tag-multi-select.tsx
@@ -65,17 +65,23 @@ export const TagMultiSelect = ({
                 }),
                 multiValueLabel: (base, { data }) => ({
                     ...base,
-                    color: data.color ? getContrastingTextColor(data.color) : '#ffffff',
+                    color: data.color
+                        ? getContrastingTextColor(data.color)
+                        : '#ffffff',
                     fontWeight: 500,
                     fontSize: '11px',
                     padding: '0 2px',
                 }),
                 multiValueRemove: (base, { data }) => ({
                     ...base,
-                    color: data.color ? getContrastingTextColor(data.color) : '#ffffff',
+                    color: data.color
+                        ? getContrastingTextColor(data.color)
+                        : '#ffffff',
                     ':hover': {
                         backgroundColor: 'rgba(0, 0, 0, 0.1)',
-                        color: data.color ? getContrastingTextColor(data.color) : '#ffffff',
+                        color: data.color
+                            ? getContrastingTextColor(data.color)
+                            : '#ffffff',
                     },
                     padding: '0 2px',
                 }),

--- a/features/transactions/api/use-import-invoice-zip.ts
+++ b/features/transactions/api/use-import-invoice-zip.ts
@@ -1,0 +1,294 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { client } from '@/lib/hono';
+import {
+    parseInvoiceZip,
+    type ZipInvoiceEntry,
+} from '@/lib/invoice-xml-parser';
+import { convertAmountToMiliunits } from '@/lib/utils';
+
+export interface ImportedInvoiceResult {
+    success: boolean;
+    transactionId?: string;
+    invoiceNumber: string;
+    error?: string;
+    documentsUploaded: number;
+}
+
+interface ImportInvoiceZipInput {
+    zipFile: File;
+    creditAccountId?: string;
+    debitAccountId?: string;
+}
+
+export const useImportInvoiceZip = (
+    onOpen?: (id: string, tab?: 'details' | 'documents' | 'history') => void,
+    onComplete?: () => void,
+) => {
+    const queryClient = useQueryClient();
+
+    const mutation = useMutation<
+        ImportedInvoiceResult[],
+        Error,
+        ImportInvoiceZipInput
+    >({
+        mutationFn: async ({ zipFile, creditAccountId, debitAccountId }) => {
+            // Step 1: Parse the ZIP file
+            const entries = await parseInvoiceZip(zipFile);
+
+            if (entries.length === 0) {
+                throw new Error(
+                    'No valid invoices found in the ZIP file. Please ensure it contains XML invoice files.',
+                );
+            }
+
+            const results: ImportedInvoiceResult[] = [];
+
+            // Step 2: Process each invoice entry
+            for (const entry of entries) {
+                if (!entry.invoice) {
+                    results.push({
+                        success: false,
+                        invoiceNumber: entry.fileName,
+                        error: entry.parseError || 'Failed to parse invoice',
+                        documentsUploaded: 0,
+                    });
+                    continue;
+                }
+
+                try {
+                    const result = await processInvoiceEntry(
+                        entry,
+                        creditAccountId,
+                        debitAccountId,
+                    );
+                    results.push(result);
+                } catch (error) {
+                    results.push({
+                        success: false,
+                        invoiceNumber: entry.invoice.invoiceNumber,
+                        error:
+                            error instanceof Error
+                                ? error.message
+                                : 'Unknown error',
+                        documentsUploaded: 0,
+                    });
+                }
+            }
+
+            return results;
+        },
+        onSuccess: (results) => {
+            const successCount = results.filter((r) => r.success).length;
+            const errorCount = results.filter((r) => !r.success).length;
+
+            queryClient.invalidateQueries({ queryKey: ['transactions'] });
+            queryClient.invalidateQueries({ queryKey: ['summary'] });
+            queryClient.invalidateQueries({ queryKey: ['documents'] });
+
+            if (successCount > 0 && errorCount === 0) {
+                toast.success(
+                    `Successfully imported ${successCount} invoice${successCount > 1 ? 's' : ''}.`,
+                );
+            } else if (successCount > 0 && errorCount > 0) {
+                toast.warning(
+                    `Imported ${successCount} invoice${successCount > 1 ? 's' : ''}, ${errorCount} failed.`,
+                );
+            } else {
+                toast.error('Failed to import any invoices.');
+            }
+
+            // Open the first successfully created transaction
+            const firstSuccess = results.find(
+                (r) => r.success && r.transactionId,
+            );
+            if (firstSuccess?.transactionId && onOpen) {
+                onOpen(firstSuccess.transactionId, 'documents');
+            }
+
+            if (onComplete) {
+                onComplete();
+            }
+        },
+        onError: (error) => {
+            toast.error(error.message || 'Failed to import invoices from ZIP.');
+        },
+    });
+
+    return mutation;
+};
+
+/**
+ * Process a single invoice entry: create transaction and upload attachments
+ */
+async function processInvoiceEntry(
+    entry: ZipInvoiceEntry,
+    creditAccountId: string | undefined,
+    debitAccountId: string | undefined,
+): Promise<ImportedInvoiceResult> {
+    if (!entry.invoice) {
+        return {
+            success: false,
+            invoiceNumber: entry.fileName,
+            error: 'No invoice data found',
+            documentsUploaded: 0,
+        };
+    }
+
+    const invoice = entry.invoice;
+
+    // Create the transaction
+    const amount = convertAmountToMiliunits(invoice.totalAmount);
+
+    // Build notes from invoice data
+    const noteParts: string[] = [];
+    if (invoice.invoiceNumber) {
+        noteParts.push(`Invoice #${invoice.invoiceNumber}`);
+    }
+    if (invoice.supplierName) {
+        noteParts.push(`From: ${invoice.supplierName}`);
+    }
+    if (invoice.payeeIban) {
+        noteParts.push(`IBAN: ${invoice.payeeIban}`);
+    }
+    if (invoice.paymentReference) {
+        noteParts.push(`Ref: ${invoice.paymentReference}`);
+    }
+    if (invoice.notes) {
+        noteParts.push(invoice.notes);
+    }
+
+    // Create transaction
+    const transactionResponse = await client.api.transactions.$post({
+        json: {
+            date: invoice.issueDate,
+            payee: invoice.supplierName || undefined,
+            notes: noteParts.join(' | ') || undefined,
+            creditAccountId: creditAccountId || undefined,
+            debitAccountId: debitAccountId || undefined,
+            amount,
+            status: 'draft',
+        },
+    });
+
+    if (!transactionResponse.ok) {
+        const error = await transactionResponse.json();
+        throw new Error(
+            (error as { error?: string }).error ||
+                'Failed to create transaction.',
+        );
+    }
+
+    const transactionData = await transactionResponse.json();
+    const transactionId = transactionData.data.id;
+
+    // Upload attachments
+    let documentsUploaded = 0;
+
+    if (entry.attachments.length > 0) {
+        // Get document types
+        const docTypesResponse = await client.api['document-types'].$get();
+        let defaultDocTypeId: string | undefined;
+
+        if (docTypesResponse.ok) {
+            const { data: docTypes } = await docTypesResponse.json();
+            // Try to find "Invoice" type, or use first available
+            const invoiceType = docTypes.find(
+                (t) =>
+                    t.name.toLowerCase().includes('invoice') ||
+                    t.name.toLowerCase().includes('receipt'),
+            );
+            defaultDocTypeId = invoiceType?.id || docTypes[0]?.id;
+        }
+
+        if (defaultDocTypeId) {
+            for (const attachment of entry.attachments) {
+                try {
+                    // Create File object from Blob
+                    const file = new File(
+                        [attachment.data],
+                        attachment.fileName,
+                        {
+                            type: attachment.mimeType,
+                        },
+                    );
+
+                    // Generate upload URL
+                    const uploadUrlResponse = await client.api.documents[
+                        'generate-upload-url'
+                    ].$post({
+                        json: {
+                            transactionId,
+                            fileName: attachment.fileName,
+                        },
+                    });
+
+                    if (!uploadUrlResponse.ok) {
+                        console.error(
+                            'Failed to generate upload URL for',
+                            attachment.fileName,
+                        );
+                        continue;
+                    }
+
+                    const { data: uploadData } = await uploadUrlResponse.json();
+                    const { uploadUrl } = uploadData;
+
+                    // Extract storage path from SAS URL
+                    const url = new URL(uploadUrl);
+                    const storagePath = url.pathname.substring(
+                        url.pathname.indexOf('/documents/') +
+                            '/documents/'.length,
+                    );
+
+                    // Upload to blob storage
+                    const uploadResponse = await fetch(uploadUrl, {
+                        method: 'PUT',
+                        headers: {
+                            'x-ms-blob-type': 'BlockBlob',
+                            'Content-Type': attachment.mimeType,
+                        },
+                        body: file,
+                    });
+
+                    if (!uploadResponse.ok) {
+                        console.error(
+                            'Failed to upload to blob storage:',
+                            attachment.fileName,
+                        );
+                        continue;
+                    }
+
+                    // Save document metadata
+                    const saveResponse = await client.api.documents.$post({
+                        json: {
+                            transactionId,
+                            documentTypeId: defaultDocTypeId,
+                            fileName: attachment.fileName,
+                            fileSize: file.size,
+                            mimeType: attachment.mimeType,
+                            storagePath,
+                        },
+                    });
+
+                    if (saveResponse.ok) {
+                        documentsUploaded++;
+                    }
+                } catch (error) {
+                    console.error(
+                        'Error uploading attachment:',
+                        attachment.fileName,
+                        error,
+                    );
+                }
+            }
+        }
+    }
+
+    return {
+        success: true,
+        transactionId,
+        invoiceNumber: invoice.invoiceNumber,
+        documentsUploaded,
+    };
+}

--- a/features/transactions/components/new-transaction-sheet.tsx
+++ b/features/transactions/components/new-transaction-sheet.tsx
@@ -1,6 +1,7 @@
 import { Loader2 } from 'lucide-react';
 import { useState } from 'react';
 
+import { InvoiceImport } from '@/components/invoice-import';
 import {
     Sheet,
     SheetContent,
@@ -22,9 +23,24 @@ import {
 } from './unified-transaction-form';
 
 export const NewTransactionSheet = () => {
-    const { isOpen, onClose, defaultValues } = useNewTransaction();
+    const { isOpen, onClose, defaultValues, defaultTab } = useNewTransaction();
     const { onOpen: onOpenEdit } = useOpenTransaction();
-    const [activeTab, setActiveTab] = useState('details');
+    const [activeTab, setActiveTab] = useState<
+        'details' | 'documents' | 'import'
+    >(defaultTab || 'details');
+
+    // Update active tab when defaultTab changes
+    const effectiveTab = defaultTab || activeTab;
+
+    const handleTabChange = (value: string) => {
+        if (
+            value === 'details' ||
+            value === 'documents' ||
+            value === 'import'
+        ) {
+            setActiveTab(value);
+        }
+    };
 
     const createMutation = useCreateUnifiedTransaction(onOpenEdit, onClose);
     const tagMutation = useCreateTag();
@@ -75,8 +91,8 @@ export const NewTransactionSheet = () => {
                     </div>
                 ) : (
                     <Tabs
-                        value={activeTab}
-                        onValueChange={setActiveTab}
+                        value={effectiveTab}
+                        onValueChange={handleTabChange}
                         className="flex-1 flex flex-col"
                     >
                         <div className="px-6 mb-4">
@@ -84,6 +100,7 @@ export const NewTransactionSheet = () => {
                                 <TabsTrigger value="details">
                                     Details
                                 </TabsTrigger>
+                                <TabsTrigger value="import">Import</TabsTrigger>
                                 <TabsTrigger value="documents">
                                     Documents
                                 </TabsTrigger>
@@ -99,6 +116,13 @@ export const NewTransactionSheet = () => {
                                     onCreateCustomer={onCreateCustomer}
                                     onSubmit={onSubmit}
                                     defaultValues={defaultValues}
+                                />
+                            </TabsContent>
+
+                            <TabsContent value="import" className="mt-6">
+                                <InvoiceImport
+                                    onComplete={onClose}
+                                    onOpenTransaction={onOpenEdit}
                                 />
                             </TabsContent>
 

--- a/features/transactions/hooks/use-new-transaction.ts
+++ b/features/transactions/hooks/use-new-transaction.ts
@@ -20,15 +20,21 @@ type TransactionDefaultValues = {
     }[];
 };
 
+type NewTransactionTab = 'details' | 'import' | 'documents';
+
 type NewTransactionState = {
     defaultValues?: TransactionDefaultValues;
+    defaultTab?: NewTransactionTab;
     setDefaultValues: (defaultValues?: TransactionDefaultValues) => void;
+    setDefaultTab: (tab?: NewTransactionTab) => void;
 };
 
 const useNewTransactionStore = create<NewTransactionState>((set) => ({
     defaultValues: undefined,
+    defaultTab: undefined,
     setDefaultValues: (defaultValues?: TransactionDefaultValues) =>
         set({ defaultValues }),
+    setDefaultTab: (defaultTab?: NewTransactionTab) => set({ defaultTab }),
 }));
 
 export const useNewTransaction = () => {
@@ -36,17 +42,24 @@ export const useNewTransaction = () => {
         'newTransaction',
         parseAsString,
     );
-    const { defaultValues, setDefaultValues } = useNewTransactionStore();
+    const { defaultValues, defaultTab, setDefaultValues, setDefaultTab } =
+        useNewTransactionStore();
 
     return {
         isOpen: newTransactionParam === '1',
         defaultValues,
-        onOpen: (values?: TransactionDefaultValues) => {
+        defaultTab,
+        onOpen: (
+            values?: TransactionDefaultValues,
+            tab?: NewTransactionTab,
+        ) => {
             setDefaultValues(values);
+            setDefaultTab(tab);
             void setNewTransactionParam('1');
         },
         onClose: () => {
             setDefaultValues(undefined);
+            setDefaultTab(undefined);
             void setNewTransactionParam(null);
         },
     };

--- a/lib/invoice-xml-parser.ts
+++ b/lib/invoice-xml-parser.ts
@@ -1,0 +1,542 @@
+/**
+ * Invoice XML Parser
+ * Parses UBL (Universal Business Language) invoice XML files
+ * to extract transaction data for creating new transactions
+ */
+
+export interface ParsedInvoice {
+    // Invoice identification
+    invoiceNumber: string;
+    issueDate: Date;
+    dueDate?: Date;
+
+    // Supplier (seller) info
+    supplierName: string;
+    supplierVatId?: string;
+    supplierAddress?: {
+        street?: string;
+        city?: string;
+        postalCode?: string;
+        country?: string;
+    };
+
+    // Customer (buyer) info
+    customerName: string;
+    customerVatId?: string;
+    customerAddress?: {
+        street?: string;
+        city?: string;
+        postalCode?: string;
+        country?: string;
+    };
+
+    // Financial data
+    currency: string;
+    totalAmount: number; // Total payable amount
+    taxAmount: number;
+    netAmount: number; // Amount without tax
+
+    // Line items
+    lineItems: ParsedInvoiceLineItem[];
+
+    // Payment info
+    paymentReference?: string;
+    payeeIban?: string;
+
+    // Notes
+    notes?: string;
+}
+
+export interface ParsedInvoiceLineItem {
+    id: string;
+    description: string;
+    quantity: number;
+    unitPrice: number;
+    lineAmount: number;
+    taxPercent?: number;
+}
+
+export interface InvoiceParseResult {
+    success: boolean;
+    invoice?: ParsedInvoice;
+    error?: string;
+    rawXml?: string;
+}
+
+/**
+ * Parse XML content to extract invoice data
+ */
+export function parseInvoiceXml(xmlContent: string): InvoiceParseResult {
+    try {
+        // Parse XML
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(xmlContent, 'text/xml');
+
+        // Check for parsing errors
+        const parseError = doc.querySelector('parsererror');
+        if (parseError) {
+            return {
+                success: false,
+                error: 'Invalid XML format',
+                rawXml: xmlContent,
+            };
+        }
+
+        // Try to find the Invoice element (handle different namespaces)
+        let invoiceElement =
+            doc.querySelector('Invoice') ||
+            doc.getElementsByTagNameNS(
+                'urn:oasis:names:specification:ubl:schema:xsd:Invoice-2',
+                'Invoice',
+            )[0];
+
+        // If wrapped in StandardBusinessDocument, find Invoice inside
+        if (!invoiceElement) {
+            const sbdInvoice = doc.querySelector(
+                'StandardBusinessDocument Invoice',
+            );
+            if (sbdInvoice) {
+                invoiceElement = sbdInvoice;
+            }
+        }
+
+        if (!invoiceElement) {
+            return {
+                success: false,
+                error: 'No Invoice element found in XML',
+                rawXml: xmlContent,
+            };
+        }
+
+        // Helper functions for extracting data
+        const getText = (
+            element: Element | null,
+            selector: string,
+        ): string | undefined => {
+            if (!element) return undefined;
+            const el =
+                element.querySelector(selector) ||
+                findElementByLocalName(element, selector);
+            return el?.textContent?.trim() || undefined;
+        };
+
+        const findElementByLocalName = (
+            parent: Element,
+            localName: string,
+        ): Element | null => {
+            // Handle namespaced elements by local name
+            const allElements = parent.getElementsByTagName('*');
+            for (let i = 0; i < allElements.length; i++) {
+                if (allElements[i].localName === localName) {
+                    return allElements[i];
+                }
+            }
+            return null;
+        };
+
+        const getNumber = (
+            element: Element | null,
+            selector: string,
+        ): number => {
+            const text = getText(element, selector);
+            if (!text) return 0;
+            return parseFloat(text.replace(',', '.')) || 0;
+        };
+
+        // Extract invoice identification
+        const invoiceNumber =
+            getText(invoiceElement, 'ID') ||
+            getText(invoiceElement, 'cbc\\:ID') ||
+            'Unknown';
+
+        const issueDateStr =
+            getText(invoiceElement, 'IssueDate') ||
+            getText(invoiceElement, 'cbc\\:IssueDate');
+        const issueDate = issueDateStr ? new Date(issueDateStr) : new Date();
+
+        const dueDateStr =
+            getText(invoiceElement, 'DueDate') ||
+            getText(invoiceElement, 'cbc\\:DueDate');
+        const dueDate = dueDateStr ? new Date(dueDateStr) : undefined;
+
+        // Extract supplier info
+        const supplierParty =
+            invoiceElement.querySelector('AccountingSupplierParty Party') ||
+            findElementByLocalName(invoiceElement, 'AccountingSupplierParty');
+
+        const supplierName =
+            getText(supplierParty, 'PartyName Name') ||
+            getText(supplierParty, 'PartyLegalEntity RegistrationName') ||
+            getText(supplierParty, 'cbc\\:Name') ||
+            'Unknown Supplier';
+
+        const supplierVatId =
+            getText(supplierParty, 'PartyTaxScheme CompanyID') ||
+            getText(supplierParty, 'PartyLegalEntity CompanyID');
+
+        const supplierPostalAddress =
+            supplierParty?.querySelector('PostalAddress');
+        const supplierAddress = supplierPostalAddress
+            ? {
+                  street: getText(supplierPostalAddress, 'StreetName'),
+                  city: getText(supplierPostalAddress, 'CityName'),
+                  postalCode: getText(supplierPostalAddress, 'PostalZone'),
+                  country: getText(
+                      supplierPostalAddress,
+                      'Country IdentificationCode',
+                  ),
+              }
+            : undefined;
+
+        // Extract customer info
+        const customerParty =
+            invoiceElement.querySelector('AccountingCustomerParty Party') ||
+            findElementByLocalName(invoiceElement, 'AccountingCustomerParty');
+
+        const customerName =
+            getText(customerParty, 'PartyName Name') ||
+            getText(customerParty, 'PartyLegalEntity RegistrationName') ||
+            getText(customerParty, 'cbc\\:Name') ||
+            'Unknown Customer';
+
+        const customerVatId =
+            getText(customerParty, 'PartyTaxScheme CompanyID') ||
+            getText(customerParty, 'PartyLegalEntity CompanyID');
+
+        const customerPostalAddress =
+            customerParty?.querySelector('PostalAddress');
+        const customerAddress = customerPostalAddress
+            ? {
+                  street: getText(customerPostalAddress, 'StreetName'),
+                  city: getText(customerPostalAddress, 'CityName'),
+                  postalCode: getText(customerPostalAddress, 'PostalZone'),
+                  country: getText(
+                      customerPostalAddress,
+                      'Country IdentificationCode',
+                  ),
+              }
+            : undefined;
+
+        // Extract financial data
+        const legalMonetaryTotal =
+            invoiceElement.querySelector('LegalMonetaryTotal') ||
+            findElementByLocalName(invoiceElement, 'LegalMonetaryTotal');
+
+        const totalAmount =
+            getNumber(legalMonetaryTotal, 'PayableAmount') ||
+            getNumber(legalMonetaryTotal, 'TaxInclusiveAmount');
+
+        const netAmount =
+            getNumber(legalMonetaryTotal, 'TaxExclusiveAmount') ||
+            getNumber(legalMonetaryTotal, 'LineExtensionAmount');
+
+        // Extract tax
+        const taxTotal =
+            invoiceElement.querySelector('TaxTotal') ||
+            findElementByLocalName(invoiceElement, 'TaxTotal');
+        const taxAmount = getNumber(taxTotal, 'TaxAmount');
+
+        // Extract currency
+        const currencyElement = invoiceElement.querySelector(
+            '[currencyID], DocumentCurrencyCode',
+        );
+        const currency =
+            currencyElement?.getAttribute('currencyID') ||
+            currencyElement?.textContent?.trim() ||
+            getText(invoiceElement, 'DocumentCurrencyCode') ||
+            'EUR';
+
+        // Extract line items
+        const lineItems: ParsedInvoiceLineItem[] = [];
+        const invoiceLines = invoiceElement.querySelectorAll('InvoiceLine');
+
+        invoiceLines.forEach((line, index) => {
+            const lineId = getText(line, 'ID') || String(index + 1);
+            const description =
+                getText(line, 'Item Name') ||
+                getText(line, 'Item Description') ||
+                'Item';
+            const quantity = getNumber(line, 'InvoicedQuantity');
+            const lineAmount = getNumber(line, 'LineExtensionAmount');
+            const unitPrice = getNumber(line, 'Price PriceAmount');
+            const taxPercent = getNumber(
+                line,
+                'Item ClassifiedTaxCategory Percent',
+            );
+
+            lineItems.push({
+                id: lineId,
+                description,
+                quantity: quantity || 1,
+                unitPrice: unitPrice || lineAmount,
+                lineAmount,
+                taxPercent,
+            });
+        });
+
+        // Extract payment info
+        const paymentMeans =
+            invoiceElement.querySelector('PaymentMeans') ||
+            findElementByLocalName(invoiceElement, 'PaymentMeans');
+
+        const paymentReference =
+            getText(paymentMeans, 'PaymentID') ||
+            getText(invoiceElement, 'PaymentMeans InstructionNote');
+
+        const payeeIban = getText(
+            paymentMeans,
+            'PayeeFinancialAccount ID',
+        )?.replace(/\s/g, '');
+
+        // Extract notes
+        const notes =
+            getText(invoiceElement, 'Note') ||
+            getText(invoiceElement, 'PaymentTerms Note');
+
+        const invoice: ParsedInvoice = {
+            invoiceNumber,
+            issueDate,
+            dueDate,
+            supplierName,
+            supplierVatId,
+            supplierAddress,
+            customerName,
+            customerVatId,
+            customerAddress,
+            currency,
+            totalAmount,
+            taxAmount,
+            netAmount,
+            lineItems,
+            paymentReference,
+            payeeIban,
+            notes,
+        };
+
+        return {
+            success: true,
+            invoice,
+            rawXml: xmlContent,
+        };
+    } catch (error) {
+        return {
+            success: false,
+            error:
+                error instanceof Error
+                    ? error.message
+                    : 'Unknown parsing error',
+            rawXml: xmlContent,
+        };
+    }
+}
+
+/**
+ * Parse a ZIP file containing invoice XML files
+ * Returns parsed invoices along with any embedded PDF attachments
+ */
+export interface ZipInvoiceEntry {
+    fileName: string;
+    invoice: ParsedInvoice | null;
+    parseError?: string;
+    attachments: ZipAttachment[];
+}
+
+export interface ZipAttachment {
+    fileName: string;
+    mimeType: string;
+    data: Blob;
+}
+
+export async function parseInvoiceZip(
+    zipFile: File,
+): Promise<ZipInvoiceEntry[]> {
+    const JSZip = (await import('jszip')).default;
+    type JSZipObject = import('jszip').JSZipObject;
+
+    const zip = await JSZip.loadAsync(zipFile);
+    const entries: ZipInvoiceEntry[] = [];
+
+    // Process each file in the ZIP
+    const filePromises: Promise<void>[] = [];
+
+    zip.forEach((relativePath: string, file: JSZipObject) => {
+        if (file.dir) return;
+
+        const lowerPath = relativePath.toLowerCase();
+
+        if (lowerPath.endsWith('.xml')) {
+            // Parse XML invoice files
+            const promise = file.async('string').then((content: string) => {
+                const parseResult = parseInvoiceXml(content);
+
+                // Check for embedded attachments in the XML
+                const attachments: ZipAttachment[] = [];
+
+                if (parseResult.success && parseResult.invoice) {
+                    // Try to extract embedded base64 PDF from XML
+                    const embeddedAttachments =
+                        extractEmbeddedAttachments(content);
+                    attachments.push(...embeddedAttachments);
+                }
+
+                entries.push({
+                    fileName: relativePath,
+                    invoice: parseResult.invoice || null,
+                    parseError: parseResult.error,
+                    attachments,
+                });
+            });
+            filePromises.push(promise);
+        } else if (
+            lowerPath.endsWith('.pdf') ||
+            lowerPath.endsWith('.png') ||
+            lowerPath.endsWith('.jpg') ||
+            lowerPath.endsWith('.jpeg')
+        ) {
+            // Handle standalone document files in ZIP
+            const promise = file.async('blob').then((blob: Blob) => {
+                const mimeType = getMimeType(relativePath);
+
+                // Find the corresponding XML entry to attach to, or create orphan
+                const baseNameMatch = relativePath.match(
+                    /^(.+?)\.(pdf|png|jpg|jpeg)$/i,
+                );
+                const baseName = baseNameMatch
+                    ? baseNameMatch[1]
+                    : relativePath;
+
+                // Try to find matching XML entry
+                let found = false;
+                for (const entry of entries) {
+                    const entryBaseName = entry.fileName.replace(/\.xml$/i, '');
+                    if (
+                        entryBaseName === baseName ||
+                        entry.fileName.includes(baseName)
+                    ) {
+                        entry.attachments.push({
+                            fileName: relativePath,
+                            mimeType,
+                            data: blob,
+                        });
+                        found = true;
+                        break;
+                    }
+                }
+
+                // If no matching XML, create a placeholder entry
+                if (!found) {
+                    entries.push({
+                        fileName: relativePath,
+                        invoice: null,
+                        attachments: [
+                            {
+                                fileName: relativePath,
+                                mimeType,
+                                data: blob,
+                            },
+                        ],
+                    });
+                }
+            });
+            filePromises.push(promise);
+        }
+    });
+
+    await Promise.all(filePromises);
+
+    // Post-process: try to match orphan attachments with XML entries
+    const xmlEntries = entries.filter((e) => e.invoice !== null);
+    const orphanEntries = entries.filter(
+        (e) => e.invoice === null && e.attachments.length > 0,
+    );
+
+    // If we have exactly one XML and one orphan PDF, combine them
+    if (xmlEntries.length === 1 && orphanEntries.length === 1) {
+        xmlEntries[0].attachments.push(...orphanEntries[0].attachments);
+        entries.splice(entries.indexOf(orphanEntries[0]), 1);
+    }
+
+    return entries.filter(
+        (e) => e.invoice !== null || e.attachments.length > 0,
+    );
+}
+
+/**
+ * Extract embedded base64 attachments from UBL invoice XML
+ */
+function extractEmbeddedAttachments(xmlContent: string): ZipAttachment[] {
+    const attachments: ZipAttachment[] = [];
+
+    try {
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(xmlContent, 'text/xml');
+
+        // Find EmbeddedDocumentBinaryObject elements
+        const binaryObjects = doc.querySelectorAll(
+            'EmbeddedDocumentBinaryObject',
+        );
+
+        binaryObjects.forEach((obj, index) => {
+            const base64Content = obj.textContent?.trim();
+            if (!base64Content) return;
+
+            const mimeType =
+                obj.getAttribute('mimeCode') || 'application/octet-stream';
+            const filename =
+                obj.getAttribute('filename') ||
+                `attachment_${index + 1}.${getExtensionFromMime(mimeType)}`;
+
+            try {
+                // Decode base64 to binary
+                const binaryString = atob(base64Content);
+                const bytes = new Uint8Array(binaryString.length);
+                for (let i = 0; i < binaryString.length; i++) {
+                    bytes[i] = binaryString.charCodeAt(i);
+                }
+                const blob = new Blob([bytes], { type: mimeType });
+
+                attachments.push({
+                    fileName: filename,
+                    mimeType,
+                    data: blob,
+                });
+            } catch {
+                // Ignore invalid base64
+            }
+        });
+    } catch {
+        // Ignore parsing errors
+    }
+
+    return attachments;
+}
+
+function getMimeType(fileName: string): string {
+    const ext = fileName.split('.').pop()?.toLowerCase();
+    switch (ext) {
+        case 'pdf':
+            return 'application/pdf';
+        case 'png':
+            return 'image/png';
+        case 'jpg':
+        case 'jpeg':
+            return 'image/jpeg';
+        case 'xml':
+            return 'application/xml';
+        default:
+            return 'application/octet-stream';
+    }
+}
+
+function getExtensionFromMime(mimeType: string): string {
+    switch (mimeType.toLowerCase()) {
+        case 'application/pdf':
+            return 'pdf';
+        case 'image/png':
+            return 'png';
+        case 'image/jpeg':
+            return 'jpg';
+        default:
+            return 'bin';
+    }
+}

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "clsx": "2.1.1",
         "date-fns": "4.1.0",
         "hono": "4.11.3",
+        "jszip": "^3.10.1",
         "lucide-react": "0.562.0",
         "next": "16.1.1",
         "nuqs": "^2.4.3",
@@ -74,6 +75,7 @@
     },
     "devDependencies": {
         "@biomejs/biome": "2.3.11",
+        "@types/jszip": "^3.4.1",
         "@types/node": "22.13.10",
         "@types/react": "19.2.7",
         "@types/react-dom": "19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       hono:
         specifier: 4.11.3
         version: 4.11.3
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       lucide-react:
         specifier: 0.562.0
         version: 0.562.0(react@19.2.3)
@@ -168,6 +171,9 @@ importers:
       '@biomejs/biome':
         specifier: 2.3.11
         version: 2.3.11
+      '@types/jszip':
+        specifier: ^3.4.1
+        version: 3.4.1
       '@types/node':
         specifier: 22.13.10
         version: 22.13.10
@@ -1565,6 +1571,10 @@ packages:
   '@types/js-cookie@2.2.7':
     resolution: {integrity: sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==}
 
+  '@types/jszip@3.4.1':
+    resolution: {integrity: sha512-TezXjmf3lj+zQ651r6hPqvSScqBLvyPI9FxdXBqpEwBijNGQ2NXpaFW/7joGzveYkKQUil7iiDHLo6LV71Pc0A==}
+    deprecated: This is a stub types definition. jszip provides its own type definitions, so you do not need this installed.
+
   '@types/node@22.13.10':
     resolution: {integrity: sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==}
 
@@ -1725,6 +1735,9 @@ packages:
 
   copy-to-clipboard@3.3.3:
     resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
@@ -2127,9 +2140,15 @@ packages:
   hyphenate-style-name@1.1.0:
     resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   inline-style-prefixer@7.0.1:
     resolution: {integrity: sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==}
@@ -2165,6 +2184,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -2196,6 +2218,12 @@ packages:
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -2322,6 +2350,9 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
   papaparse@5.4.1:
     resolution: {integrity: sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw==}
@@ -2463,6 +2494,9 @@ packages:
     resolution: {integrity: sha512-xtXazslu25CdnGnUkByU1RoOjK55TqwatJkjjJLg5ZAdz2Lngko/mmaUgeET36P2GMlNwh3fdM7FWBO717pNcw==}
     engines: {node: '>=12.13'}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -2592,6 +2626,9 @@ packages:
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -2634,6 +2671,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -2652,6 +2692,9 @@ packages:
   set-harmonic-interval@1.0.1:
     resolution: {integrity: sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==}
     engines: {node: '>=6.9'}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -2747,6 +2790,9 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -4201,6 +4247,10 @@ snapshots:
 
   '@types/js-cookie@2.2.7': {}
 
+  '@types/jszip@3.4.1':
+    dependencies:
+      jszip: 3.10.1
+
   '@types/node@22.13.10':
     dependencies:
       undici-types: 6.20.0
@@ -4356,6 +4406,8 @@ snapshots:
   copy-to-clipboard@3.3.3:
     dependencies:
       toggle-selection: 1.0.6
+
+  core-util-is@1.0.3: {}
 
   cosmiconfig@7.1.0:
     dependencies:
@@ -4709,10 +4761,14 @@ snapshots:
 
   hyphenate-style-name@1.1.0: {}
 
+  immediate@3.0.6: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+
+  inherits@2.0.4: {}
 
   inline-style-prefixer@7.0.1:
     dependencies:
@@ -4740,6 +4796,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  isarray@1.0.0: {}
+
   isexe@2.0.0: {}
 
   isexe@3.1.1:
@@ -4762,6 +4820,17 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-parse-even-better-errors@2.3.1: {}
+
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lilconfig@3.1.3: {}
 
@@ -4862,6 +4931,8 @@ snapshots:
   object-inspect@1.13.4: {}
 
   package-json-from-dist@1.0.1: {}
+
+  pako@1.0.11: {}
 
   papaparse@5.4.1: {}
 
@@ -4986,6 +5057,8 @@ snapshots:
   pretty-cache-header@1.0.0:
     dependencies:
       timestring: 6.0.0
+
+  process-nextick-args@2.0.1: {}
 
   prop-types@15.8.1:
     dependencies:
@@ -5139,6 +5212,16 @@ snapshots:
     dependencies:
       pify: 2.3.0
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
@@ -5184,6 +5267,8 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.1.2: {}
+
   scheduler@0.27.0: {}
 
   screenfull@5.2.0: {}
@@ -5194,6 +5279,8 @@ snapshots:
   server-only@0.0.1: {}
 
   set-harmonic-interval@1.0.1: {}
+
+  setimmediate@1.0.5: {}
 
   sharp@0.34.5:
     dependencies:
@@ -5323,6 +5410,10 @@ snapshots:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   strip-ansi@6.0.1:
     dependencies:


### PR DESCRIPTION
Introduce a reusable InvoiceZipDropzone React component that enables
drag-and-drop or click-to-browse upload of a single ZIP file containing
invoices. The component accepts props for handling the accepted ZIP
(onZipAccepted), a processing state (isProcessing), a disabled state,
and custom className.

Key changes:
- Add client-side component with react-dropzone integration.
- Restrict accepted files to ZIP MIME types and a single file (max 1,
  50MB).
- Handle file rejections and display contextual messages for drag
  states (active/reject).
- Provide a processing UI with spinner and descriptive text while the
  ZIP is being extracted/parsed.
- Include utility for formatting file sizes and composable styling
  classes via cn helper.