### PR TITLE
feat(api): add colSpan to dashboard widget config

### DIFF
--- a/app/api/[[...route]]/dashboardRoutes.ts
+++ b/app/api/[[...route]]/dashboardRoutes.ts
@@ -18,6 +18,7 @@ const baseWidgetConfigSchema = z.object({
         'chart',
     ]),
     title: z.string().optional(),
+    colSpan: z.number().min(1).max(4).optional(),
 });
 
 const dataGridWidgetConfigSchema = baseWidgetConfigSchema.extend({


### PR DESCRIPTION
Add an optional colSpan property to the base dashboard widget config
schema (number between 1 and 4). This enables widgets to declare how many
grid columns they should span when rendered, improving layout control
for the dashboard grid. Validate the value with zod to prevent invalid
span values.