### PR TITLE
fix(accounts): correct month separator balance and key

### DIFF
--- a/app/(dashboard)/accounts/[id]/page.tsx
+++ b/app/(dashboard)/accounts/[id]/page.tsx
@@ -125,12 +125,12 @@ export default function AccountLedgerPage({ params }: Props) {
 
                 // If month or year changes, we need a separator after this entry
                 if (month !== nextMonth || year !== nextYear) {
-                    // Store the separator info - the balance at the end of this month (current entry's balance)
-                    const key = `${year}-${month}`;
+                    // Store the separator info - the balance at the end of the older month (next entry's balance)
+                    const key = `${nextYear}-${nextMonth}`;
                     separators[key] = {
-                        month,
-                        year,
-                        endBalance: entry.balance,
+                        month: nextMonth,
+                        year: nextYear,
+                        endBalance: nextEntry.balance,
                     };
                 }
             }


### PR DESCRIPTION
Adjust separator key and stored data for month/year boundaries so the
separator references the older month (the next entry's month) instead
of the current entry. Previously the separator used `${year}-${month}`
and the current entry's balance, which pointed to the newer month and
an incorrect end balance. Now the key is `${nextYear}-${nextMonth}`
and the separator stores month, year, and endBalance from the next
entry, ensuring separators represent the end-of-month balance for the
older month.