### PR TITLE
feat(date-filter): add "Last year" quick range option

### DIFF
--- a/components/date-filter.tsx
+++ b/components/date-filter.tsx
@@ -6,6 +6,7 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import {
     addDays,
+    endOfYear,
     format,
     startOfMonth,
     startOfWeek,
@@ -95,6 +96,12 @@ export const DateFilter = () => {
                 newFrom = subDays(new Date(), 365);
                 newTo = new Date();
                 break;
+            case 'Last year': {
+                const lastYear = new Date().getFullYear() - 1;
+                newFrom = startOfYear(new Date(lastYear, 0, 1));
+                newTo = endOfYear(new Date(lastYear, 0, 1));
+                break;
+            }
             default:
                 break;
         }
@@ -219,6 +226,14 @@ export const DateFilter = () => {
                                 }
                             >
                                 Last 365 days
+                            </Button>
+                            <Button
+                                variant="outlined"
+                                onClick={() =>
+                                    handleDateRangeClick('Last year')
+                                }
+                            >
+                                Last year
                             </Button>
                         </Stack>
                         <Stack>


### PR DESCRIPTION
Add endOfYear import and implement a "Last year" preset in the
date filter so users can quickly select the full previous calendar
year. Compute start and end of last year using startOfYear and
endOfYear to ensure the range covers the entire year. Also add a
corresponding outlined button in the preset list that triggers the
new range.

This improves UX by providing a common relative range without
requiring manual date selection.