### PR TITLE
feat(table): add column filter state & DataTableSearch

### DIFF
--- a/app/(dashboard)/customers/page.tsx
+++ b/app/(dashboard)/customers/page.tsx
@@ -6,10 +6,11 @@ import {
     CardHeader,
     CardTitle,
 } from '@signalco/ui-primitives/Card';
-import type { Row } from '@tanstack/react-table';
+import type { ColumnFiltersState, Row } from '@tanstack/react-table';
 import { MoreHorizontal, Plus } from 'lucide-react';
 import { useState } from 'react';
 import { DataTable } from '@/components/data-table';
+import { DataTableSearch } from '@/components/data-table-search';
 import { Button } from '@/components/ui/button';
 import {
     DropdownMenu,
@@ -27,6 +28,7 @@ import { columns, type ResponseType, selectColumn } from './columns';
 
 const CustomersPage = () => {
     const [bulkDeleteMode, setBulkDeleteMode] = useState(false);
+    const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
     const [ConfirmDialog, confirm] = useConfirm(
         'Delete customers?',
         'This action cannot be undone.',
@@ -99,13 +101,21 @@ const CustomersPage = () => {
                     </div>
                 </CardHeader>
                 <CardContent>
+                    <div className="mb-4 flex items-center">
+                        <DataTableSearch
+                            filterKey="name"
+                            columnFilters={columnFilters}
+                            onColumnFiltersChange={setColumnFilters}
+                        />
+                    </div>
                     <DataTable
-                        filterKey="name"
                         paginationKey="customers"
                         columns={tableColumns}
                         data={customers}
                         onDelete={bulkDeleteMode ? handleBulkDelete : undefined}
                         disabled={isDisabled}
+                        columnFilters={columnFilters}
+                        onColumnFiltersChange={setColumnFilters}
                     />
                 </CardContent>
             </Card>

--- a/app/(dashboard)/documents/page.tsx
+++ b/app/(dashboard)/documents/page.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import type { Row } from '@tanstack/react-table';
+import type { ColumnFiltersState, Row } from '@tanstack/react-table';
 import { Plus } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { DataTable } from '@/components/data-table';
+import { DataTableSearch } from '@/components/data-table-search';
 import { DatePicker } from '@/components/date-picker';
 import { DocumentDropzone } from '@/components/document-dropzone';
 import { Button } from '@/components/ui/button';
@@ -41,6 +42,7 @@ export default function DocumentsPage() {
     const [showUnattachedOnly, setShowUnattachedOnly] = useState(false);
     const [dateFrom, setDateFrom] = useState<Date | undefined>();
     const [dateTo, setDateTo] = useState<Date | undefined>();
+    const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
 
     const { onOpen: openTransaction } = useOpenTransaction();
 
@@ -144,6 +146,12 @@ export default function DocumentsPage() {
                     {/* Filters */}
                     <div className="mb-6 space-y-4">
                         <div className="flex flex-wrap gap-4">
+                            <DataTableSearch
+                                filterKey="fileName"
+                                placeholder="Search documents..."
+                                columnFilters={columnFilters}
+                                onColumnFiltersChange={setColumnFilters}
+                            />
                             <div className="w-[180px]">
                                 <Label className="sr-only">Document Type</Label>
                                 <Select
@@ -200,8 +208,6 @@ export default function DocumentsPage() {
 
                     {/* Documents Table with Pagination */}
                     <DataTable
-                        filterKey="fileName"
-                        filterPlaceholder="Search documents..."
                         paginationKey="documents"
                         autoResetPageIndex={false}
                         columns={tableColumns}
@@ -209,6 +215,8 @@ export default function DocumentsPage() {
                         disabled={isInitialLoading || isDeleting}
                         loading={isDeleting}
                         onRowClick={handleRowClick}
+                        columnFilters={columnFilters}
+                        onColumnFiltersChange={setColumnFilters}
                     />
                 </CardContent>
             </Card>

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -6,10 +6,12 @@ import {
     CardHeader,
     CardTitle,
 } from '@signalco/ui-primitives/Card';
+import type { ColumnFiltersState } from '@tanstack/react-table';
 import { Loader2, Plus } from 'lucide-react';
-import { Suspense } from 'react';
+import { Suspense, useState } from 'react';
 import { BankIntegrationCard } from '@/components/bank-integration-card';
 import { DataTable } from '@/components/data-table';
+import { DataTableSearch } from '@/components/data-table-search';
 import { DocumentTypesSettingsCard } from '@/components/document-types-settings-card';
 import { OpenFinancesSettingsCard } from '@/components/open-finances-settings-card';
 import { ReconciliationSettingsCard } from '@/components/reconciliation-settings-card';
@@ -116,6 +118,7 @@ function TagsSection() {
     const deleteTags = useBulkDeleteTags();
     const tagsQuery = useGetTags();
     const tags = tagsQuery.data || [];
+    const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
 
     const isDisabled = tagsQuery.isLoading || deleteTags.isPending;
 
@@ -127,10 +130,16 @@ function TagsSection() {
                     <Plus className="size-4 mr-2" />
                     Add new
                 </Button>
-            </CardHeader>
+                </CardHeader>
             <CardContent>
+                <div className="mb-4 flex items-center">
+                    <DataTableSearch
+                        filterKey="name"
+                        columnFilters={columnFilters}
+                        onColumnFiltersChange={setColumnFilters}
+                    />
+                </div>
                 <DataTable
-                    filterKey="name"
                     paginationKey="settingsTags"
                     columns={tagColumns}
                     data={tags}
@@ -139,6 +148,8 @@ function TagsSection() {
                         deleteTags.mutate({ ids });
                     }}
                     disabled={isDisabled}
+                    columnFilters={columnFilters}
+                    onColumnFiltersChange={setColumnFilters}
                 />
             </CardContent>
         </Card>

--- a/app/(dashboard)/transactions/TransactionsDataTable.tsx
+++ b/app/(dashboard)/transactions/TransactionsDataTable.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { Row } from '@tanstack/react-table';
+import type { ColumnFiltersState, Row } from '@tanstack/react-table';
 import { DataTable } from '@/components/data-table';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useBulkDeleteTransactions } from '@/features/transactions/api/use-bulk-delete-transactions';
@@ -11,10 +11,18 @@ import { hasValidationIssues } from './validation';
 
 type TransactionsDataTableProps = {
     bulkDeleteMode?: boolean;
+    columnFilters?: ColumnFiltersState;
+    onColumnFiltersChange?: (
+        updater:
+            | ColumnFiltersState
+            | ((prev: ColumnFiltersState) => ColumnFiltersState),
+    ) => void;
 };
 
 export function TransactionsDataTable({
     bulkDeleteMode = false,
+    columnFilters,
+    onColumnFiltersChange,
 }: TransactionsDataTableProps) {
     const transactionsQuery = useGetTransactions();
     const bulkDeleteMutation = useBulkDeleteTransactions();
@@ -52,8 +60,6 @@ export function TransactionsDataTable({
 
     return (
         <DataTable
-            filterKey="payeeCustomerName"
-            filterPlaceholder="Filter transactions..."
             autoPageSize
             rowHeight={48}
             paginationKey="transactions"
@@ -74,6 +80,8 @@ export function TransactionsDataTable({
             onDelete={bulkDeleteMode ? handleBulkDelete : undefined}
             onRowClick={bulkDeleteMode ? undefined : handleRowClick}
             getRowClassName={getRowClassName}
+            columnFilters={columnFilters}
+            onColumnFiltersChange={onColumnFiltersChange}
         />
     );
 }

--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -6,11 +6,13 @@ import {
     CardHeader,
     CardTitle,
 } from '@signalco/ui-primitives/Card';
+import type { ColumnFiltersState } from '@tanstack/react-table';
 import { Archive, Loader2, MoreHorizontal, Plus } from 'lucide-react';
 import { Suspense, useState } from 'react';
 import { toast } from 'sonner';
 import { AccountFilter } from '@/components/account-filter';
 import { DateFilter } from '@/components/date-filter';
+import { DataTableSearch } from '@/components/data-table-search';
 import { ImportCard } from '@/components/import/import-card';
 import { ImportButton } from '@/components/import-button';
 import { Button } from '@/components/ui/button';
@@ -311,6 +313,7 @@ export default function TransactionsPage() {
     const [importResults, setImportResults] = useState(INITIAL_IMPORT_RESULTS);
     const [variant, setVariant] = useState<VARIANTS>(VARIANTS.LIST);
     const [bulkDeleteMode, setBulkDeleteMode] = useState(false);
+    const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
 
     const newTransaction = useNewTransaction();
 
@@ -399,6 +402,13 @@ export default function TransactionsPage() {
 
                 <CardContent>
                     <div className="flex flex-col items-stretch gap-y-2 md:flex-row md:gap-x-2 md:gap-y-0">
+                        <DataTableSearch
+                            filterKey="payeeCustomerName"
+                            placeholder="Filter transactions..."
+                            columnFilters={columnFilters}
+                            onColumnFiltersChange={setColumnFilters}
+                            className="w-full md:w-[220px]"
+                        />
                         <AccountFilter />
                         <DateFilter />
                     </div>
@@ -411,6 +421,8 @@ export default function TransactionsPage() {
                     >
                         <TransactionsDataTable
                             bulkDeleteMode={bulkDeleteMode}
+                            columnFilters={columnFilters}
+                            onColumnFiltersChange={setColumnFilters}
                         />
                     </Suspense>
                 </CardContent>

--- a/components/data-table-search.tsx
+++ b/components/data-table-search.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import * as React from 'react';
+import type { ColumnFiltersState } from '@tanstack/react-table';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+
+interface DataTableSearchProps {
+    columnFilters: ColumnFiltersState;
+    onColumnFiltersChange: (
+        updater:
+            | ColumnFiltersState
+            | ((prev: ColumnFiltersState) => ColumnFiltersState),
+    ) => void;
+    filterKey: string;
+    placeholder?: string;
+    className?: string;
+}
+
+export function DataTableSearch({
+    columnFilters,
+    onColumnFiltersChange,
+    filterKey,
+    placeholder,
+    className,
+}: DataTableSearchProps) {
+    const value = React.useMemo(() => {
+        const match = columnFilters.find((filter) => filter.id === filterKey);
+        return typeof match?.value === 'string' ? match.value : '';
+    }, [columnFilters, filterKey]);
+
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const nextValue = event.target.value;
+        onColumnFiltersChange((prev) => {
+            const nextFilters = prev.filter(
+                (filter) => filter.id !== filterKey,
+            );
+
+            if (nextValue) {
+                nextFilters.push({ id: filterKey, value: nextValue });
+            }
+
+            return nextFilters;
+        });
+    };
+
+    return (
+        <Input
+            placeholder={placeholder ?? `Filter ${filterKey}...`}
+            value={value}
+            onChange={handleChange}
+            className={cn('max-w-sm', className)}
+        />
+    );
+}


### PR DESCRIPTION
- Expose ColumnFiltersState and change handlers across table components.
  - Add columnFilters and onColumnFiltersChange props to
    TransactionsDataTable and CustomersPage; thread them into DataTable.
  - Accept columnFilters/onColumnFiltersChange in DataTable and wire them to
    the table instance (prop names normalized).
- Replace the in-component string search with a reusable
  DataTableSearch in CustomersPage and lift its state into the page so the
  DataTable receives controlled filter state.
- Remove legacy single filterKey/filterPlaceholder props and the unused
  Input import from DataTable, consolidating filtering into the new
  column-filters API.
- Minor cleanup: import ColumnFiltersState types where needed and pass
  onColumnFiltersChange through to child components.

Reason:
Enable controlled, column-aware filtering and reuse a standard search
component for consistent filtering behavior across pages. This also
prepares the table for more advanced filter UIs and external control.