### PR TITLE
feat(ui): add styled control bar for draggable widgets

### DIFF
--- a/components/dashboard/draggable-widget.tsx
+++ b/components/dashboard/draggable-widget.tsx
@@ -53,17 +53,17 @@ export function DraggableWidget({ widget }: DraggableWidgetProps) {
                 )}
             >
                 {/* Widget Control Bar */}
-                <div className="absolute -top-10 left-0 right-0 flex items-center justify-between opacity-0 group-hover:opacity-100 transition-opacity">
+                <div className="absolute -top-10 left-0 right-0 flex items-center justify-between opacity-0 group-hover:opacity-100 transition-opacity rounded-md bg-background/80 backdrop-blur-sm border border-border shadow-sm px-2 py-1">
                     <div className="flex items-center gap-2">
                         <Button
                             variant="ghost"
                             size="sm"
-                            className="h-8 cursor-grab active:cursor-grabbing"
+                            className="h-8 cursor-grab active:cursor-grabbing text-foreground"
                             {...attributes}
                             {...listeners}
                         >
                             <GripVertical className="h-4 w-4" />
-                            <span className="ml-2 text-xs">
+                            <span className="ml-2 text-xs text-foreground">
                                 {definition.name}
                             </span>
                         </Button>
@@ -72,7 +72,7 @@ export function DraggableWidget({ widget }: DraggableWidgetProps) {
                         <Button
                             variant="ghost"
                             size="sm"
-                            className="h-8"
+                            className="h-8 text-foreground"
                             onClick={() => setIsConfigOpen(true)}
                         >
                             <Settings className="h-4 w-4" />


### PR DESCRIPTION
Add a rounded, semi-transparent control bar with backdrop blur,
border, shadow, and padding to the widget header to improve
visibility and separation from the widget content. Ensure the
control buttons and label inherit the foreground color so icons
and text remain legible against the new background. Keep existing
drag and settings behavior while enhancing the visual styling.