### PR TITLE
feat(transactions): add uncomplete transaction mutation and hook up UI

### DIFF
--- a/app/(dashboard)/accounts/page.tsx
+++ b/app/(dashboard)/accounts/page.tsx
@@ -41,10 +41,12 @@ import {
 import { Input } from '@/components/ui/input';
 import type { accounts as accountsSchema } from '@/db/schema';
 import { useBulkCreateAccounts } from '@/features/accounts/api/use-bulk-create-accounts';
+import { useGetAccountBalances } from '@/features/accounts/api/use-get-account-balances';
 import { useGetAccounts } from '@/features/accounts/api/use-get-accounts';
 import { useNewAccount } from '@/features/accounts/hooks/use-new-accounts';
 import { useGetSettings } from '@/features/settings/api/use-get-settings';
 import { ACCOUNT_CLASS_LABELS } from '@/lib/accounting';
+import { cn, formatCurrency } from '@/lib/utils';
 import { ImportCard } from '../../../components/import/import-card';
 import { Actions } from './actions';
 
@@ -70,10 +72,12 @@ function AccountsDataTable() {
         pageSize: 9999,
         showClosed,
     });
+    const balancesQuery = useGetAccountBalances();
     const settingsQuery = useGetSettings();
     const doubleEntryMode = settingsQuery.data?.doubleEntryMode ?? false;
 
     const allAccounts = accountsQuery.data || [];
+    const balances = balancesQuery.data || {};
     const newAccount = useNewAccount();
 
     const isDisabled = accountsQuery.isLoading;
@@ -284,7 +288,7 @@ function AccountsDataTable() {
                                                             : 24), // Add indent for leaf nodes
                                                 }}
                                             >
-                                                <div className="grid grid-cols-[auto_1fr_auto] items-center px-4 py-2 gap-1">
+                                                <div className="grid grid-cols-[auto_1fr_auto_auto] items-center px-4 py-2 gap-1">
                                                     {/* Expand/Collapse Button */}
                                                     <div className="w-6 flex justify-center">
                                                         {accountHasChildren &&
@@ -383,6 +387,43 @@ function AccountsDataTable() {
                                                             {code}
                                                         </Typography>
                                                     </Stack>
+
+                                                    {/* Balance */}
+                                                    <div className="text-right min-w-[100px] px-2">
+                                                        {account.isOpen &&
+                                                            balances[
+                                                                account.id
+                                                            ] !== undefined && (
+                                                                <Typography
+                                                                    level="body1"
+                                                                    mono
+                                                                    className={cn(
+                                                                        'font-medium',
+                                                                        balances[
+                                                                            account
+                                                                                .id
+                                                                        ] < 0 &&
+                                                                            'text-red-600',
+                                                                    )}
+                                                                >
+                                                                    {formatCurrency(
+                                                                        balances[
+                                                                            account
+                                                                                .id
+                                                                        ],
+                                                                    )}
+                                                                </Typography>
+                                                            )}
+                                                        {account.isOpen &&
+                                                            balances[
+                                                                account.id
+                                                            ] === undefined &&
+                                                            balancesQuery.isLoading && (
+                                                                <span className="text-muted-foreground text-sm">
+                                                                    ...
+                                                                </span>
+                                                            )}
+                                                    </div>
 
                                                     {/* Actions */}
                                                     <Actions

--- a/app/api/[[...route]]/accountsRoutes.ts
+++ b/app/api/[[...route]]/accountsRoutes.ts
@@ -1,7 +1,7 @@
 import { clerkMiddleware, getAuth } from '@hono/clerk-auth';
 import { zValidator } from '@hono/zod-validator';
 import { createId } from '@paralleldrive/cuid2';
-import { and, desc, eq, gte, ilike, inArray, lte, or } from 'drizzle-orm';
+import { and, desc, eq, gte, ilike, inArray, lte, or, sql } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { z } from 'zod';
 
@@ -253,6 +253,171 @@ const app = new Hono()
                     entries: ledgerEntries,
                 },
             });
