### PR TITLE
feat: add comprehensive schema snapshot (v)

### DIFF
--- a/app/open-finances/[userId]/page.tsx
+++ b/app/open-finances/[userId]/page.tsx
@@ -9,7 +9,7 @@ import { Card } from '@/components/ui/card';
 type MetricConfig = {
     enabled: boolean;
     label: string;
-    value?: string;
+    value: string; // Now always provided by the API
 };
 
 type ExposedMetrics = {
@@ -23,8 +23,6 @@ type PublicFinanceData = {
     pageTitle: string | null;
     pageDescription: string | null;
     metrics: ExposedMetrics;
-    dateFrom: string | null;
-    dateTo: string | null;
     allowEmbedding: boolean;
 };
 
@@ -62,14 +60,14 @@ export default function OpenFinancesPage() {
     if (loading) {
         return (
             <div className="min-h-screen flex items-center justify-center">
-                <Card className="p-8">
+                <div className="p-8">
                     <div className="flex items-center space-x-3">
                         <Loader2 className="size-6 animate-spin text-slate-600" />
                         <span className="text-slate-600">
                             Loading financial data...
                         </span>
                     </div>
-                </Card>
+                </div>
             </div>
         );
     }
@@ -77,7 +75,7 @@ export default function OpenFinancesPage() {
     if (error) {
         return (
             <div className="min-h-screen flex items-center justify-center p-4">
-                <Card className="p-8 max-w-md w-full">
+                <div className="p-8 max-w-md w-full">
                     <div className="text-center space-y-3">
                         <div className="text-6xl">🔒</div>
                         <h1 className="text-2xl font-bold text-slate-800">
@@ -85,7 +83,7 @@ export default function OpenFinancesPage() {
                         </h1>
                         <p className="text-slate-600">{error}</p>
                     </div>
-                </Card>
+                </div>
             </div>
         );
     }
@@ -140,29 +138,11 @@ export default function OpenFinancesPage() {
                     </Card>
                 )}
 
-                {/* Date Range */}
-                {(data.dateFrom || data.dateTo) && (
-                    <div className="text-center text-sm text-slate-500">
-                        {data.dateFrom && data.dateTo ? (
-                            <span>
-                                Data from{' '}
-                                {new Date(data.dateFrom).toLocaleDateString()}{' '}
-                                to {new Date(data.dateTo).toLocaleDateString()}
-                            </span>
-                        ) : data.dateFrom ? (
-                            <span>
-                                Data from{' '}
-                                {new Date(data.dateFrom).toLocaleDateString()}
-                            </span>
-                        ) : (
-                            <span>
-                                Data until{' '}
-                                {data.dateTo &&
-                                    new Date(data.dateTo).toLocaleDateString()}
-                            </span>
-                        )}
-                    </div>
-                )}
+                {/* Real-time data notice */}
+                <div className="text-center text-xs text-slate-400 italic">
+                    Real-time data calculated from transactions as of{' '}
+                    {new Date().toLocaleString()}.
+                </div>
 
                 {/* Footer */}
                 <a

--- a/components/open-finances-settings-card.tsx
+++ b/components/open-finances-settings-card.tsx
@@ -21,7 +21,6 @@ import { useUpdateOpenFinancesSettings } from '@/features/open-finances/api/use-
 type MetricConfig = {
     enabled: boolean;
     label: string;
-    value?: string;
 };
 
 type ExposedMetrics = {
@@ -64,27 +63,6 @@ export function OpenFinancesSettingsCard() {
                 label:
                     exposedMetrics[metric]?.label ||
                     metric.charAt(0).toUpperCase() + metric.slice(1),
-                value: exposedMetrics[metric]?.value || '',
-            },
-        };
-        updateSettings.mutate({
-            exposedMetrics: JSON.stringify(newMetrics),
-        });
-    };
-
-    const handleUpdateMetricValue = (
-        metric: keyof ExposedMetrics,
-        value: string,
-    ) => {
-        const newMetrics = {
-            ...exposedMetrics,
-            [metric]: {
-                ...exposedMetrics[metric],
-                enabled: exposedMetrics[metric]?.enabled ?? true,
-                label:
-                    exposedMetrics[metric]?.label ||
-                    metric.charAt(0).toUpperCase() + metric.slice(1),
-                value: value,
             },
         };
         updateSettings.mutate({
@@ -169,8 +147,8 @@ export function OpenFinancesSettingsCard() {
                                         share publicly
                                     </li>
                                     <li>
-                                        Enter the values for your selected
-                                        metrics
+                                        Metrics will be automatically calculated
+                                        from your transactions
                                     </li>
                                     <li>
                                         Copy the public URL to share directly,
@@ -222,16 +200,22 @@ export function OpenFinancesSettingsCard() {
                         <div className="space-y-3">
                             <Label>Exposed Metrics</Label>
                             <p className="text-xs text-muted-foreground">
-                                Select which financial metrics to share publicly
-                                and set their values
+                                Select which financial metrics to share
+                                publicly. Values are automatically calculated
+                                from your transactions.
                             </p>
 
                             {/* Revenue */}
-                            <div className="rounded-lg border p-3 space-y-2">
+                            <div className="rounded-lg border p-3">
                                 <div className="flex items-center justify-between">
-                                    <Label htmlFor="metric-revenue">
-                                        Revenue
-                                    </Label>
+                                    <div className="flex-1">
+                                        <Label htmlFor="metric-revenue">
+                                            Revenue
+                                        </Label>
+                                        <p className="text-xs text-muted-foreground">
+                                            Total income from your transactions
+                                        </p>
+                                    </div>
                                     <Switch
                                         id="metric-revenue"
                                         checked={
@@ -244,28 +228,20 @@ export function OpenFinancesSettingsCard() {
                                         disabled={updateSettings.isPending}
                                     />
                                 </div>
-                                {exposedMetrics.revenue?.enabled && (
-                                    <Input
-                                        placeholder="e.g., $100,000"
-                                        value={
-                                            exposedMetrics.revenue?.value ?? ''
-                                        }
-                                        onChange={(e) =>
-                                            handleUpdateMetricValue(
-                                                'revenue',
-                                                e.target.value,
-                                            )
-                                        }
-                                    />
-                                )}
                             </div>
 
                             {/* Expenses */}
-                            <div className="rounded-lg border p-3 space-y-2">
+                            <div className="rounded-lg border p-3">
                                 <div className="flex items-center justify-between">
-                                    <Label htmlFor="metric-expenses">
-                                        Expenses
-                                    </Label>
+                                    <div className="flex-1">
+                                        <Label htmlFor="metric-expenses">
+                                            Expenses
+                                        </Label>
+                                        <p className="text-xs text-muted-foreground">
+                                            Total expenses from your
+                                            transactions
+                                        </p>
+                                    </div>
                                     <Switch
                                         id="metric-expenses"
                                         checked={
@@ -278,28 +254,19 @@ export function OpenFinancesSettingsCard() {
                                         disabled={updateSettings.isPending}
                                     />
                                 </div>
-                                {exposedMetrics.expenses?.enabled && (
-                                    <Input
-                                        placeholder="e.g., $60,000"
-                                        value={
-                                            exposedMetrics.expenses?.value ?? ''
-                                        }
-                                        onChange={(e) =>
-                                            handleUpdateMetricValue(
-                                                'expenses',
-                                                e.target.value,
-                                            )
-                                        }
-                                    />
-                                )}
                             </div>
 
                             {/* Profit */}
-                            <div className="rounded-lg border p-3 space-y-2">
+                            <div className="rounded-lg border p-3">
                                 <div className="flex items-center justify-between">
-                                    <Label htmlFor="metric-profit">
-                                        Profit
-                                    </Label>
+                                    <div className="flex-1">
+                                        <Label htmlFor="metric-profit">
+                                            Profit
+                                        </Label>
+                                        <p className="text-xs text-muted-foreground">
+                                            Net profit (revenue - expenses)
+                                        </p>
+                                    </div>
                                     <Switch
                                         id="metric-profit"
                                         checked={
@@ -312,28 +279,20 @@ export function OpenFinancesSettingsCard() {
                                         disabled={updateSettings.isPending}
                                     />
                                 </div>
-                                {exposedMetrics.profit?.enabled && (
-                                    <Input
-                                        placeholder="e.g., $40,000"
-                                        value={
-                                            exposedMetrics.profit?.value ?? ''
-                                        }
-                                        onChange={(e) =>
-                                            handleUpdateMetricValue(
-                                                'profit',
-                                                e.target.value,
-                                            )
-                                        }
-                                    />
-                                )}
                             </div>
 
                             {/* Balance */}
-                            <div className="rounded-lg border p-3 space-y-2">
+                            <div className="rounded-lg border p-3">
                                 <div className="flex items-center justify-between">
-                                    <Label htmlFor="metric-balance">
-                                        Balance
-                                    </Label>
+                                    <div className="flex-1">
+                                        <Label htmlFor="metric-balance">
+                                            Balance
+                                        </Label>
+                                        <p className="text-xs text-muted-foreground">
+                                            Current account balance (assets -
+                                            liabilities)
+                                        </p>
+                                    </div>
                                     <Switch
                                         id="metric-balance"
                                         checked={
@@ -346,20 +305,6 @@ export function OpenFinancesSettingsCard() {
                                         disabled={updateSettings.isPending}
                                     />
                                 </div>
-                                {exposedMetrics.balance?.enabled && (
-                                    <Input
-                                        placeholder="e.g., $150,000"
-                                        value={
-                                            exposedMetrics.balance?.value ?? ''
-                                        }
-                                        onChange={(e) =>
-                                            handleUpdateMetricValue(
-                                                'balance',
-                                                e.target.value,
-                                            )
-                                        }
-                                    />
-                                )}
                             </div>
                         </div>
 
@@ -490,8 +435,8 @@ export function OpenFinancesSettingsCard() {
                                             </li>
                                         )}
                                         <li>
-                                            Changes to metrics update
-                                            immediately—no redeployment needed
+                                            Metrics are calculated automatically
+                                            from your real transaction data
                                         </li>
                                         <li>
                                             Only enabled metrics are visible to

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -510,9 +510,6 @@ export const openFinancesSettings = pgTable(
         pageTitle: text('page_title'),
         // Optional custom description
         pageDescription: text('page_description'),
-        // Date range for displaying data
-        dateFrom: timestamp('date_from', { mode: 'date' }),
-        dateTo: timestamp('date_to', { mode: 'date' }),
         // Whether to allow embedding in iframes
         allowEmbedding: boolean('allow_embedding').notNull().default(true),
         createdAt: timestamp('created_at', { mode: 'date' })

--- a/drizzle/0034_nosy_starjammers.sql
+++ b/drizzle/0034_nosy_starjammers.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "open_finances_settings" DROP COLUMN "date_from";--> statement-breakpoint
+ALTER TABLE "open_finances_settings" DROP COLUMN "date_to";

--- a/drizzle/meta/0034_snapshot.json
+++ b/drizzle/meta/0034_snapshot.json
@@ -1,0 +1,1500 @@
+{
+    "id": "2ba1ecb3-0a3e-405e-9fc3-8bba47ff488a",
+    "prevId": "19ad7ff9-5bcc-4fe1-b93a-0916d5bcee37",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.accounts": {
+            "name": "accounts",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "plaid_id": {
+                    "name": "plaid_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "code": {
+                    "name": "code",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "is_open": {
+                    "name": "is_open",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": true
+                },
+                "is_read_only": {
+                    "name": "is_read_only",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "account_type": {
+                    "name": "account_type",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'neutral'"
+                },
+                "account_class": {
+                    "name": "account_class",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "opening_balance": {
+                    "name": "opening_balance",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": 0
+                }
+            },
+            "indexes": {
+                "accounts_userid_idx": {
+                    "name": "accounts_userid_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "accounts_isopen_idx": {
+                    "name": "accounts_isopen_idx",
+                    "columns": [
+                        {
+                            "expression": "is_open",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "accounts_code_idx": {
+                    "name": "accounts_code_idx",
+                    "columns": [
+                        {
+                            "expression": "code",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.customer_ibans": {
+            "name": "customer_ibans",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "customer_id": {
+                    "name": "customer_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "iban": {
+                    "name": "iban",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "bank_name": {
+                    "name": "bank_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "customer_ibans_customerid_idx": {
+                    "name": "customer_ibans_customerid_idx",
+                    "columns": [
+                        {
+                            "expression": "customer_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "customer_ibans_iban_idx": {
+                    "name": "customer_ibans_iban_idx",
+                    "columns": [
+                        {
+                            "expression": "iban",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "customer_ibans_customer_id_customers_id_fk": {
+                    "name": "customer_ibans_customer_id_customers_id_fk",
+                    "tableFrom": "customer_ibans",
+                    "tableTo": "customers",
+                    "columnsFrom": ["customer_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.customers": {
+            "name": "customers",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "pin": {
+                    "name": "pin",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "vat_number": {
+                    "name": "vat_number",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "address": {
+                    "name": "address",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "contact_email": {
+                    "name": "contact_email",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "contact_telephone": {
+                    "name": "contact_telephone",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "is_complete": {
+                    "name": "is_complete",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "is_own_firm": {
+                    "name": "is_own_firm",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                }
+            },
+            "indexes": {
+                "customers_userid_idx": {
+                    "name": "customers_userid_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "customers_name_idx": {
+                    "name": "customers_name_idx",
+                    "columns": [
+                        {
+                            "expression": "name",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "customers_pin_idx": {
+                    "name": "customers_pin_idx",
+                    "columns": [
+                        {
+                            "expression": "pin",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "customers_iscomplete_idx": {
+                    "name": "customers_iscomplete_idx",
+                    "columns": [
+                        {
+                            "expression": "is_complete",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "customers_isownfirm_idx": {
+                    "name": "customers_isownfirm_idx",
+                    "columns": [
+                        {
+                            "expression": "is_own_firm",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.dashboard_layouts": {
+            "name": "dashboard_layouts",
+            "schema": "",
+            "columns": {
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "widgets_config": {
+                    "name": "widgets_config",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'[]'"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "dashboard_layouts_userid_idx": {
+                    "name": "dashboard_layouts_userid_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.document_types": {
+            "name": "document_types",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description": {
+                    "name": "description",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "document_types_userid_idx": {
+                    "name": "document_types_userid_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "document_types_name_idx": {
+                    "name": "document_types_name_idx",
+                    "columns": [
+                        {
+                            "expression": "name",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.documents": {
+            "name": "documents",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "file_name": {
+                    "name": "file_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "file_size": {
+                    "name": "file_size",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "mime_type": {
+                    "name": "mime_type",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "document_type_id": {
+                    "name": "document_type_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "transaction_id": {
+                    "name": "transaction_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "storage_path": {
+                    "name": "storage_path",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "uploaded_by": {
+                    "name": "uploaded_by",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "uploaded_at": {
+                    "name": "uploaded_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "is_deleted": {
+                    "name": "is_deleted",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                }
+            },
+            "indexes": {
+                "documents_transactionid_idx": {
+                    "name": "documents_transactionid_idx",
+                    "columns": [
+                        {
+                            "expression": "transaction_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "documents_documenttypeid_idx": {
+                    "name": "documents_documenttypeid_idx",
+                    "columns": [
+                        {
+                            "expression": "document_type_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "documents_uploadedby_idx": {
+                    "name": "documents_uploadedby_idx",
+                    "columns": [
+                        {
+                            "expression": "uploaded_by",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "documents_isdeleted_idx": {
+                    "name": "documents_isdeleted_idx",
+                    "columns": [
+                        {
+                            "expression": "is_deleted",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "documents_document_type_id_document_types_id_fk": {
+                    "name": "documents_document_type_id_document_types_id_fk",
+                    "tableFrom": "documents",
+                    "tableTo": "document_types",
+                    "columnsFrom": ["document_type_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "restrict",
+                    "onUpdate": "no action"
+                },
+                "documents_transaction_id_transactions_id_fk": {
+                    "name": "documents_transaction_id_transactions_id_fk",
+                    "tableFrom": "documents",
+                    "tableTo": "transactions",
+                    "columnsFrom": ["transaction_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.open_finances_settings": {
+            "name": "open_finances_settings",
+            "schema": "",
+            "columns": {
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "is_enabled": {
+                    "name": "is_enabled",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "exposed_metrics": {
+                    "name": "exposed_metrics",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'{}'"
+                },
+                "page_title": {
+                    "name": "page_title",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "page_description": {
+                    "name": "page_description",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "allow_embedding": {
+                    "name": "allow_embedding",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "open_finances_settings_userid_idx": {
+                    "name": "open_finances_settings_userid_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.settings": {
+            "name": "settings",
+            "schema": "",
+            "columns": {
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "double_entry_mode": {
+                    "name": "double_entry_mode",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "auto_draft_to_pending": {
+                    "name": "auto_draft_to_pending",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "reconciliation_conditions": {
+                    "name": "reconciliation_conditions",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'[\"hasReceipt\"]'"
+                },
+                "min_required_documents": {
+                    "name": "min_required_documents",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": 0
+                },
+                "required_document_type_ids": {
+                    "name": "required_document_type_ids",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'[]'"
+                }
+            },
+            "indexes": {
+                "settings_userid_idx": {
+                    "name": "settings_userid_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.stripe_settings": {
+            "name": "stripe_settings",
+            "schema": "",
+            "columns": {
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "stripe_account_id": {
+                    "name": "stripe_account_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "stripe_secret_key": {
+                    "name": "stripe_secret_key",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "webhook_secret": {
+                    "name": "webhook_secret",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "default_credit_account_id": {
+                    "name": "default_credit_account_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "default_debit_account_id": {
+                    "name": "default_debit_account_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "default_tag_id": {
+                    "name": "default_tag_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "is_enabled": {
+                    "name": "is_enabled",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "sync_from_date": {
+                    "name": "sync_from_date",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "last_sync_at": {
+                    "name": "last_sync_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "stripe_settings_userid_idx": {
+                    "name": "stripe_settings_userid_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "stripe_settings_stripeaccountid_idx": {
+                    "name": "stripe_settings_stripeaccountid_idx",
+                    "columns": [
+                        {
+                            "expression": "stripe_account_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "stripe_settings_default_credit_account_id_accounts_id_fk": {
+                    "name": "stripe_settings_default_credit_account_id_accounts_id_fk",
+                    "tableFrom": "stripe_settings",
+                    "tableTo": "accounts",
+                    "columnsFrom": ["default_credit_account_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                },
+                "stripe_settings_default_debit_account_id_accounts_id_fk": {
+                    "name": "stripe_settings_default_debit_account_id_accounts_id_fk",
+                    "tableFrom": "stripe_settings",
+                    "tableTo": "accounts",
+                    "columnsFrom": ["default_debit_account_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                },
+                "stripe_settings_default_tag_id_tags_id_fk": {
+                    "name": "stripe_settings_default_tag_id_tags_id_fk",
+                    "tableFrom": "stripe_settings",
+                    "tableTo": "tags",
+                    "columnsFrom": ["default_tag_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.tags": {
+            "name": "tags",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "color": {
+                    "name": "color",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "tags_userid_idx": {
+                    "name": "tags_userid_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "tags_name_idx": {
+                    "name": "tags_name_idx",
+                    "columns": [
+                        {
+                            "expression": "name",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.transaction_status_history": {
+            "name": "transaction_status_history",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "transaction_id": {
+                    "name": "transaction_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "from_status": {
+                    "name": "from_status",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "to_status": {
+                    "name": "to_status",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "changed_at": {
+                    "name": "changed_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "changed_by": {
+                    "name": "changed_by",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "notes": {
+                    "name": "notes",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "transaction_status_history_transactionid_idx": {
+                    "name": "transaction_status_history_transactionid_idx",
+                    "columns": [
+                        {
+                            "expression": "transaction_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "transaction_status_history_changedat_idx": {
+                    "name": "transaction_status_history_changedat_idx",
+                    "columns": [
+                        {
+                            "expression": "changed_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "transaction_status_history_transaction_id_transactions_id_fk": {
+                    "name": "transaction_status_history_transaction_id_transactions_id_fk",
+                    "tableFrom": "transaction_status_history",
+                    "tableTo": "transactions",
+                    "columnsFrom": ["transaction_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.transaction_tags": {
+            "name": "transaction_tags",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "transaction_id": {
+                    "name": "transaction_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "tag_id": {
+                    "name": "tag_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "transaction_tags_transactionid_idx": {
+                    "name": "transaction_tags_transactionid_idx",
+                    "columns": [
+                        {
+                            "expression": "transaction_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "transaction_tags_tagid_idx": {
+                    "name": "transaction_tags_tagid_idx",
+                    "columns": [
+                        {
+                            "expression": "tag_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "transaction_tags_transaction_id_transactions_id_fk": {
+                    "name": "transaction_tags_transaction_id_transactions_id_fk",
+                    "tableFrom": "transaction_tags",
+                    "tableTo": "transactions",
+                    "columnsFrom": ["transaction_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "transaction_tags_tag_id_tags_id_fk": {
+                    "name": "transaction_tags_tag_id_tags_id_fk",
+                    "tableFrom": "transaction_tags",
+                    "tableTo": "tags",
+                    "columnsFrom": ["tag_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.transactions": {
+            "name": "transactions",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "amount": {
+                    "name": "amount",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "payee": {
+                    "name": "payee",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "payee_customer_id": {
+                    "name": "payee_customer_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "notes": {
+                    "name": "notes",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "date": {
+                    "name": "date",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "account_id": {
+                    "name": "account_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "credit_account_id": {
+                    "name": "credit_account_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "debit_account_id": {
+                    "name": "debit_account_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "status": {
+                    "name": "status",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'pending'"
+                },
+                "status_changed_at": {
+                    "name": "status_changed_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "status_changed_by": {
+                    "name": "status_changed_by",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "split_group_id": {
+                    "name": "split_group_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "split_type": {
+                    "name": "split_type",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "stripe_payment_id": {
+                    "name": "stripe_payment_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "stripe_payment_url": {
+                    "name": "stripe_payment_url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "transactions_accountid_idx": {
+                    "name": "transactions_accountid_idx",
+                    "columns": [
+                        {
+                            "expression": "account_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "transactions_creditaccountid_idx": {
+                    "name": "transactions_creditaccountid_idx",
+                    "columns": [
+                        {
+                            "expression": "credit_account_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "transactions_debutaccountid_idx": {
+                    "name": "transactions_debutaccountid_idx",
+                    "columns": [
+                        {
+                            "expression": "debit_account_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "transactions_payeecustomerid_idx": {
+                    "name": "transactions_payeecustomerid_idx",
+                    "columns": [
+                        {
+                            "expression": "payee_customer_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "transactions_date_idx": {
+                    "name": "transactions_date_idx",
+                    "columns": [
+                        {
+                            "expression": "date",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "transactions_status_idx": {
+                    "name": "transactions_status_idx",
+                    "columns": [
+                        {
+                            "expression": "status",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "transactions_splitgroupid_idx": {
+                    "name": "transactions_splitgroupid_idx",
+                    "columns": [
+                        {
+                            "expression": "split_group_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "transactions_splittype_idx": {
+                    "name": "transactions_splittype_idx",
+                    "columns": [
+                        {
+                            "expression": "split_type",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "transactions_stripepaymentid_idx": {
+                    "name": "transactions_stripepaymentid_idx",
+                    "columns": [
+                        {
+                            "expression": "stripe_payment_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "transactions_payee_customer_id_customers_id_fk": {
+                    "name": "transactions_payee_customer_id_customers_id_fk",
+                    "tableFrom": "transactions",
+                    "tableTo": "customers",
+                    "columnsFrom": ["payee_customer_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                },
+                "transactions_account_id_accounts_id_fk": {
+                    "name": "transactions_account_id_accounts_id_fk",
+                    "tableFrom": "transactions",
+                    "tableTo": "accounts",
+                    "columnsFrom": ["account_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                },
+                "transactions_credit_account_id_accounts_id_fk": {
+                    "name": "transactions_credit_account_id_accounts_id_fk",
+                    "tableFrom": "transactions",
+                    "tableTo": "accounts",
+                    "columnsFrom": ["credit_account_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                },
+                "transactions_debit_account_id_accounts_id_fk": {
+                    "name": "transactions_debit_account_id_accounts_id_fk",
+                    "tableFrom": "transactions",
+                    "tableTo": "accounts",
+                    "columnsFrom": ["debit_account_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        }
+    },
+    "enums": {},
+    "schemas": {},
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
             "when": 1768012348643,
             "tag": "0033_mysterious_gamma_corps",
             "breakpoints": true
+        },
+        {
+            "idx": 34,
+            "version": "7",
+            "when": 1768058534585,
+            "tag": "0034_nosy_starjammers",
+            "breakpoints": true
         }
     ]
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -178,7 +178,7 @@ function hslToHex(h: number, s: number, l: number): string {
 
     const toHex = (n: number) => {
         const hex = Math.round((n + m) * 255).toString(16);
-        return hex.length === 1 ? '0' + hex : hex;
+        return hex.length === 1 ? `0${hex}` : hex;
     };
 
     return `#${toHex(r)}${toHex(g)}${toHex(b)}`;


### PR DESCRIPTION
Add a new snapshot JSON describing the full database schema at
version 7 for the PostgreSQL dialect. The snapshot includes detailed
definitions for tables such as public.accounts and public.customer_ibans
(and other tables not shown in the diff excerpt), with column types,
nullability, defaults, primary keys, indexes, and other constraints.

This commit captures schema metadata required for migrations, drift
detection, and tooling that depends on a canonical snapshot of the
database structure. It enables consistent schema introspection and
supports future automated migration generation and verification.