### PR TITLE
feat(widgets): add accumulation and account filtering to widgets

### DIFF
--- a/app/(dashboard)/accounts/page.tsx
+++ b/app/(dashboard)/accounts/page.tsx
@@ -482,15 +482,22 @@ export default function AccountsPage() {
         });
 
         // CSV header
-        const headers = ['Code', 'Name', 'Status', 'OpeningBalance', 'AccountClass'];
-        
+        const headers = [
+            'Code',
+            'Name',
+            'Status',
+            'OpeningBalance',
+            'AccountClass',
+        ];
+
         // Convert accounts to CSV rows
         const rows = sortedAccounts.map((account) => {
             // Force code to be treated as text in Excel by using ="value" format to preserve leading zeros
             const code = account.code ? `="${account.code}"` : '';
-            const name = account.name.includes(',') || account.name.includes('"') 
-                ? `"${account.name.replace(/"/g, '""')}"` 
-                : account.name;
+            const name =
+                account.name.includes(',') || account.name.includes('"')
+                    ? `"${account.name.replace(/"/g, '""')}"`
+                    : account.name;
             const status = account.isOpen ? 'Open' : 'Closed';
             // Convert milliunits to units (divide by 1000)
             const openingBalance = (account.openingBalance / 1000).toFixed(2);
@@ -503,11 +510,16 @@ export default function AccountsPage() {
 
         // Create and download the file with UTF-8 BOM for proper encoding
         const BOM = '\uFEFF';
-        const blob = new Blob([BOM + csvContent], { type: 'text/csv;charset=utf-8;' });
+        const blob = new Blob([BOM + csvContent], {
+            type: 'text/csv;charset=utf-8;',
+        });
         const url = URL.createObjectURL(blob);
         const link = document.createElement('a');
         link.setAttribute('href', url);
-        link.setAttribute('download', `accounts-export-${new Date().toISOString().split('T')[0]}.csv`);
+        link.setAttribute(
+            'download',
+            `accounts-export-${new Date().toISOString().split('T')[0]}.csv`,
+        );
         link.style.visibility = 'hidden';
         document.body.appendChild(link);
         link.click();
@@ -623,7 +635,10 @@ export default function AccountsPage() {
                                 />
                                 <DropdownMenuItem
                                     onClick={exportAccountsToCSV}
-                                    disabled={accountsQuery.isLoading || !accountsQuery.data?.length}
+                                    disabled={
+                                        accountsQuery.isLoading ||
+                                        !accountsQuery.data?.length
+                                    }
                                 >
                                     <Download className="mr-2 size-4" />
                                     Export CSV

--- a/app/(dashboard)/transactions/actions.tsx
+++ b/app/(dashboard)/transactions/actions.tsx
@@ -50,7 +50,11 @@ type ActionsProps = {
         debitAccountId?: string | null;
         splitGroupId?: string | null;
         splitType?: string | null;
-        tags?: Array<{ id: string; name: string; color?: string | null }> | null;
+        tags?: Array<{
+            id: string;
+            name: string;
+            color?: string | null;
+        }> | null;
     };
 };
 

--- a/app/(dashboard)/transactions/tags-column.tsx
+++ b/app/(dashboard)/transactions/tags-column.tsx
@@ -54,7 +54,8 @@ export const TagsColumn = ({ id, tags }: TagsColumnProps) => {
                         style={
                             badgeColors
                                 ? {
-                                      backgroundColor: badgeColors.backgroundColor,
+                                      backgroundColor:
+                                          badgeColors.backgroundColor,
                                       color: badgeColors.textColor,
                                   }
                                 : {}

--- a/app/api/[[...route]]/dashboardRoutes.ts
+++ b/app/api/[[...route]]/dashboardRoutes.ts
@@ -39,6 +39,7 @@ const financialSummaryWidgetConfigSchema = baseWidgetConfigSchema.extend({
     type: z.literal('financial-summary'),
     refreshRate: z.number().optional(),
     summaryType: z.enum(['balance', 'income', 'expenses']),
+    accountId: z.string().optional(),
 });
 
 const graphWidgetConfigSchema = baseWidgetConfigSchema.extend({
@@ -46,6 +47,7 @@ const graphWidgetConfigSchema = baseWidgetConfigSchema.extend({
     refreshRate: z.number().optional(),
     dataSource: z.enum(['transactions', 'tags']),
     chartType: z.enum(['area', 'bar', 'line']),
+    accumulation: z.enum(['none', 'week', 'month']).optional(),
 });
 
 const chartWidgetConfigSchema = baseWidgetConfigSchema.extend({

--- a/app/open-finances/[userId]/page.tsx
+++ b/app/open-finances/[userId]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Loader2 } from 'lucide-react';
+import Image from 'next/image';
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { Card } from '@/components/ui/card';
@@ -60,7 +61,7 @@ export default function OpenFinancesPage() {
 
     if (loading) {
         return (
-            <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100">
+            <div className="min-h-screen flex items-center justify-center">
                 <Card className="p-8">
                     <div className="flex items-center space-x-3">
                         <Loader2 className="size-6 animate-spin text-slate-600" />
@@ -75,7 +76,7 @@ export default function OpenFinancesPage() {
 
     if (error) {
         return (
-            <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 p-4">
+            <div className="min-h-screen flex items-center justify-center p-4">
                 <Card className="p-8 max-w-md w-full">
                     <div className="text-center space-y-3">
                         <div className="text-6xl">🔒</div>
@@ -98,7 +99,7 @@ export default function OpenFinancesPage() {
     );
 
     return (
-        <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 py-12 px-4 sm:px-6 lg:px-8">
+        <div className="min-h-screen py-12 px-4 sm:px-6 lg:px-8">
             <div className="max-w-4xl mx-auto space-y-8">
                 {/* Header */}
                 <div className="text-center space-y-4">
@@ -164,11 +165,19 @@ export default function OpenFinancesPage() {
                 )}
 
                 {/* Footer */}
-                <div className="text-center text-xs text-slate-400 pt-8">
-                    <p>
-                        Powered by Numera - Financial Transparency Made Simple
-                    </p>
-                </div>
+                <a
+                    href="https://www.numera.now"
+                    className="flex items-center justify-center gap-2 text-xs text-slate-400 pt-8"
+                >
+                    <span>Powered by</span>
+                    <Image
+                        alt="Numera Now"
+                        src="/NumeraNowLogomarkDark.svg"
+                        className="bg-black object-cover"
+                        width={20}
+                        height={20}
+                    />
+                </a>
             </div>
         </div>
     );

--- a/components/dashboard/widget-config-dialog.tsx
+++ b/components/dashboard/widget-config-dialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { AccountSelect } from '@/components/account-select';
 import { Button } from '@/components/ui/button';
 import {
     Dialog,
@@ -206,6 +207,20 @@ export function WidgetConfigDialog({
                                             ))}
                                         </SelectContent>
                                     </Select>
+                                )}
+
+                                {field.type === 'account' && (
+                                    <AccountSelect
+                                        value={(value as string) || ''}
+                                        onChange={(val) =>
+                                            handleFieldChange(
+                                                field.name,
+                                                val === 'all' ? '' : val,
+                                            )
+                                        }
+                                        selectAll={true}
+                                        placeholder="Select account (optional)"
+                                    />
                                 )}
 
                                 {field.description && (

--- a/components/status-progression.tsx
+++ b/components/status-progression.tsx
@@ -285,9 +285,7 @@ export function StatusProgression({
                                 isUncompleting || !uncompleteReason.trim()
                             }
                         >
-                            {isUncompleting
-                                ? 'Uncompleting...'
-                                : 'Uncomplete'}
+                            {isUncompleting ? 'Uncompleting...' : 'Uncomplete'}
                         </Button>
                     </DialogFooter>
                 </DialogContent>
@@ -422,20 +420,23 @@ export function StatusProgression({
                                     </div>
                                     <div className="flex items-center gap-2">
                                         {/* Uncomplete button for completed status */}
-                                        {currentStatus === 'completed' && onUncomplete && (
-                                            <Button
-                                                variant="outline"
-                                                size="sm"
-                                                onClick={() =>
-                                                    setShowUncompleteDialog(true)
-                                                }
-                                                disabled={disabled}
-                                                className="gap-1"
-                                            >
-                                                <Undo2 className="w-4 h-4" />
-                                                Uncomplete
-                                            </Button>
-                                        )}
+                                        {currentStatus === 'completed' &&
+                                            onUncomplete && (
+                                                <Button
+                                                    variant="outline"
+                                                    size="sm"
+                                                    onClick={() =>
+                                                        setShowUncompleteDialog(
+                                                            true,
+                                                        )
+                                                    }
+                                                    disabled={disabled}
+                                                    className="gap-1"
+                                                >
+                                                    <Undo2 className="w-4 h-4" />
+                                                    Uncomplete
+                                                </Button>
+                                            )}
                                         {nextStatus &&
                                             !isAutoDraftToPendingBlocked && (
                                                 <Button

--- a/components/widgets/graph-widget.tsx
+++ b/components/widgets/graph-widget.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import { useMemo } from 'react';
 import {
     ChartConfigurable,
     ChartConfigurableLoading,
 } from '@/components/chart-configurable';
 import { useGetSummary } from '@/features/summary/api/use-get-summary';
+import { accumulateData } from '@/lib/utils';
 import type { GraphWidgetConfig } from '@/lib/widgets/types';
 
 interface GraphWidgetProps {
@@ -16,18 +18,27 @@ export function GraphWidget({ config }: GraphWidgetProps) {
 
     const chartData = config.dataSource === 'transactions' ? data?.days : [];
 
+    // Apply accumulation if configured
+    const processedData = useMemo(() => {
+        if (!chartData || chartData.length === 0) return [];
+
+        const accumulation = config.accumulation ?? 'none';
+        return accumulateData(chartData, accumulation);
+    }, [chartData, config.accumulation]);
+
     if (isLoading) {
         return <ChartConfigurableLoading />;
     }
 
+    const title =
+        config.dataSource === 'transactions'
+            ? `Transactions Over Time${config.accumulation && config.accumulation !== 'none' ? ` (${config.accumulation === 'week' ? 'Weekly' : 'Monthly'})` : ''}`
+            : 'Tags Over Time';
+
     return (
         <ChartConfigurable
-            title={
-                config.dataSource === 'transactions'
-                    ? 'Transactions Over Time'
-                    : 'Tags Over Time'
-            }
-            data={chartData}
+            title={title}
+            data={processedData}
             chartType={config.chartType}
             isLoading={isLoading}
         />

--- a/features/summary/api/use-get-summary.ts
+++ b/features/summary/api/use-get-summary.ts
@@ -4,7 +4,7 @@ import { parseAsString, useQueryStates } from 'nuqs';
 import { client } from '@/lib/hono';
 import { convertAmountFromMiliunits } from '@/lib/utils';
 
-export const useGetSummary = () => {
+export const useGetSummary = (overrideAccountId?: string) => {
     const [{ from, to, accountId }] = useQueryStates({
         from: parseAsString,
         to: parseAsString,
@@ -12,7 +12,8 @@ export const useGetSummary = () => {
     });
     const queryFrom = from ?? '';
     const queryTo = to ?? '';
-    const queryAccountId = accountId ?? '';
+    // Use overrideAccountId if provided, otherwise use accountId from query state
+    const queryAccountId = overrideAccountId ?? accountId ?? '';
 
     const query = useQuery({
         queryKey: [

--- a/features/tags/components/tag-multi-select.tsx
+++ b/features/tags/components/tag-multi-select.tsx
@@ -62,7 +62,8 @@ export const TagMultiSelect = ({
                         : null;
                     return {
                         ...base,
-                        backgroundColor: badgeColors?.backgroundColor ?? '#dbeafe',
+                        backgroundColor:
+                            badgeColors?.backgroundColor ?? '#dbeafe',
                         border: 'none',
                         borderRadius: '9999px',
                         padding: '0 2px',

--- a/lib/widgets/registry.ts
+++ b/lib/widgets/registry.ts
@@ -47,6 +47,13 @@ const widgetRegistry: Record<WidgetType, WidgetDefinition> = {
                         'Which financial summary to display in this widget',
                 },
                 {
+                    name: 'accountId',
+                    label: 'Account',
+                    type: 'account',
+                    description:
+                        'Optional account to filter. Leave empty for total.',
+                },
+                {
                     name: 'refreshRate',
                     label: 'Refresh Rate (seconds)',
                     type: 'number',
@@ -94,6 +101,18 @@ const widgetRegistry: Record<WidgetType, WidgetDefinition> = {
                     ],
                     defaultValue: 'area',
                     description: 'The type of chart to display',
+                },
+                {
+                    name: 'accumulation',
+                    label: 'Accumulation',
+                    type: 'select',
+                    options: [
+                        { label: 'None (Daily)', value: 'none' },
+                        { label: 'Weekly', value: 'week' },
+                        { label: 'Monthly', value: 'month' },
+                    ],
+                    defaultValue: 'none',
+                    description: 'How to accumulate values over time',
                 },
                 {
                     name: 'refreshRate',

--- a/lib/widgets/types.ts
+++ b/lib/widgets/types.ts
@@ -50,6 +50,7 @@ export interface FinancialSummaryWidgetConfig extends BaseWidgetConfig {
     type: 'financial-summary';
     refreshRate?: number; // in seconds
     summaryType: 'balance' | 'income' | 'expenses'; // Which summary card to display
+    accountId?: string; // Optional account filter - if not set, shows total
 }
 
 /**
@@ -60,6 +61,7 @@ export interface GraphWidgetConfig extends BaseWidgetConfig {
     refreshRate?: number; // in seconds
     dataSource: 'transactions' | 'tags'; // transactions for daily data, tags for category data
     chartType: 'area' | 'bar' | 'line'; // Chart type is now defined in config
+    accumulation?: 'none' | 'week' | 'month'; // Accumulation period
 }
 
 /**
@@ -103,7 +105,7 @@ export interface WidgetDefinition<T extends WidgetConfig = WidgetConfig> {
 export interface WidgetConfigField {
     name: string;
     label: string;
-    type: 'text' | 'number' | 'boolean' | 'select';
+    type: 'text' | 'number' | 'boolean' | 'select' | 'account';
     options?: { label: string; value: string | number | boolean }[];
     defaultValue?: string | number | boolean;
     description?: string;


### PR DESCRIPTION
Introduce accumulation support and optional account filtering for
time-series widget data and provide a utility to aggregate daily
transactions into weekly or monthly periods.

- Add accumulateData util to lib/utils.ts:
  - Accepts daily entries {date, income, expenses} and accumulates
    them by 'none' | 'week' | 'month'.
  - Sums income and expenses per period and returns an array keyed by
    the period start date. Handles empty input and preserves daily
    output when period is 'none'.
- Extend widget registry schema in lib/widgets/registry.ts:
  - Add accountId field (type: account) to allow selecting a specific
    account or leaving empty for totals.
  - Add accumulation select field to configure accumulation mode
    (none, week, month).
- Update widget config UI in components/dashboard/widget-config-dialog.tsx:
  - Import and render AccountSelect for accountId fields and wire
    changes into the field handler.

These changes enable widgets to display accumulated summaries and to
filter by account, improving flexibility for time-based financial
visualizations.