### PR TITLE
feat(date-filter): add "Last month" range and simplify presets

### DIFF
--- a/components/date-filter.tsx
+++ b/components/date-filter.tsx
@@ -6,6 +6,7 @@ import { Row } from '@signalco/ui-primitives/Row';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import {
     addDays,
+    endOfMonth,
     endOfYear,
     format,
     startOfMonth,
@@ -66,18 +67,8 @@ export const DateFilter = () => {
         let newTo = defaultTo;
 
         switch (range) {
-            case 'Today':
-                newFrom = newTo = new Date();
-                break;
-            case 'Yesterday':
-                newFrom = newTo = subDays(new Date(), 1);
-                break;
             case 'This week':
                 newFrom = startOfWeek(new Date(), { weekStartsOn: 1 });
-                newTo = new Date();
-                break;
-            case 'Last 7 days':
-                newFrom = subDays(new Date(), 7);
                 newTo = new Date();
                 break;
             case 'This month':
@@ -87,6 +78,10 @@ export const DateFilter = () => {
             case 'Last 30 days':
                 newFrom = subDays(new Date(), 30);
                 newTo = new Date();
+                break;
+            case 'Last month':
+                newFrom = startOfMonth(subDays(startOfMonth(new Date()), 1));
+                newTo = endOfMonth(subDays(startOfMonth(new Date()), 1));
                 break;
             case 'This year':
                 newFrom = startOfYear(new Date());
@@ -168,33 +163,11 @@ export const DateFilter = () => {
                         <Stack spacing={1} className="p-2">
                             <Button
                                 variant="outlined"
-                                onClick={() => handleDateRangeClick('Today')}
-                            >
-                                Today
-                            </Button>
-                            <Button
-                                variant="outlined"
-                                onClick={() =>
-                                    handleDateRangeClick('Yesterday')
-                                }
-                            >
-                                Yesterday
-                            </Button>
-                            <Button
-                                variant="outlined"
                                 onClick={() =>
                                     handleDateRangeClick('This week')
                                 }
                             >
                                 This week
-                            </Button>
-                            <Button
-                                variant="outlined"
-                                onClick={() =>
-                                    handleDateRangeClick('Last 7 days')
-                                }
-                            >
-                                Last 7 days
                             </Button>
                             <Button
                                 variant="outlined"
@@ -211,6 +184,14 @@ export const DateFilter = () => {
                                 }
                             >
                                 Last 30 days
+                            </Button>
+                            <Button
+                                variant="outlined"
+                                onClick={() =>
+                                    handleDateRangeClick('Last month')
+                                }
+                            >
+                                Last month
                             </Button>
                             <Button
                                 variant="outlined"


### PR DESCRIPTION
Add support for a "Last month" quick range by computing the start
and end of the previous month using startOfMonth and endOfMonth.
Reorder and simplify preset handlers to remove Today/Yesterday and
Last 7 days buttons, and shift button labels so presets now map to:
This week, This month, Last 30 days, Last month, This year, etc.

Import endOfMonth and adjust switch to return correct boundaries for
the new "Last month" case. Fix an earlier missing break in Last 30
days and streamline the preset buttons to match the updated ranges.