### PR TITLE
Set PWA status bar color and theme metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,6 +20,8 @@ export default function RootLayout({ children }: PropsWithChildren) {
             <html lang="en">
                 <Head>
                     <meta name="apple-mobile-web-app-title" content="Numera" />
+                    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+                    <meta name="theme-color" content="#000000" />
                 </Head>
                 <body className={inter.className}>
                     <QueryProvider>

--- a/config/index.ts
+++ b/config/index.ts
@@ -3,6 +3,7 @@ import type { Metadata } from 'next';
 export const siteConfig: Metadata = {
     title: 'Numera',
     description: 'Your numbers, now.',
+    themeColor: '#000000',
     keywords: [
         'finance',
         'accounting',


### PR DESCRIPTION
### Motivation
- Fix the white bar visible under the status bar on mobile PWA so it matches the app's dark navbar.
- Ensure the installed/standalone PWA uses the app's dark theme color across platforms and browsers.

### Description
- Added `themeColor: '#000000'` to shared site metadata in `config/index.ts`.
- Added `<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />` and `<meta name="theme-color" content="#000000" />` to the `<Head>` in `app/layout.tsx`.
- Updated files: `app/layout.tsx` and `config/index.ts` to provide consistent PWA status bar theming.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963019dc65c832fb0493c215ce8c4da)