### PR TITLE
feat(tags): use TagBadge and generate badge colors

### DIFF
--- a/app/(dashboard)/accounts/[id]/page.tsx
+++ b/app/(dashboard)/accounts/[id]/page.tsx
@@ -11,7 +11,7 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import { format, getMonth, getYear } from 'date-fns';
 import { ArrowLeft, Calendar, Loader2, Search } from 'lucide-react';
 import Link from 'next/link';
-import { use, useMemo, useState, Fragment } from 'react';
+import { Fragment, use, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useGetAccountLedger } from '@/features/accounts/api/use-get-account-ledger';

--- a/app/(dashboard)/settings/tag-columns.tsx
+++ b/app/(dashboard)/settings/tag-columns.tsx
@@ -12,6 +12,7 @@ import {
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useDeleteTag } from '@/features/tags/api/use-delete-tag';
+import { TagBadge } from '@/features/tags/components/tag-badge';
 import { useOpenTag } from '@/features/tags/hooks/use-open-tag';
 import { useConfirm } from '@/hooks/use-confirm';
 import type { client } from '@/lib/hono';
@@ -109,17 +110,12 @@ export const tagColumns: ColumnDef<ResponseType>[] = [
             );
         },
         cell: ({ row }) => {
-            const color = row.original.color;
             return (
-                <div className="flex items-center gap-2">
-                    {color && (
-                        <div
-                            className="w-3 h-3 rounded-full"
-                            style={{ backgroundColor: color }}
-                        />
-                    )}
-                    <span>{row.original.name}</span>
-                </div>
+                <TagBadge
+                    name={row.original.name}
+                    color={row.original.color}
+                    size="sm"
+                />
             );
         },
     },

--- a/app/(dashboard)/transactions/tags-column.tsx
+++ b/app/(dashboard)/transactions/tags-column.tsx
@@ -1,5 +1,5 @@
 import { useOpenTransaction } from '@/features/transactions/hooks/use-open-transaction';
