### PR TITLE
feat(tables): open entity on row click for customers and accounts

### DIFF
--- a/app/(dashboard)/accounts/page.tsx
+++ b/app/(dashboard)/accounts/page.tsx
@@ -47,6 +47,7 @@ import { useBulkCreateAccounts } from '@/features/accounts/api/use-bulk-create-a
 import { useGetAccountBalances } from '@/features/accounts/api/use-get-account-balances';
 import { useGetAccounts } from '@/features/accounts/api/use-get-accounts';
 import { useNewAccount } from '@/features/accounts/hooks/use-new-accounts';
+import { useOpenAccount } from '@/features/accounts/hooks/use-open-account';
 import { useGetSettings } from '@/features/settings/api/use-get-settings';
 import { ACCOUNT_CLASS_LABELS } from '@/lib/accounting';
 import { cn, formatCurrency } from '@/lib/utils';
@@ -82,6 +83,7 @@ function AccountsDataTable() {
     const allAccounts = accountsQuery.data || [];
     const balances = balancesQuery.data || {};
     const newAccount = useNewAccount();
+    const { onOpen } = useOpenAccount();
 
     const isDisabled = accountsQuery.isLoading;
 
@@ -282,7 +284,7 @@ function AccountsDataTable() {
                                             }}
                                         >
                                             <div
-                                                className="border-b group hover:bg-neutral-100"
+                                                className="border-b group hover:bg-neutral-100 cursor-pointer"
                                                 style={{
                                                     paddingLeft:
                                                         depth * 24 +
@@ -290,16 +292,27 @@ function AccountsDataTable() {
                                                             ? 0
                                                             : 24), // Add indent for leaf nodes
                                                 }}
+                                                onClick={(e) => {
+                                                    // Don't trigger row click if clicking on a button or action
+                                                    const target = e.target as HTMLElement;
+                                                    if (
+                                                        target.closest('button') ||
+                                                        target.closest('[role="menuitem"]')
+                                                    ) {
+                                                        return;
+                                                    }
+                                                    onOpen(account.id);
+                                                }}
                                             >
                                                 <div className="grid grid-cols-[auto_1fr_auto_auto] items-center px-4 py-2 gap-1">
                                                     {/* Expand/Collapse Button */}
-                                                    <div className="w-6 flex justify-center">
+                                                    <div className="w-8 flex justify-center">
                                                         {accountHasChildren &&
                                                             code && (
                                                                 <Button
                                                                     variant="ghost"
                                                                     size="sm"
-                                                                    className="h-6 w-6 p-0 hover:bg-neutral-200"
+                                                                    className="h-8 w-8 p-0 hover:bg-neutral-200"
                                                                     onClick={() =>
                                                                         toggleExpand(
                                                                             code,
@@ -307,9 +320,9 @@ function AccountsDataTable() {
                                                                     }
                                                                 >
                                                                     {isExpanded ? (
-                                                                        <ChevronDown className="h-4 w-4" />
+                                                                        <ChevronDown className="h-5 w-5" />
                                                                     ) : (
-                                                                        <ChevronRight className="h-4 w-4" />
+                                                                        <ChevronRight className="h-5 w-5" />
                                                                     )}
                                                                 </Button>
                                                             )}

--- a/app/(dashboard)/customers/page.tsx
+++ b/app/(dashboard)/customers/page.tsx
@@ -22,6 +22,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { useBulkDeleteCustomers } from '@/features/customers/api/use-bulk-delete-customers';
 import { useGetCustomers } from '@/features/customers/api/use-get-customers';
 import { useNewCustomer } from '@/features/customers/hooks/use-new-customer';
+import { useOpenCustomer } from '@/features/customers/hooks/use-open-customer';
 import { useConfirm } from '@/hooks/use-confirm';
 import { columns, type ResponseType, selectColumn } from './columns';
 
@@ -32,6 +33,7 @@ const CustomersPage = () => {
         'This action cannot be undone.',
     );
     const newCustomer = useNewCustomer();
+    const { onOpen } = useOpenCustomer();
     const customersQuery = useGetCustomers();
     const bulkDeleteMutation = useBulkDeleteCustomers();
     const customers = customersQuery.data || [];
@@ -44,6 +46,10 @@ const CustomersPage = () => {
 
         const ids = rows.map((row) => row.original.id);
         bulkDeleteMutation.mutate({ ids });
+    };
+
+    const handleRowClick = (row: Row<ResponseType>) => {
+        onOpen(row.original.id);
     };
 
     // Add select column when in bulk delete mode
@@ -105,6 +111,7 @@ const CustomersPage = () => {
                         columns={tableColumns}
                         data={customers}
                         onDelete={bulkDeleteMode ? handleBulkDelete : undefined}
+                        onRowClick={bulkDeleteMode ? undefined : handleRowClick}
                         disabled={isDisabled}
                     />
                 </CardContent>


### PR DESCRIPTION
Add row-click behavior to customer and account listings so clicking
a row opens the corresponding entity view. Import and use the
useOpenCustomer and useOpenAccount hooks and call their onOpen
handlers when a non-action area of a row is clicked.

For customers:
- Import useOpenCustomer and call onOpen with the customer id.
- Add handleRowClick and pass it to the table when not in bulk-delete
  mode to avoid interfering with selection.

For accounts:
- Import useOpenAccount and call onOpen from row click handler.
- Add cursor-pointer to row container and guard clicks so buttons
  and menu items do not trigger navigation.
- Slightly adjust layout spacing for row controls.

These changes improve navigability by allowing users to open an item
directly from a row without breaking existing bulk actions or control
interactions.