+        },
+    )
+    .get(
+        '/balances/open',
+        clerkMiddleware(),
+        async (ctx) => {
+            const auth = getAuth(ctx);
+
+            if (!auth?.userId) {
+                return ctx.json({ error: 'Unauthorized.' }, 401);
+            }
+
+            // Get all open accounts for this user
+            const openAccounts = await db
+                .select({
+                    id: accounts.id,
+                    code: accounts.code,
+                    isReadOnly: accounts.isReadOnly,
+                    openingBalance: accounts.openingBalance,
+                    accountClass: accounts.accountClass,
+                })
+                .from(accounts)
+                .where(
+                    and(
+                        eq(accounts.userId, auth.userId),
+                        eq(accounts.isOpen, true),
+                    ),
+                );
+
+            // Get non-read-only account IDs (these have transactions)
+            const nonReadOnlyAccountIds = openAccounts
+                .filter((a) => !a.isReadOnly)
+                .map((a) => a.id);
+
+            // If no non-read-only accounts, skip transaction query
+            const transactionTotals: Record<
+                string,
+                { debitTotal: number; creditTotal: number }
+            > = {};
+
+            if (nonReadOnlyAccountIds.length > 0) {
+                // Aggregate transaction totals per account using SQL
+                // This is much more efficient than fetching all transactions
+                const debitTotals = await db
+                    .select({
+                        accountId: transactions.debitAccountId,
+                        total: sql<number>`COALESCE(SUM(${transactions.amount}), 0)`.as(
+                            'total',
+                        ),
+                    })
+                    .from(transactions)
+                    .where(
+                        inArray(
+                            transactions.debitAccountId,
+                            nonReadOnlyAccountIds,
+                        ),
+                    )
+                    .groupBy(transactions.debitAccountId);
+
+                const creditTotals = await db
+                    .select({
+                        accountId: transactions.creditAccountId,
+                        total: sql<number>`COALESCE(SUM(${transactions.amount}), 0)`.as(
+                            'total',
+                        ),
+                    })
+                    .from(transactions)
+                    .where(
+                        inArray(
+                            transactions.creditAccountId,
+                            nonReadOnlyAccountIds,
+                        ),
+                    )
+                    .groupBy(transactions.creditAccountId);
+
+                // Build transaction totals map
+                for (const row of debitTotals) {
+                    if (row.accountId) {
+                        if (!transactionTotals[row.accountId]) {
+                            transactionTotals[row.accountId] = {
+                                debitTotal: 0,
+                                creditTotal: 0,
+                            };
+                        }
+                        transactionTotals[row.accountId].debitTotal = Number(
+                            row.total,
+                        );
+                    }
+                }
+
+                for (const row of creditTotals) {
+                    if (row.accountId) {
+                        if (!transactionTotals[row.accountId]) {
+                            transactionTotals[row.accountId] = {
+                                debitTotal: 0,
+                                creditTotal: 0,
+                            };
+                        }
+                        transactionTotals[row.accountId].creditTotal = Number(
+                            row.total,
+                        );
+                    }
+                }
+            }
+
+            // Calculate balances for non-read-only accounts
+            const balances: Record<string, number> = {};
+
+            for (const account of openAccounts) {
+                if (account.isReadOnly) continue;
+
+                const totals = transactionTotals[account.id] || {
+                    debitTotal: 0,
+                    creditTotal: 0,
+                };
+
+                // Calculate balance based on account class
+                // Default to debit normal if no class set
+                const accountClass = account.accountClass || 'asset';
+                const normalBalance =
+                    accountClass === 'asset' || accountClass === 'expense'
+                        ? 'debit'
+                        : 'credit';
+
+                if (normalBalance === 'debit') {
+                    // Debit normal: Opening + Debits - Credits
+                    balances[account.id] =
+                        account.openingBalance +
+                        totals.debitTotal -
+                        totals.creditTotal;
+                } else {
+                    // Credit normal: Opening + Credits - Debits
+                    balances[account.id] =
+                        account.openingBalance +
+                        totals.creditTotal -
+                        totals.debitTotal;
+                }
+            }
+
+            // Calculate balances for read-only accounts (sum of children)
+            // Sort by code length descending so we process children before parents
+            const readOnlyAccounts = openAccounts
+                .filter((a) => a.isReadOnly && a.code)
+                .sort((a, b) => (b.code?.length ?? 0) - (a.code?.length ?? 0));
+
+            for (const account of readOnlyAccounts) {
+                const parentCode = account.code;
+                if (!parentCode) continue;
+                let childrenSum = 0;
+
+                // Find all direct and indirect children (accounts whose code starts with this code)
+                for (const otherAccount of openAccounts) {
+                    if (
+                        otherAccount.code?.startsWith(parentCode) &&
+                        otherAccount.code !== parentCode &&
+                        balances[otherAccount.id] !== undefined
+                    ) {
+                        childrenSum += balances[otherAccount.id];
+                    }
+                }
+
+                balances[account.id] = childrenSum;
+            }
+
+            return ctx.json({ data: balances });
         },
     )
     .post(

--- a/features/accounts/api/use-get-account-balances.ts
+++ b/features/accounts/api/use-get-account-balances.ts
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/react-query';
+import { client } from '@/lib/hono';
+import { convertAmountFromMiliunits } from '@/lib/utils';
+
+export const useGetAccountBalances = () => {
+    const query = useQuery({
+        queryKey: ['account-balances'],
+        queryFn: async () => {
+            const response = await client.api.accounts.balances.open.$get();
+
+            if (!response.ok) {
+                throw new Error('Failed to fetch account balances');
+            }
+
+            const { data } = await response.json();
+
+            // Convert balances from miliunits
+            const convertedBalances: Record<string, number> = {};
+            for (const [accountId, balance] of Object.entries(data)) {
+                convertedBalances[accountId] = convertAmountFromMiliunits(
+                    balance as number,
+                );
+            }
+
+            return convertedBalances;
+        },
+        // Refresh every 30 seconds to keep balances reasonably current
+        staleTime: 30 * 1000,
+    });
+
+    return query;
+};

--- a/features/transactions/api/use-uncomplete-transaction.ts
+++ b/features/transactions/api/use-uncomplete-transaction.ts
@@ -1,0 +1,58 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { InferRequestType, InferResponseType } from 'hono';
+import { toast } from 'sonner';
+
+import { client } from '@/lib/hono';
+
+type ResponseType = InferResponseType<
+    (typeof client.api.transactions)[':id']['uncomplete']['$post']
+>;
+type RequestType = InferRequestType<
+    (typeof client.api.transactions)[':id']['uncomplete']['$post']
+>['json'];
+
+export const useUncompleteTransaction = (id?: string) => {
+    const queryClient = useQueryClient();
+
+    const mutation = useMutation<ResponseType, Error, RequestType>({
+        mutationFn: async (json) => {
+            if (!id) {
+                throw new Error('Transaction ID is required');
+            }
+            const response = await client.api.transactions[
+                ':id'
+            ].uncomplete.$post({
+                json,
+                param: { id },
+            });
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => null);
+                const errorMessage =
+                    (errorData as { error?: string })?.error ||
+                    'Failed to uncomplete transaction.';
+                console.error('[useUncompleteTransaction] Error:', {
+                    status: response.status,
+                    errorData,
+                });
+                throw new Error(errorMessage);
+            }
+            return await response.json();
+        },
+        onSuccess: () => {
+            toast.success('Transaction uncompleted.');
+            queryClient.invalidateQueries({
+                queryKey: ['transaction', { id }],
+            });
+            queryClient.invalidateQueries({ queryKey: ['transactions'] });
+            queryClient.invalidateQueries({
+                queryKey: ['transaction-status-history', { id }],
+            });
+            queryClient.invalidateQueries({ queryKey: ['summary'] });
+        },
+        onError: (error) => {
+            toast.error(error.message || 'Failed to uncomplete transaction.');
+        },
+    });
+
+    return mutation;
+};

