### PR TITLE
feat(summary): calculate balances correctly for totals and accounts

### DIFF
--- a/app/api/[[...route]]/openFinancesRoutes.ts
+++ b/app/api/[[...route]]/openFinancesRoutes.ts
@@ -183,7 +183,9 @@ const app = new Hono()
         // Calculate profit (revenue - expenses)
         // Convert from milliunits to units
         const revenue = convertAmountFromMiliunits(financialData?.revenue || 0);
-        const expenses = Math.abs(convertAmountFromMiliunits(financialData?.expenses || 0)); // Make expenses positive for display
+        const expenses = Math.abs(
+            convertAmountFromMiliunits(financialData?.expenses || 0),
+        ); // Make expenses positive for display
         const profit = revenue - expenses;
 
         // Calculate balance (sum of all asset accounts minus liabilities)
@@ -245,7 +247,7 @@ const app = new Hono()
         // Convert from milliunits to units
         const balance = convertAmountFromMiliunits(
             (balanceData?.balance || 0) +
-            (balanceData?.transactionBalance || 0)
+                (balanceData?.transactionBalance || 0),
         );
 
         // Build the metrics object with calculated values


### PR DESCRIPTION
Adjust balance computation in summaryRoutes to produce correct
remaining balances for both global (total) and account-filtered
views. Remove unused sum import and add debit/credit aggregates to the
transactions query so we can compute balances precisely instead of
relying on a naive sum.

Introduce calculateBalance helper to:
- For total view: compute Balance = Income - |Expenses| (treat expenses
  by absolute value).
- For account-filtered view: fetch the account's class and compute
  balance from debitTotal/creditTotal using normal-balance rules
  (assets/expenses debit-normal; liabilities/equity/income credit-normal).

Also fix CASE branches to emit explicit 0 for unmatched cases and map
numeric aggregates with Number. These changes ensure financial totals
and per-account balances are accurate and robust.