### PR TITLE
feat(open-fin): convert milliunit & add metric

### DIFF
--- a/app/api/[[...route]]/openFinancesRoutes.ts
+++ b/app/api/[[...route]]/openFinancesRoutes.ts
@@ -5,7 +5,7 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import { db } from '@/db/drizzle';
 import { accounts, openFinancesSettings, transactions } from '@/db/schema';
-import { formatCurrency } from '@/lib/utils';
+import { convertAmountFromMiliunits, formatCurrency } from '@/lib/utils';
 
 const app = new Hono()
     // Get open finances settings
@@ -181,8 +181,9 @@ const app = new Hono()
             );
 
         // Calculate profit (revenue - expenses)
-        const revenue = financialData?.revenue || 0;
-        const expenses = Math.abs(financialData?.expenses || 0); // Make expenses positive for display
+        // Convert from milliunits to units
+        const revenue = convertAmountFromMiliunits(financialData?.revenue || 0);
+        const expenses = Math.abs(convertAmountFromMiliunits(financialData?.expenses || 0)); // Make expenses positive for display
         const profit = revenue - expenses;
 
         // Calculate balance (sum of all asset accounts minus liabilities)
@@ -241,9 +242,11 @@ const app = new Hono()
         const balanceData = balanceDataResult[0] as
             | { balance: number; transactionBalance: number }
             | undefined;
-        const balance =
+        // Convert from milliunits to units
+        const balance = convertAmountFromMiliunits(
             (balanceData?.balance || 0) +
-            (balanceData?.transactionBalance || 0);
+            (balanceData?.transactionBalance || 0)
+        );
 
         // Build the metrics object with calculated values
         const metricsWithValues: Record<

--- a/app/open-finances/[userId]/page.tsx
+++ b/app/open-finances/[userId]/page.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import { Loader2 } from 'lucide-react';
+import {
+    ArrowDownIcon,
+    ArrowUpIcon,
+    Loader2,
+    TrendingUpIcon,
+    WalletIcon,
+} from 'lucide-react';
 import Image from 'next/image';
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
@@ -96,6 +102,14 @@ export default function OpenFinancesPage() {
         ([_, config]) => config.enabled,
     );
 
+    // Icon mapping for each metric
+    const metricIcons: Record<string, React.ReactNode> = {
+        revenue: <ArrowUpIcon className="size-8 text-slate-400" />,
+        expenses: <ArrowDownIcon className="size-8 text-slate-400" />,
+        profit: <TrendingUpIcon className="size-8 text-slate-400" />,
+        balance: <WalletIcon className="size-8 text-slate-400" />,
+    };
+
     return (
         <div className="min-h-screen py-12 px-4 sm:px-6 lg:px-8">
             <div className="max-w-4xl mx-auto space-y-8">
@@ -119,13 +133,18 @@ export default function OpenFinancesPage() {
                                 key={key}
                                 className="p-6 bg-white hover:shadow-lg transition-shadow"
                             >
-                                <div className="space-y-2">
-                                    <h3 className="text-sm font-medium text-slate-500 uppercase tracking-wide">
-                                        {config.label}
-                                    </h3>
-                                    <p className="text-3xl font-bold text-slate-900">
-                                        {config.value || 'N/A'}
-                                    </p>
+                                <div className="flex items-start justify-between gap-4">
+                                    <div className="flex-1 space-y-2">
+                                        <h3 className="text-sm font-medium text-slate-500 uppercase tracking-wide">
+                                            {config.label}
+                                        </h3>
+                                        <p className="text-3xl font-bold text-slate-900">
+                                            {config.value || 'N/A'}
+                                        </p>
+                                    </div>
+                                    <div className="flex-shrink-0">
+                                        {metricIcons[key]}
+                                    </div>
                                 </div>
                             </Card>
                         ))}


### PR DESCRIPTION
Convert stored amounts milliunits to-facing units in theopen finances API and metric-specific icons the UI.

- Replace direct usage of raw amounts with convertAmountFromMiliunits
  when computing revenue, expenses, profit, and balance so values are
  converted from milliunits to standard units before formatting and
  presentation.
- Keep expenses positive for display by taking absolute value after
  conversion.
- Add visual icons for revenue, expenses, profit, and balance in the
  open-finances page and restructure metric cards to place the icon on
  the right with a flexible label/value area.

These changes ensure numeric metrics are accurate for users and improve
the readability and UX of the metrics panel.