-import { cn, getContrastingTextColor } from '@/lib/utils';
+import { cn, getTagBadgeColors } from '@/lib/utils';
 
 type Tag = {
     id: string;
@@ -37,26 +37,34 @@ export const TagsColumn = ({ id, tags }: TagsColumnProps) => {
             onClick={onClick}
             className="flex flex-wrap gap-1 cursor-pointer"
         >
-            {tags.slice(0, 3).map((tag) => (
-                <span
-                    key={tag.id}
-                    className={cn(
-                        'inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium',
-                        'border hover:opacity-80 transition-opacity',
-                        'max-w-[100px] overflow-hidden',
-                    )}
-                    style={{
-                        backgroundColor: tag.color ?? '#3b82f6',
-                        borderColor: tag.color ?? '#3b82f6',
-                        color: tag.color
-                            ? getContrastingTextColor(tag.color)
-                            : '#ffffff',
-                    }}
-                    title={tag.name}
-                >
-                    <span className="truncate">{tag.name}</span>
-                </span>
-            ))}
+            {tags.slice(0, 3).map((tag) => {
+                const badgeColors = tag.color
+                    ? getTagBadgeColors(tag.color)
+                    : null;
+
+                return (
+                    <span
+                        key={tag.id}
+                        className={cn(
+                            'inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium',
+                            'hover:opacity-80 transition-opacity',
+                            'max-w-[100px] overflow-hidden',
+                            !tag.color && 'bg-blue-100 text-blue-800',
+                        )}
+                        style={
+                            badgeColors
+                                ? {
+                                      backgroundColor: badgeColors.backgroundColor,
+                                      color: badgeColors.textColor,
+                                  }
+                                : {}
+                        }
+                        title={tag.name}
+                    >
+                        <span className="truncate">{tag.name}</span>
+                    </span>
+                );
+            })}
             {tags.length > 3 && (
                 <span className="text-xs text-muted-foreground">
                     +{tags.length - 3}

--- a/features/tags/components/tag-badge.tsx
+++ b/features/tags/components/tag-badge.tsx
@@ -1,4 +1,4 @@
-import { cn, getContrastingTextColor } from '@/lib/utils';
+import { cn, getTagBadgeColors } from '@/lib/utils';
 
 type TagBadgeProps = {
     name: string;
@@ -14,15 +14,16 @@ export const TagBadge = ({
     className,
 }: TagBadgeProps) => {
     const baseClasses =
-        'inline-flex items-center rounded-full font-medium max-w-[120px] overflow-hidden';
+        'inline-flex items-center rounded-full font-medium max-w-[100px] overflow-hidden';
     const sizeClasses =
         size === 'sm' ? 'px-1.5 py-0.5 text-[10px]' : 'px-2 py-0.5 text-xs';
 
-    const style = color
+    const badgeColors = color ? getTagBadgeColors(color) : null;
+
+    const style = badgeColors
         ? {
-              backgroundColor: color,
-              color: getContrastingTextColor(color),
-              borderColor: color,
+              backgroundColor: badgeColors.backgroundColor,
+              color: badgeColors.textColor,
           }
         : {};
 
@@ -31,8 +32,7 @@ export const TagBadge = ({
             className={cn(
                 baseClasses,
                 sizeClasses,
-                'border',
-                !color && 'bg-blue-100 text-blue-800 border-blue-200',
+                !color && 'bg-blue-100 text-blue-800',
                 className,
             )}
             style={style}

--- a/features/tags/components/tag-multi-select.tsx
+++ b/features/tags/components/tag-multi-select.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import type { MultiValue } from 'react-select';
 import CreatableSelect from 'react-select/creatable';
 
-import { getContrastingTextColor } from '@/lib/utils';
+import { getTagBadgeColors } from '@/lib/utils';
 
 type TagOption = {
     label: string;
@@ -56,35 +56,45 @@ export const TagMultiSelect = ({
                         borderColor: '#e2e8f0',
                     },
                 }),
-                multiValue: (base, { data }) => ({
-                    ...base,
-                    backgroundColor: data.color ?? '#3b82f6',
-                    borderColor: data.color ?? '#3b82f6',
-                    border: '1px solid',
-                    padding: '1px 4px',
-                }),
-                multiValueLabel: (base, { data }) => ({
-                    ...base,
-                    color: data.color
-                        ? getContrastingTextColor(data.color)
-                        : '#ffffff',
-                    fontWeight: 500,
-                    fontSize: '11px',
-                    padding: '0 2px',
-                }),
-                multiValueRemove: (base, { data }) => ({
-                    ...base,
-                    color: data.color
-                        ? getContrastingTextColor(data.color)
-                        : '#ffffff',
-                    ':hover': {
-                        backgroundColor: 'rgba(0, 0, 0, 0.1)',
-                        color: data.color
-                            ? getContrastingTextColor(data.color)
-                            : '#ffffff',
-                    },
-                    padding: '0 2px',
-                }),
+                multiValue: (base, { data }) => {
+                    const badgeColors = data.color
+                        ? getTagBadgeColors(data.color)
+                        : null;
+                    return {
+                        ...base,
+                        backgroundColor: badgeColors?.backgroundColor ?? '#dbeafe',
+                        border: 'none',
+                        borderRadius: '9999px',
+                        padding: '0 2px',
+                    };
+                },
+                multiValueLabel: (base, { data }) => {
+                    const badgeColors = data.color
+                        ? getTagBadgeColors(data.color)
+                        : null;
+                    return {
+                        ...base,
+                        color: badgeColors?.textColor ?? '#1e40af',
+                        fontWeight: 500,
+                        fontSize: '10px',
+                        padding: '0 2px',
+                    };
+                },
+                multiValueRemove: (base, { data }) => {
+                    const badgeColors = data.color
+                        ? getTagBadgeColors(data.color)
+                        : null;
+                    return {
+                        ...base,
+                        color: badgeColors?.textColor ?? '#1e40af',
+                        borderRadius: '0 9999px 9999px 0',
+                        ':hover': {
+                            backgroundColor: 'rgba(0, 0, 0, 0.1)',
+                            color: badgeColors?.textColor ?? '#1e40af',
+                        },
+                        padding: '0 2px',
+                    };
+                },
             }}
             value={formattedValue}
             onChange={onSelect}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -102,6 +102,110 @@ export function formatPercentage(
 }
 
 /**
+ * Convert hex color to HSL components
+ */
+function hexToHsl(hexColor: string): { h: number; s: number; l: number } {
+    const hex = hexColor.replace('#', '');
+    const r = parseInt(hex.substring(0, 2), 16) / 255;
+    const g = parseInt(hex.substring(2, 4), 16) / 255;
+    const b = parseInt(hex.substring(4, 6), 16) / 255;
+
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    let h = 0;
+    let s = 0;
+    const l = (max + min) / 2;
+
+    if (max !== min) {
+        const d = max - min;
+        s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+        switch (max) {
+            case r:
+                h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+                break;
+            case g:
+                h = ((b - r) / d + 2) / 6;
+                break;
+            case b:
+                h = ((r - g) / d + 4) / 6;
+                break;
+        }
+    }
+
+    return { h: h * 360, s: s * 100, l: l * 100 };
+}
+
+/**
+ * Convert HSL to hex color
+ */
+function hslToHex(h: number, s: number, l: number): string {
+    s /= 100;
+    l /= 100;
+
+    const c = (1 - Math.abs(2 * l - 1)) * s;
+    const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+    const m = l - c / 2;
+
+    let r = 0;
+    let g = 0;
+    let b = 0;
+
+    if (h >= 0 && h < 60) {
+        r = c;
+        g = x;
+        b = 0;
+    } else if (h >= 60 && h < 120) {
+        r = x;
+        g = c;
+        b = 0;
+    } else if (h >= 120 && h < 180) {
+        r = 0;
+        g = c;
+        b = x;
+    } else if (h >= 180 && h < 240) {
+        r = 0;
+        g = x;
+        b = c;
+    } else if (h >= 240 && h < 300) {
+        r = x;
+        g = 0;
+        b = c;
+    } else if (h >= 300 && h < 360) {
+        r = c;
+        g = 0;
+        b = x;
+    }
+
+    const toHex = (n: number) => {
+        const hex = Math.round((n + m) * 255).toString(16);
+        return hex.length === 1 ? '0' + hex : hex;
+    };
+
+    return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+/**
+ * Generate pastel badge colors based on the hue of the input color
+ * Returns colors matching the app's badge style (light bg, dark text, medium border)
+ */
+export function getTagBadgeColors(hexColor: string): {
+    backgroundColor: string;
+    textColor: string;
+    borderColor: string;
+} {
+    const { h } = hexToHsl(hexColor);
+
+    // Create pastel/light background (high lightness, low saturation)
+    const backgroundColor = hslToHex(h, 70, 92);
+    // Create dark text color (same hue, low lightness)
+    const textColor = hslToHex(h, 60, 30);
+    // Create medium border color
+    const borderColor = hslToHex(h, 50, 80);
+
+    return { backgroundColor, textColor, borderColor };
+}
+
+/**
  * Calculate contrasting text color (black or white) based on background color
  * Uses relative luminance calculation from WCAG guidelines
  */


### PR DESCRIPTION
Replace manual tag rendering with the TagBadge component in the
dashboard settings tag columns so badges are consistent across the UI.
This simplifies the cell renderer and centralizes badge presentation.

Add color utility helpers to lib/utils:
- hexToHsl and hslToHex for color conversions.
- getTagBadgeColors to compute pastel background, readable text,
  and border colors derived from an input hex hue.

Update tag multi-select to use getTagBadgeColors instead of the
older contrast helper so tag items render with the new badge color
scheme and match the TagBadge styling.

These changes improve visual consistency, make color logic reusable,
and move presentation details into shared components/utilities.