### PR TITLE
refactor(ui): standardize button styles and imports

### DIFF
--- a/components/dashboard/dashboard-controls.tsx
+++ b/components/dashboard/dashboard-controls.tsx
@@ -1,7 +1,7 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
 import { RefreshCcw } from 'lucide-react';
-import { Button } from '@/components/ui/button';
 import { useDashboardStore } from '@/lib/widgets/store';
 import { WidgetStoreButton } from './widget-store-button';
 
@@ -13,12 +13,7 @@ export function DashboardControls() {
             <div className="flex items-center gap-2">
                 <WidgetStoreButton />
             </div>
-            <Button
-                variant="ghost"
-                size="sm"
-                onClick={resetToDefault}
-                className="text-muted-foreground"
-            >
+            <Button variant="plain" onClick={resetToDefault} className="text-white/70">
                 <RefreshCcw className="mr-2 h-4 w-4" />
                 Reset Layout
             </Button>

--- a/components/dashboard/widget-store-button.tsx
+++ b/components/dashboard/widget-store-button.tsx
@@ -34,7 +34,7 @@ export function WidgetStoreButton() {
     return (
         <Dialog open={open} onOpenChange={setOpen}>
             <DialogTrigger asChild>
-                <Button variant="outline" size="sm">
+                <Button variant="outline" size="sm" className='bg-white/10 text-white border-neutral-800 hover:bg-white/20'>
                     <Plus className="mr-2 h-4 w-4" />
                     Add Widget
                 </Button>


### PR DESCRIPTION
Update Dashboard controls and WidgetStoreButton to unify button
appearance and sourcing. Replace the previous UI button import with the
Button component from @signalco/ui-primitives to centralize styling.
Adjust WidgetStoreButton to apply explicit utility classes for a darker
outlined look (bg-white/10, text-white, border-neutral-800, hover
state). Change the Reset Layout control to use the new Button variant
and simplified props (variant="plain", className="text-white/70")
instead of the prior ghost/sm configuration and verbose props.

These changes harmonize button visuals across the dashboard, reduce
duplicate imports, and simplify component code for consistent theming
and easier maintenance.