### PR TITLE
Add header badge for unattached (unlinked) documents

### DIFF
--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -15,6 +15,7 @@ import {
     SheetTrigger,
 } from '@/components/ui/sheet';
 import { useGetIncompleteCustomersCount } from '@/features/customers/api/use-get-incomplete-count';
+import { useGetUnattachedDocuments } from '@/features/documents/api/use-get-unattached-documents';
 import { NavButton } from './nav-button';
 import { Badge } from './ui/badge';
 import { Button } from './ui/button';
@@ -61,6 +62,8 @@ export const Navigation = () => {
     const searchParams = useSearchParams();
 
     const { data: incompleteCount } = useGetIncompleteCustomersCount();
+    const { data: unattachedDocuments } = useGetUnattachedDocuments();
+    const unattachedCount = unattachedDocuments?.length ?? 0;
 
     if (isMobile) {
         return (
@@ -117,6 +120,15 @@ export const Navigation = () => {
                                                         {incompleteCount}
                                                     </Badge>
                                                 )}
+                                            {route.href === '/documents' &&
+                                                unattachedCount > 0 && (
+                                                    <Badge
+                                                        variant="destructive"
+                                                        className="ml-1 h-5 min-w-5 flex items-center justify-center px-1.5"
+                                                    >
+                                                        {unattachedCount}
+                                                    </Badge>
+                                                )}
                                         </span>
                                     </Button>
                                 </Link>
@@ -134,6 +146,8 @@ export const Navigation = () => {
                         badge={
                             route.href === '/customers'
                                 ? incompleteCount
+                                : route.href === '/documents'
+                                  ? unattachedCount
                                 : undefined
                         }
                     />
@@ -154,6 +168,8 @@ export const Navigation = () => {
                     badge={
                         route.href === '/customers'
                             ? incompleteCount
+                            : route.href === '/documents'
+                              ? unattachedCount
                             : undefined
                     }
                 />


### PR DESCRIPTION
### Motivation
- Surface a header indicator when there are unattached (unlinked) documents so users see the same high-level warning as for incomplete customers. 
- Reuse existing document APIs/hooks to keep the header behavior consistent with other validation signals.

### Description
- Import and use the `useGetUnattachedDocuments` hook in `components/navigation.tsx` and compute `unattachedCount` from the hook result. 
- Render a destructive `Badge` with the `unattachedCount` next to the `Documents` nav item in both the mobile sheet and the desktop nav. 
- Pass `unattachedCount` into `NavButton` `badge` prop for mobile and desktop routes so the badge appears consistently.

### Testing
- Attempted an automated Playwright screenshot to validate the header UI, but the run failed due to browser/Playwright environment issues (no successful automated UI verification); no automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a4f458598832f8710b2e7b0287793)