### PR TITLE
feat(accounts): add currency input and include opening balances

### DIFF
--- a/app/api/[[...route]]/accountsRoutes.ts
+++ b/app/api/[[...route]]/accountsRoutes.ts
@@ -392,7 +392,7 @@ const app = new Hono()
                 }
             }
 
-            // Calculate balances for read-only accounts (sum of children)
+            // Calculate balances for read-only accounts (sum of children + own opening balance)
             // Sort by code length descending so we process children before parents
             const readOnlyAccounts = openAccounts
                 .filter((a) => a.isReadOnly && a.code)
@@ -414,7 +414,8 @@ const app = new Hono()
                     }
                 }
 
-                balances[account.id] = childrenSum;
+                // Include the read-only account's own opening balance
+                balances[account.id] = childrenSum + account.openingBalance;
             }
 
             return ctx.json({ data: balances });

--- a/features/accounts/components/account-form.tsx
+++ b/features/accounts/components/account-form.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { AlertCircle, Trash } from 'lucide-react';
+import CurrencyInput from 'react-currency-input-field';
 import { useForm } from 'react-hook-form';
 import type { z } from 'zod';
 import { Alert, AlertDescription } from '@/components/ui/alert';
@@ -26,6 +27,10 @@ import { SheetFooter } from '@/components/ui/sheet';
 import { insertAccountSchema } from '@/db/schema';
 import { useGetSettings } from '@/features/settings/api/use-get-settings';
 import { ACCOUNT_CLASS_LABELS } from '@/lib/accounting';
+import {
+    convertAmountFromMiliunits,
+    convertAmountToMiliunits,
+} from '@/lib/utils';
 
 const formSchema = insertAccountSchema.pick({
     name: true,
@@ -235,26 +240,36 @@ export const AccountForm = ({
                                 <FormItem>
                                     <FormLabel>Opening Balance</FormLabel>
                                     <FormControl>
-                                        <Input
-                                            type="number"
+                                        <CurrencyInput
+                                            prefix="€"
+                                            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                                            placeholder="0.00"
                                             disabled={disabled}
-                                            placeholder="0"
-                                            value={field.value ?? 0}
-                                            onChange={(e) => {
-                                                const numValue = Number(
-                                                    e.target.value,
-                                                );
+                                            value={
+                                                field.value
+                                                    ? convertAmountFromMiliunits(
+                                                          field.value,
+                                                      )
+                                                    : ''
+                                            }
+                                            decimalScale={2}
+                                            decimalsLimit={2}
+                                            onValueChange={(value) => {
+                                                const numValue = value
+                                                    ? parseFloat(value)
+                                                    : 0;
                                                 field.onChange(
                                                     Number.isNaN(numValue)
                                                         ? 0
-                                                        : numValue,
+                                                        : convertAmountToMiliunits(
+                                                              numValue,
+                                                          ),
                                                 );
                                             }}
                                         />
                                     </FormControl>
                                     <FormDescription>
-                                        Initial balance for this account (enter
-                                        as a decimal amount, e.g., 1.00)
+                                        Initial balance for this account
                                     </FormDescription>
                                     <FormMessage />
                                 </FormItem>

--- a/features/accounts/components/edit-account-sheet.tsx
+++ b/features/accounts/components/edit-account-sheet.tsx
@@ -21,6 +21,8 @@ const formSchema = insertAccountSchema.pick({
     isOpen: true,
     isReadOnly: true,
     accountType: true,
+    accountClass: true,
+    openingBalance: true,
 });
 
 type FormValues = z.input<typeof formSchema>;
@@ -68,6 +70,8 @@ export const EditAccountSheet = () => {
               isOpen: accountQuery.data.isOpen,
               isReadOnly: accountQuery.data.isReadOnly,
               accountType: accountQuery.data.accountType,
+              accountClass: accountQuery.data.accountClass,
+              openingBalance: accountQuery.data.openingBalance,
           }
         : {
               name: '',
@@ -75,6 +79,8 @@ export const EditAccountSheet = () => {
               isOpen: true,
               isReadOnly: false,
               accountType: 'neutral' as const,
+              accountClass: undefined,
+              openingBalance: 0,
           };
 
     return (

--- a/features/accounts/components/new-account-sheet.tsx
+++ b/features/accounts/components/new-account-sheet.tsx
@@ -17,6 +17,8 @@ const formSchema = insertAccountSchema.pick({
     isOpen: true,
     isReadOnly: true,
     accountType: true,
+    accountClass: true,
+    openingBalance: true,
 });
 
 type FormValues = z.input<typeof formSchema>;
@@ -55,6 +57,8 @@ export const NewAccountSheet = () => {
                             isOpen: true,
                             isReadOnly: false,
                             accountType: 'neutral',
+                            accountClass: undefined,
+                            openingBalance: 0,
                         }}
                     />
                 </div>

--- a/features/transactions/components/edit-transaction-sheet.tsx
+++ b/features/transactions/components/edit-transaction-sheet.tsx
@@ -27,8 +27,8 @@ import { useEditTransaction } from '@/features/transactions/api/use-edit-transac
 import { useGetSplitGroup } from '@/features/transactions/api/use-get-split-group';
 import { useGetStatusHistory } from '@/features/transactions/api/use-get-status-history';
 import { useGetTransaction } from '@/features/transactions/api/use-get-transaction';
-import { useUnreconcileTransaction } from '@/features/transactions/api/use-unreconcile-transaction';
 import { useUncompleteTransaction } from '@/features/transactions/api/use-uncomplete-transaction';
+import { useUnreconcileTransaction } from '@/features/transactions/api/use-unreconcile-transaction';
 import { useNewTransaction } from '@/features/transactions/hooks/use-new-transaction';
 import { useOpenTransaction } from '@/features/transactions/hooks/use-open-transaction';
 import { useConfirm } from '@/hooks/use-confirm';


### PR DESCRIPTION
- Replace plain numeric input with CurrencyInput for opening balance in the
  account form and wire conversions to/from milliunits. This provides a
  localized, formatted entry with two-decimal precision and stores amounts
  consistently in milliunits via convertAmountToMiliunits / convertAmountFromMiliunits.
- Update displayed placeholder, styling, and onValueChange handling to
  ensure empty values map to zero and invalid parses are handled.
- Include accountClass in new-account-sheet default values.

- Fix balance calculation for read-only accounts: include the account's own
  openingBalance when summing child balances. Also clarify the comment to
  reflect that read-only balances are children sum plus the account's own
  opening balance.