### PR TITLE
feat(dashboard): show date filter and guard edit controls

### DIFF
--- a/components/dashboard/dashboard-controls.tsx
+++ b/components/dashboard/dashboard-controls.tsx
@@ -2,29 +2,31 @@
 
 import { Button } from '@signalco/ui-primitives/Button';
 import { RefreshCcw } from 'lucide-react';
+import { DateFilter } from '@/components/date-filter';
 import { useDashboardStore } from '@/lib/widgets/store';
 import { WidgetStoreButton } from './widget-store-button';
 
 export function DashboardControls() {
     const { resetToDefault, isEditMode } = useDashboardStore();
 
-    if (!isEditMode) {
-        return null;
-    }
-
     return (
         <div className="mb-6 flex items-center justify-between">
             <div className="flex items-center gap-2">
-                <WidgetStoreButton />
+                <div className='bg-white rounded-lg'>
+                    <DateFilter />
+                </div>
+                {isEditMode && <WidgetStoreButton />}
             </div>
-            <Button
-                variant="plain"
-                onClick={resetToDefault}
-                className="text-white/70"
-            >
-                <RefreshCcw className="mr-2 h-4 w-4" />
-                Reset Layout
-            </Button>
+            {isEditMode && (
+                <Button
+                    variant="plain"
+                    onClick={resetToDefault}
+                    className="text-white/70"
+                >
+                    <RefreshCcw className="mr-2 h-4 w-4" />
+                    Reset Layout
+                </Button>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
Add a DateFilter to dashboard controls and ensure edit-only UI is
consistently guarded by isEditMode. Previously the entire component
returned null outside edit mode; controls were unrendered. The change
wraps WidgetStoreButton and the Reset Layout button with conditional
isEditMode checks and embeds DateFilter inside a rounded container so
date selection is visible while editing. This makes intent explicit and
prevents rendering edit actions when not in edit mode.