### PR TITLE
feat(dashboard): add grid layout, migration UI, and colSpan config

### DIFF
--- a/app/(dashboard)/accounts/page.tsx
+++ b/app/(dashboard)/accounts/page.tsx
@@ -337,7 +337,8 @@ function AccountsDataTable() {
                                                                 <span className="inline-flex items-center px-2 py-1 text-xs font-medium bg-blue-100 text-blue-800 rounded-full">
                                                                     {
                                                                         ACCOUNT_CLASS_LABELS[
-                                                                            account.accountClass
+                                                                            account
+                                                                                .accountClass
                                                                         ]
                                                                     }
                                                                 </span>

--- a/app/api/[[...route]]/dashboardRoutes.ts
+++ b/app/api/[[...route]]/dashboardRoutes.ts
@@ -10,7 +10,13 @@ import { dashboardLayouts } from '@/db/schema';
 // Widget configuration schemas
 const baseWidgetConfigSchema = z.object({
     id: z.string(),
-    type: z.enum(['data-grid', 'data-charts', 'financial-summary', 'graph', 'chart']),
+    type: z.enum([
+        'data-grid',
+        'data-charts',
+        'financial-summary',
+        'graph',
+        'chart',
+    ]),
     title: z.string().optional(),
 });
 

--- a/components/chart-configurable.tsx
+++ b/components/chart-configurable.tsx
@@ -56,7 +56,7 @@ export const ChartConfigurable = ({
     );
 };
 
-export const ChartConfigurableLoading = ({ title }: { title: string }) => {
+export const ChartConfigurableLoading = () => {
     return (
         <Card>
             <CardHeader className="flex justify-between space-y-2 lg:flex-row lg:items-center lg:space-y-0">

--- a/components/dashboard/draggable-widget.tsx
+++ b/components/dashboard/draggable-widget.tsx
@@ -13,9 +13,10 @@ import { WidgetConfigDialog } from './widget-config-dialog';
 
 interface DraggableWidgetProps {
     widget: WidgetConfig;
+    isLegacy?: boolean;
 }
 
-export function DraggableWidget({ widget }: DraggableWidgetProps) {
+export function DraggableWidget({ widget, isLegacy }: DraggableWidgetProps) {
     const [isConfigOpen, setIsConfigOpen] = useState(false);
     const { removeWidget } = useDashboardStore();
     const definition = getWidgetDefinition(widget.type);
@@ -50,6 +51,7 @@ export function DraggableWidget({ widget }: DraggableWidgetProps) {
                 className={cn(
                     'relative group',
                     isDragging && 'opacity-50 z-50',
+                    isLegacy && 'opacity-75',
                 )}
             >
                 {/* Widget Control Bar */}
@@ -66,6 +68,11 @@ export function DraggableWidget({ widget }: DraggableWidgetProps) {
                             <span className="ml-2 text-xs">
                                 {definition.name}
                             </span>
+                            {isLegacy && (
+                                <span className="ml-2 text-xs bg-amber-200 dark:bg-amber-800 text-amber-900 dark:text-amber-200 px-2 py-0.5 rounded">
+                                    Deprecated
+                                </span>
+                            )}
                         </Button>
                     </div>
                     <div className="flex items-center gap-2">

--- a/components/dashboard/legacy-widgets-accordion.tsx
+++ b/components/dashboard/legacy-widgets-accordion.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { ChevronDown } from 'lucide-react';
+import { useState } from 'react';
+import type { WidgetConfig } from '@/lib/widgets/types';
+import { DraggableWidget } from './draggable-widget';
+
+interface LegacyWidgetsAccordionProps {
+    widgets: WidgetConfig[];
+}
+
+export function LegacyWidgetsAccordion({
+    widgets,
+}: LegacyWidgetsAccordionProps) {
+    const [isOpen, setIsOpen] = useState(false);
+
+    if (widgets.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="border-l-4 border-amber-500 rounded-lg bg-amber-50 dark:bg-amber-950/20 p-4 mb-8">
+            <button
+                type="button"
+                onClick={() => setIsOpen(!isOpen)}
+                className="flex items-center justify-between w-full hover:opacity-80 transition-opacity"
+            >
+                <div className="flex items-center gap-3">
+                    <div className="text-sm font-semibold text-amber-900 dark:text-amber-200">
+                        Legacy Widgets ({widgets.length})
+                    </div>
+                    <div className="text-xs bg-amber-200 dark:bg-amber-800 text-amber-900 dark:text-amber-200 px-2 py-1 rounded-full">
+                        Deprecated
+                    </div>
+                </div>
+                <ChevronDown
+                    className={`h-5 w-5 text-amber-700 dark:text-amber-300 transition-transform ${
+                        isOpen ? 'rotate-180' : ''
+                    }`}
+                />
+            </button>
+
+            {isOpen && (
+                <div className="mt-4 space-y-4 pt-4 border-t border-amber-200 dark:border-amber-800">
+                    <p className="text-xs text-amber-800 dark:text-amber-300 mb-3">
+                        These widgets are deprecated. Please migrate to the new
+                        modular widgets:
+                    </p>
+                    <ul className="text-xs text-amber-700 dark:text-amber-400 space-y-1 mb-4 ml-2">
+                        <li>
+                            • "Financial Summary" → Use individual "Financial
+                            Summary" widgets
+                        </li>
+                        <li>
+                            • "Analytics Charts" → Use "Graph" and "Chart"
+                            widgets
+                        </li>
+                    </ul>
+                    <div className="space-y-4">
+                        {widgets.map((widget) => (
+                            <DraggableWidget
+                                key={widget.id}
+                                widget={widget}
+                                isLegacy={true}
+                            />
+                        ))}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/components/dashboard/migration-indicator.tsx
+++ b/components/dashboard/migration-indicator.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { AlertCircle, X } from 'lucide-react';
+import { useState } from 'react';
+
+export function MigrationIndicator() {
+    const [isDismissed, setIsDismissed] = useState(false);
+
+    if (isDismissed) {
+        return null;
+    }
+
+    return (
+        <div className="bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4 mb-6 flex items-start gap-3">
+            <AlertCircle className="h-5 w-5 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" />
+            <div className="flex-1">
+                <h3 className="font-semibold text-blue-900 dark:text-blue-200 text-sm">
+                    Dashboard Upgrade Available
+                </h3>
+                <p className="text-sm text-blue-800 dark:text-blue-300 mt-1">
+                    Your dashboard contains legacy widgets. Update to the new
+                    modular widgets for better flexibility and control.
+                </p>
+            </div>
+            <button
+                type="button"
+                onClick={() => setIsDismissed(true)}
+                className="flex-shrink-0 text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition-colors"
+                aria-label="Dismiss"
+            >
+                <X className="h-4 w-4" />
+            </button>
+        </div>
+    );
+}

--- a/components/dashboard/widget-config-dialog.tsx
+++ b/components/dashboard/widget-config-dialog.tsx
@@ -77,6 +77,43 @@ export function WidgetConfigDialog({
                 </DialogHeader>
 
                 <div className="space-y-4 py-4">
+                    {/* Grid Width Option - shown for new widgets */}
+                    {(config.type === 'graph' ||
+                        config.type === 'chart' ||
+                        config.type === 'financial-summary') && (
+                        <div className="grid gap-2">
+                            <Label htmlFor="colSpan">Grid Width</Label>
+                            <Select
+                                value={String(config.colSpan ?? 1)}
+                                onValueChange={(val) =>
+                                    handleFieldChange('colSpan', Number(val))
+                                }
+                            >
+                                <SelectTrigger id="colSpan">
+                                    <SelectValue placeholder="Select width" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="1">
+                                        1 Column (Small)
+                                    </SelectItem>
+                                    <SelectItem value="2">
+                                        2 Columns (Medium)
+                                    </SelectItem>
+                                    <SelectItem value="3">
+                                        3 Columns (Large)
+                                    </SelectItem>
+                                    <SelectItem value="4">
+                                        4 Columns (Full Width)
+                                    </SelectItem>
+                                </SelectContent>
+                            </Select>
+                            <p className="text-xs text-muted-foreground">
+                                Adjust how much space this widget takes in the
+                                grid
+                            </p>
+                        </div>
+                    )}
+
                     {definition.configSchema.fields.map((field) => {
                         const value = getConfigValue(field.name);
 

--- a/components/pie-chart-configurable.tsx
+++ b/components/pie-chart-configurable.tsx
@@ -58,7 +58,7 @@ export const PieChartConfigurable = ({
     );
 };
 
-export const PieChartConfigurableLoading = ({ title }: { title: string }) => {
+export const PieChartConfigurableLoading = () => {
     return (
         <Card>
             <CardHeader className="flex justify-between space-y-2 lg:flex-row lg:items-center lg:space-y-0">

--- a/components/widgets/chart-widget.tsx
+++ b/components/widgets/chart-widget.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useGetSummary } from '@/features/summary/api/use-get-summary';
 import {
     PieChartConfigurable,
     PieChartConfigurableLoading,
 } from '@/components/pie-chart-configurable';
+import { useGetSummary } from '@/features/summary/api/use-get-summary';
 import type { ChartWidgetConfig } from '@/lib/widgets/types';
 
 interface ChartWidgetProps {
@@ -17,15 +17,7 @@ export function ChartWidget({ config }: ChartWidgetProps) {
     const chartData = config.dataSource === 'tags' ? data?.tags : [];
 
     if (isLoading) {
-        return (
-            <PieChartConfigurableLoading
-                title={
-                    config.dataSource === 'transactions'
-                        ? 'Transactions Distribution'
-                        : 'Tags Distribution'
-                }
-            />
-        );
+        return <PieChartConfigurableLoading />;
     }
 
     return (

--- a/components/widgets/financial-summary-widget.tsx
+++ b/components/widgets/financial-summary-widget.tsx
@@ -7,9 +7,9 @@ import {
     FaBalanceScaleRight,
 } from 'react-icons/fa';
 import { FaArrowTrendDown, FaArrowTrendUp } from 'react-icons/fa6';
+import { DataCard, DataCardLoading } from '@/components/data-card';
 import { useGetSummary } from '@/features/summary/api/use-get-summary';
 import { formatDateRange } from '@/lib/utils';
-import { DataCard, DataCardLoading } from '@/components/data-card';
 import type { FinancialSummaryWidgetConfig } from '@/lib/widgets/types';
 
 interface FinancialSummaryWidgetProps {

--- a/components/widgets/graph-widget.tsx
+++ b/components/widgets/graph-widget.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useGetSummary } from '@/features/summary/api/use-get-summary';
 import {
     ChartConfigurable,
     ChartConfigurableLoading,
 } from '@/components/chart-configurable';
+import { useGetSummary } from '@/features/summary/api/use-get-summary';
 import type { GraphWidgetConfig } from '@/lib/widgets/types';
 
 interface GraphWidgetProps {
@@ -17,15 +17,7 @@ export function GraphWidget({ config }: GraphWidgetProps) {
     const chartData = config.dataSource === 'transactions' ? data?.days : [];
 
     if (isLoading) {
-        return (
-            <ChartConfigurableLoading
-                title={
-                    config.dataSource === 'transactions'
-                        ? 'Transactions Over Time'
-                        : 'Tags Over Time'
-                }
-            />
-        );
+        return <ChartConfigurableLoading />;
     }
 
     return (

--- a/features/accounts/components/account-form.tsx
+++ b/features/accounts/components/account-form.tsx
@@ -253,8 +253,8 @@ export const AccountForm = ({
                                         />
                                     </FormControl>
                                     <FormDescription>
-                                        Initial balance for this account (enter as a
-                                        decimal amount, e.g., 1.00)
+                                        Initial balance for this account (enter
+                                        as a decimal amount, e.g., 1.00)
                                     </FormDescription>
                                     <FormMessage />
                                 </FormItem>

--- a/lib/widgets/registry.ts
+++ b/lib/widgets/registry.ts
@@ -1,22 +1,15 @@
-import {
-    BarChart3,
-    Grid3x3,
-    LineChart,
-    PieChart,
-    TrendingDown,
-    TrendingUp,
-} from 'lucide-react';
+import { BarChart3, Grid3x3, LineChart, PieChart } from 'lucide-react';
+import { ChartWidget } from '@/components/widgets/chart-widget';
 import { DataChartsWidget } from '@/components/widgets/data-charts-widget';
 import { DataGridWidget } from '@/components/widgets/data-grid-widget';
-import { GraphWidget } from '@/components/widgets/graph-widget';
-import { ChartWidget } from '@/components/widgets/chart-widget';
 import { FinancialSummaryWidget } from '@/components/widgets/financial-summary-widget';
+import { GraphWidget } from '@/components/widgets/graph-widget';
 import type {
+    ChartWidgetConfig,
     DataChartsWidgetConfig,
     DataGridWidgetConfig,
-    GraphWidgetConfig,
-    ChartWidgetConfig,
     FinancialSummaryWidgetConfig,
+    GraphWidgetConfig,
     WidgetConfig,
     WidgetDefinition,
     WidgetType,
@@ -75,6 +68,7 @@ const widgetRegistry: Record<WidgetType, WidgetDefinition> = {
             dataSource: 'transactions',
             chartType: 'area',
             refreshRate: 60,
+            colSpan: 2,
         } as Omit<GraphWidgetConfig, 'id'>,
         configSchema: {
             fields: [
@@ -123,6 +117,7 @@ const widgetRegistry: Record<WidgetType, WidgetDefinition> = {
             dataSource: 'tags',
             chartType: 'pie',
             refreshRate: 60,
+            colSpan: 2,
         } as Omit<ChartWidgetConfig, 'id'>,
         configSchema: {
             fields: [

--- a/lib/widgets/store.ts
+++ b/lib/widgets/store.ts
@@ -3,12 +3,12 @@
 import { create } from 'zustand';
 import { createWidgetInstance } from './registry';
 import type {
+    ChartWidgetConfig,
     DashboardLayout,
-    WidgetConfig,
-    WidgetType,
     FinancialSummaryWidgetConfig,
     GraphWidgetConfig,
-    ChartWidgetConfig,
+    WidgetConfig,
+    WidgetType,
 } from './types';
 
 interface DashboardStore extends DashboardLayout {
@@ -60,6 +60,7 @@ const defaultLayout: DashboardLayout = {
             refreshRate: 60,
             dataSource: 'transactions',
             chartType: 'area',
+            colSpan: 2,
         } as GraphWidgetConfig,
         // Chart Widget - for pie/radar/radial charts
         {
@@ -68,6 +69,7 @@ const defaultLayout: DashboardLayout = {
             refreshRate: 60,
             dataSource: 'tags',
             chartType: 'pie',
+            colSpan: 2,
         } as ChartWidgetConfig,
     ],
 };
@@ -93,7 +95,10 @@ export const useDashboardStore = create<DashboardStore>()((set) => ({
 
     addWidget: (type) =>
         set((state) => ({
-            widgets: [...state.widgets, createWidgetInstance(type)] as WidgetConfig[],
+            widgets: [
+                ...state.widgets,
+                createWidgetInstance(type),
+            ] as WidgetConfig[],
         })),
 
     removeWidget: (id) =>
@@ -140,6 +145,7 @@ export const useDashboardStore = create<DashboardStore>()((set) => ({
                     refreshRate: 60,
                     dataSource: 'transactions',
                     chartType: 'area',
+                    colSpan: 2,
                 } as GraphWidgetConfig,
                 {
                     id: generateWidgetId(),
@@ -147,6 +153,7 @@ export const useDashboardStore = create<DashboardStore>()((set) => ({
                     refreshRate: 60,
                     dataSource: 'tags',
                     chartType: 'pie',
+                    colSpan: 2,
                 } as ChartWidgetConfig,
             ],
         }),

--- a/lib/widgets/types.ts
+++ b/lib/widgets/types.ts
@@ -17,6 +17,9 @@ export interface BaseWidgetConfig {
     id: string;
     type: WidgetType;
     title?: string;
+    // Grid layout options (1-4 columns on desktop)
+    colSpan?: number; // 1-4, defaults to 1
+    isCollapsed?: boolean; // For accordion/collapse
 }
 
 /**


### PR DESCRIPTION
Separate legacy widgets from new widgets and render new widgets in a
responsive grid with per-widget colSpan handling. Add a MigrationIndicator
component display when legacy widgets exist, and move legacy widgets into
a collapsible LegacyWidgetsAccordion, keeping their sorting context
separate. Update DndContext/SortableContext usage to operate on the
appropriate widget subsets.

Introduce colSpan and isCollapsed fields to WidgetConfig to support grid
width and accordion state. Expose a Grid Width option in the widget
config dialog for applicable new widget types so users can set 1-4
column spans. Add getColSpan utility and responsive class mapping to
derive layout classes for each widget.

These changes enable a more flexible dashboard layout, improve handling
of legacy widgets during migration, and provide user control over widget
widths.