### PR TITLE
refactor: use startOfYear as default date & tidy JSX

### DIFF
--- a/app/api/[[...route]]/reportsRoutes.ts
+++ b/app/api/[[...route]]/reportsRoutes.ts
@@ -1,7 +1,7 @@
 import { UTCDate } from '@date-fns/utc';
 import { clerkMiddleware, getAuth } from '@hono/clerk-auth';
 import { zValidator } from '@hono/zod-validator';
-import { endOfDay, parse, subDays } from 'date-fns';
+import { endOfDay, parse, startOfYear } from 'date-fns';
 import { and, eq, gte, inArray, lte, ne, or, sql } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { z } from 'zod';
@@ -30,7 +30,7 @@ const app = new Hono().get(
 
         const startDate = from
             ? parse(from, 'yyyy-MM-dd', new UTCDate())
-            : subDays(new UTCDate(), 30);
+            : startOfYear(new UTCDate());
         const endDate = to
             ? endOfDay(parse(to, 'yyyy-MM-dd', new UTCDate()))
             : new UTCDate();

--- a/app/api/[[...route]]/summaryRoutes.ts
+++ b/app/api/[[...route]]/summaryRoutes.ts
@@ -1,7 +1,13 @@
 import { UTCDate } from '@date-fns/utc';
 import { clerkMiddleware, getAuth } from '@hono/clerk-auth';
 import { zValidator } from '@hono/zod-validator';
-import { differenceInDays, endOfDay, parse, subDays } from 'date-fns';
+import {
+    differenceInDays,
+    endOfDay,
+    parse,
+    startOfYear,
+    subDays,
+} from 'date-fns';
 import {
     aliasedTable,
     and,
@@ -40,7 +46,7 @@ const app = new Hono().get(
 
         const startDate = from
             ? parse(from, 'yyyy-MM-dd', new UTCDate())
-            : subDays(new UTCDate(), 30);
+            : startOfYear(new UTCDate());
         const endDate = to
             ? endOfDay(parse(to, 'yyyy-MM-dd', new UTCDate()))
             : new UTCDate();

--- a/app/api/[[...route]]/transactionsRoutes.ts
+++ b/app/api/[[...route]]/transactionsRoutes.ts
@@ -2,7 +2,7 @@ import { UTCDate } from '@date-fns/utc';
 import { clerkMiddleware, getAuth } from '@hono/clerk-auth';
 import { zValidator } from '@hono/zod-validator';
 import { createId } from '@paralleldrive/cuid2';
-import { endOfDay, parse, subDays } from 'date-fns';
+import { endOfDay, parse, startOfYear } from 'date-fns';
 import {
     aliasedTable,
     and,
@@ -220,7 +220,7 @@ const app = new Hono()
 
             const startDate = from
                 ? parse(from, 'yyyy-MM-dd', new UTCDate())
-                : subDays(new UTCDate(), 30);
+                : startOfYear(new UTCDate());
             const endDate = to
                 ? endOfDay(parse(to, 'yyyy-MM-dd', new UTCDate()))
                 : new UTCDate();

--- a/components/dashboard/dashboard-controls.tsx
+++ b/components/dashboard/dashboard-controls.tsx
@@ -13,7 +13,11 @@ export function DashboardControls() {
             <div className="flex items-center gap-2">
                 <WidgetStoreButton />
             </div>
-            <Button variant="plain" onClick={resetToDefault} className="text-white/70">
+            <Button
+                variant="plain"
+                onClick={resetToDefault}
+                className="text-white/70"
+            >
                 <RefreshCcw className="mr-2 h-4 w-4" />
                 Reset Layout
             </Button>

--- a/components/dashboard/widget-store-button.tsx
+++ b/components/dashboard/widget-store-button.tsx
@@ -34,7 +34,11 @@ export function WidgetStoreButton() {
     return (
         <Dialog open={open} onOpenChange={setOpen}>
             <DialogTrigger asChild>
-                <Button variant="outline" size="sm" className='bg-white/10 text-white border-neutral-800 hover:bg-white/20'>
+                <Button
+                    variant="outline"
+                    size="sm"
+                    className="bg-white/10 text-white border-neutral-800 hover:bg-white/20"
+                >
                     <Plus className="mr-2 h-4 w-4" />
                     Add Widget
                 </Button>

--- a/components/date-filter.tsx
+++ b/components/date-filter.tsx
@@ -32,7 +32,7 @@ export const DateFilter = () => {
     });
 
     const defaultTo = useMemo(() => new Date(), []);
-    const defaultFrom = useMemo(() => subDays(defaultTo, 30), [defaultTo]);
+    const defaultFrom = useMemo(() => startOfYear(defaultTo), [defaultTo]);
 
     const paramState = useMemo(
         () => ({

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,5 @@
 import { type ClassValue, clsx } from 'clsx';
-import { eachDayOfInterval, format, isSameDay, subDays } from 'date-fns';
+import { eachDayOfInterval, format, isSameDay, startOfYear } from 'date-fns';
 import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {
@@ -69,7 +69,7 @@ type Period = {
 
 export function formatDateRange(period?: Period) {
     const defaultTo = new Date();
-    const defaultFrom = subDays(defaultTo, 30);
+    const defaultFrom = startOfYear(defaultTo);
 
     if (!period?.from) {
         return `${format(defaultFrom, 'LLL dd')} - ${format(


### PR DESCRIPTION
- Replace subDays(..., 30) with startOfYear(...) across reports,
  transactions, summary APIs and client utilities to default period to
  the start of the year instead of the last 30 days. This changes the
  default date range logic for reports, transactions, summaries, and
  date-formatting utilities to better reflect a year-to-date view.
- Update date imports: remove subDays where unused and import
  startOfYear where required; consolidate date-fns imports in summary
  route.
- Replace subDays usage in client components and utils (date filter,
  formatDateRange, components) to use startOfYear so UI defaults
  align with backend behavior.
- Reformat several JSX Button components to multiline props for
  improved readability and consistent styling in widget and dashboard
  controls components.