### PR TITLE
feat(dashboard): add edit mode with toggle and UI controls

### DIFF
--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react';
 import { DashboardControls } from '@/components/dashboard/dashboard-controls';
 import { DashboardGrid } from '@/components/dashboard/dashboard-grid';
 import { DashboardSync } from '@/components/dashboard/dashboard-sync';
+import { EditModeButton } from '@/components/dashboard/edit-mode-button';
 
 export default function DashboardPage() {
     return (
@@ -11,6 +12,7 @@ export default function DashboardPage() {
             <Suspense>
                 <DashboardGrid />
             </Suspense>
+            <EditModeButton />
         </div>
     );
 }

--- a/components/dashboard/dashboard-controls.tsx
+++ b/components/dashboard/dashboard-controls.tsx
@@ -6,7 +6,11 @@ import { useDashboardStore } from '@/lib/widgets/store';
 import { WidgetStoreButton } from './widget-store-button';
 
 export function DashboardControls() {
-    const { resetToDefault } = useDashboardStore();
+    const { resetToDefault, isEditMode } = useDashboardStore();
+
+    if (!isEditMode) {
+        return null;
+    }
 
     return (
         <div className="mb-6 flex items-center justify-between">

--- a/components/dashboard/dashboard-grid.tsx
+++ b/components/dashboard/dashboard-grid.tsx
@@ -23,7 +23,7 @@ import { LegacyWidgetsAccordion } from './legacy-widgets-accordion';
 import { MigrationIndicator } from './migration-indicator';
 
 export function DashboardGrid() {
-    const { widgets, reorderWidgets } = useDashboardStore();
+    const { widgets, reorderWidgets, isEditMode } = useDashboardStore();
 
     // Separate legacy and new widgets
     const legacyWidgets = widgets.filter(
@@ -67,7 +67,7 @@ export function DashboardGrid() {
 
     return (
         <DndContext
-            sensors={sensors}
+            sensors={isEditMode ? sensors : []}
             collisionDetection={closestCenter}
             onDragEnd={handleDragEnd}
         >

--- a/components/dashboard/dashboard-sync.tsx
+++ b/components/dashboard/dashboard-sync.tsx
@@ -14,7 +14,7 @@ import { useDashboardStore } from '@/lib/widgets/store';
 export function DashboardSync() {
     const { data: dashboardData, isLoading } = useGetDashboardLayout();
     const { mutate: updateLayout } = useUpdateDashboardLayout();
-    const { widgets, setWidgets, isInitialized, setInitialized } =
+    const { widgets, setWidgets, isInitialized, setInitialized, isEditMode } =
         useDashboardStore();
     const isFirstLoad = useRef(true);
     const hasLoadedFromDb = useRef(false);
@@ -51,6 +51,11 @@ export function DashboardSync() {
             return;
         }
 
+        // Don't save changes when not in edit mode
+        if (!isEditMode) {
+            return;
+        }
+
         // Check if widgets have actually changed
         const currentWidgetsJson = JSON.stringify(widgets);
         if (currentWidgetsJson === previousWidgetsRef.current) {
@@ -67,7 +72,7 @@ export function DashboardSync() {
         }, 1000); // Debounce for 1 second
 
         return () => clearTimeout(timeoutId);
-    }, [widgets, isInitialized, updateLayout]);
+    }, [widgets, isInitialized, isEditMode, updateLayout]);
 
     return null;
 }

--- a/components/dashboard/draggable-widget.tsx
+++ b/components/dashboard/draggable-widget.tsx
@@ -18,7 +18,7 @@ interface DraggableWidgetProps {
 
 export function DraggableWidget({ widget, isLegacy }: DraggableWidgetProps) {
     const [isConfigOpen, setIsConfigOpen] = useState(false);
-    const { removeWidget } = useDashboardStore();
+    const { removeWidget, isEditMode } = useDashboardStore();
     const definition = getWidgetDefinition(widget.type);
 
     const {
@@ -54,8 +54,9 @@ export function DraggableWidget({ widget, isLegacy }: DraggableWidgetProps) {
                     isLegacy && 'opacity-75',
                 )}
             >
-                {/* Widget Control Bar */}
-                <div className="absolute -top-10 left-0 right-0 flex items-center justify-between opacity-0 group-hover:opacity-100 transition-opacity rounded-md bg-background/80 backdrop-blur-sm border border-border shadow-sm px-2 py-1">
+                {/* Widget Control Bar - only shown in edit mode */}
+                {isEditMode && (
+                    <div className="absolute -top-10 left-0 right-0 flex items-center justify-between opacity-0 group-hover:opacity-100 transition-opacity rounded-md bg-background/80 backdrop-blur-sm border border-border shadow-sm px-2 py-1">
                     <div className="flex items-center gap-2">
                         <Button
                             variant="ghost"
@@ -93,10 +94,11 @@ export function DraggableWidget({ widget, isLegacy }: DraggableWidgetProps) {
                             <Trash2 className="h-4 w-4" />
                         </Button>
                     </div>
-                </div>
+                    </div>
+                )}
 
                 {/* Widget Content */}
-                <div className="pt-2">
+                <div className={isEditMode ? "pt-2" : ""}>
                     <WidgetComponent config={widget} />
                 </div>
             </div>

--- a/components/dashboard/edit-mode-button.tsx
+++ b/components/dashboard/edit-mode-button.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { IconButton } from '@signalco/ui-primitives/IconButton';
+import { Check, Pencil } from 'lucide-react';
+import { useDashboardStore } from '@/lib/widgets/store';
+
+export function EditModeButton() {
+    const { isEditMode, toggleEditMode } = useDashboardStore();
+
+    return (
+        <IconButton
+            onClick={toggleEditMode}
+            size='lg'
+            className="fixed bottom-6 right-6 z-50 rounded-full shadow-lg"
+            aria-label={isEditMode ? 'Exit edit mode' : 'Enter edit mode'}
+            title={isEditMode ? 'Exit edit mode' : 'Edit dashboard'}
+        >
+            {isEditMode ? (
+                <Check className="size-6 shrink-0" />
+            ) : (
+                <Pencil className="size-6 shrink-0" />
+            )}
+        </IconButton>
+    );
+}

--- a/lib/widgets/store.ts
+++ b/lib/widgets/store.ts
@@ -20,6 +20,8 @@ interface DashboardStore extends DashboardLayout {
     setWidgets: (widgets: WidgetConfig[]) => void;
     isInitialized: boolean;
     setInitialized: (initialized: boolean) => void;
+    isEditMode: boolean;
+    toggleEditMode: () => void;
 }
 
 /**
@@ -82,11 +84,17 @@ const defaultLayout: DashboardLayout = {
 export const useDashboardStore = create<DashboardStore>()((set) => ({
     widgets: defaultLayout.widgets,
     isInitialized: false,
+    isEditMode: false,
 
     setWidgets: (widgets) =>
         set({
             widgets,
         }),
+
+    toggleEditMode: () =>
+        set((state) => ({
+            isEditMode: !state.isEditMode,
+        })),
 
     setInitialized: (initialized) =>
         set({


### PR DESCRIPTION
Introduce an edit mode for the dashboard allow safe, discoverable
editing of widgets.

- add isEditMode state and toggleEditMode to the dashboard store so the
  app can track and change whether the dashboard is editable.
- add EditModeButton component that in the UI and toggles edit  mode; the button shows a pencil when off and a check when on.
- show widget control bar (move/remove/config buttons) only when in
  edit mode to prevent accidental interactions during normal use.
- disable drag sensors when not in edit mode so widgets cannot be
  reordered unless edit mode is active.
- hide dashboard-level controls (reset, widget store) unless edit mode
  is enabled.
- ensure widget content layout adjusts based on edit mode to maintain
  consistent spacing and visual behavior.

These changes improve UX by separating viewing and editing states,
reducing accidental changes and making edit actions explicit.