--- a/features/transactions/components/edit-transaction-sheet.tsx
+++ b/features/transactions/components/edit-transaction-sheet.tsx
@@ -28,6 +28,7 @@ import { useGetSplitGroup } from '@/features/transactions/api/use-get-split-grou
 import { useGetStatusHistory } from '@/features/transactions/api/use-get-status-history';
 import { useGetTransaction } from '@/features/transactions/api/use-get-transaction';
 import { useUnreconcileTransaction } from '@/features/transactions/api/use-unreconcile-transaction';
+import { useUncompleteTransaction } from '@/features/transactions/api/use-uncomplete-transaction';
 import { useNewTransaction } from '@/features/transactions/hooks/use-new-transaction';
 import { useOpenTransaction } from '@/features/transactions/hooks/use-open-transaction';
 import { useConfirm } from '@/hooks/use-confirm';
@@ -65,6 +66,7 @@ export const EditTransactionSheet = () => {
     const editMutation = useEditTransaction(id);
     const deleteMutation = useDeleteTransaction(id);
     const unreconcileMutation = useUnreconcileTransaction(id);
+    const uncompleteMutation = useUncompleteTransaction(id);
 
     // Document validation queries
     const documentsQuery = useGetDocuments(id ?? '');
@@ -95,6 +97,7 @@ export const EditTransactionSheet = () => {
         editMutation.isPending ||
         deleteMutation.isPending ||
         unreconcileMutation.isPending ||
+        uncompleteMutation.isPending ||
         transactionQuery.isLoading ||
         tagMutation.isPending ||
         accountMutation.isPending ||
@@ -156,6 +159,11 @@ export const EditTransactionSheet = () => {
     const onUnreconcile = async (reason: string) => {
         if (!transactionQuery.data) return;
         await unreconcileMutation.mutateAsync({ reason });
+    };
+
+    const onUncomplete = async (reason: string) => {
+        if (!transactionQuery.data) return;
+        await uncompleteMutation.mutateAsync({ reason });
     };
 
     const defaultValuesForForm: Partial<UnifiedEditTransactionFormValues> =
@@ -353,6 +361,7 @@ export const EditTransactionSheet = () => {
                             currentStatus={currentStatus}
                             onAdvance={onAdvanceStatus}
                             onUnreconcile={onUnreconcile}
+                            onUncomplete={onUncomplete}
                             disabled={isPending}
                             autoDraftToPendingEnabled={
                                 settingsQuery.data?.autoDraftToPending ?? false


### PR DESCRIPTION
Add a new React Query mutation hook useUncompleteTransaction to call the
transactions/:id/uncomplete POST endpoint. The hook validates the id,
handles response errors with console logging, shows success/error toasts,
and invalidates related queries (transaction, transactions, status history,
summary) on success.

Wire the new hook into the edit-transaction-sheet component: import the
hook, create uncompleteMutation, include its pending state in the overall
isPending check, add an onUncomplete handler that calls mutateAsync, and
pass onUncomplete to the status controls so users can uncomplete a
transaction from the UI.

Also import account balances hook in accounts page (preparation for
balances display).