### PR TITLE
feat(ui): normalize control heights to 40px across components

### DIFF
--- a/components/account-filter.tsx
+++ b/components/account-filter.tsx
@@ -18,7 +18,7 @@ export const AccountFilter = () => {
             value={accountId}
             onChange={onChange}
             selectAll
-            className="min-w-72 h-9 px-3 md:w-auto text-left hover:bg-muted"
+            className="min-w-72 px-3 md:w-auto text-left hover:bg-muted"
         />
     );
 };

--- a/components/chart.tsx
+++ b/components/chart.tsx
@@ -45,7 +45,7 @@ export const Chart = ({ data = [] }: ChartProps) => {
             <CardHeader className="flex justify-between space-y-2 lg:flex-row lg:items-center lg:space-y-0">
                 <CardTitle>Transactions</CardTitle>
                 <Select defaultValue={chartType} onValueChange={onTypeChange}>
-                    <SelectTrigger className="h-9 rounded-md px-3 lg:w-auto">
+                    <SelectTrigger className="rounded-md px-3 lg:w-auto">
                         <SelectValue placeholder="Chart type" />
                     </SelectTrigger>
 

--- a/components/customer-select.tsx
+++ b/components/customer-select.tsx
@@ -209,7 +209,7 @@ export const CustomerSelect = ({
             onValueChange={handleValueChange}
             disabled={disabled}
         >
-            <SelectTrigger className={clsx('h-9 pl-3 pr-2', className)}>
+            <SelectTrigger className={clsx('pl-3 pr-2', className)}>
                 <div className="flex items-center justify-between w-full">
                     <span
                         className={clsx(

--- a/components/date-filter.tsx
+++ b/components/date-filter.tsx
@@ -145,7 +145,7 @@ export const DateFilter = () => {
                 title="Previous date range"
                 variant="outlined"
                 onClick={handlePreviousDateRangeClick}
-                className="w-6 px-0 rounded-r-none border-r-0"
+                className="w-6 h-10 px-0 rounded-r-none border-r-0"
             >
                 <ChevronLeft className="size-4" />
             </IconButton>
@@ -155,7 +155,7 @@ export const DateFilter = () => {
                         disabled={false}
                         size="sm"
                         variant="outlined"
-                        className="h-9 w-full rounded-none px-3 transition lg:w-auto border-x-0"
+                        className="h-10 w-full rounded-none px-3 transition lg:w-auto border-x-0"
                     >
                         <span>{formatDateRange(paramState)}</span>
 
@@ -279,7 +279,7 @@ export const DateFilter = () => {
                 title="Next date range"
                 onClick={handleNextDateRangeClick}
                 variant="outlined"
-                className="w-6 px-0 rounded-l-none border-l-0"
+                className="w-6 h-10 px-0 rounded-l-none border-l-0"
             >
                 <ChevronRight className="size-4" />
             </IconButton>

--- a/components/spending-pie.tsx
+++ b/components/spending-pie.tsx
@@ -39,7 +39,7 @@ export const SpendingPie = ({ data = [] }: SpendingPieProps) => {
                 <CardTitle>Tags</CardTitle>
 
                 <Select defaultValue={chartType} onValueChange={onTypeChange}>
-                    <SelectTrigger className="h-9 rounded-md px-3 lg:w-auto">
+                    <SelectTrigger className="rounded-md px-3 lg:w-auto">
                         <SelectValue placeholder="Chart type" />
                     </SelectTrigger>
 

--- a/features/transactions/components/unified-transaction-form.tsx
+++ b/features/transactions/components/unified-transaction-form.tsx
@@ -458,7 +458,7 @@ export const UnifiedTransactionForm = ({
                                         <>
                                             {/* When debits are split but credit is single, show read-only synced amount */}
                                             {isSplitDebit && !isSplitCredit ? (
-                                                <div className="flex h-9 w-full items-center rounded-md border border-input bg-muted px-3 text-sm">
+                                                <div className="flex h-10 w-full items-center rounded-md border border-input bg-muted px-3 text-sm">
                                                     {debitTotal.toFixed(2)}
                                                 </div>
                                             ) : (
@@ -546,7 +546,7 @@ export const UnifiedTransactionForm = ({
                             </div>
                         )}
                         {isAnySplit && (
-                            <div className="h-9 flex items-center justify-center text-sm text-muted-foreground">
+                            <div className="h-10 flex items-center justify-center text-sm text-muted-foreground">
                                 <ChevronRight className="size-4" />
                             </div>
                         )}
@@ -595,7 +595,7 @@ export const UnifiedTransactionForm = ({
                                         <>
                                             {/* When credits are split but debit is single, show read-only synced amount */}
                                             {isSplitCredit && !isSplitDebit ? (
-                                                <div className="flex h-9 w-full items-center rounded-md border border-input bg-muted px-3 text-sm">
+                                                <div className="flex h-10 w-full items-center rounded-md border border-input bg-muted px-3 text-sm">
                                                     {creditTotal.toFixed(2)}
                                                 </div>
                                             ) : (


### PR DESCRIPTION
Adjust various component classNames to standardize control heights and
spacing so UI elements align consistently across the app.

- date-filter: set IconButton and central trigger to 40px height for
  consistent button sizing in the date range picker.
- unified-transaction-form: increase split/readonly amount rows and
  center chevron container to 40px height for consistent form row
  alignment.
- account-filter: remove explicit h-9 to allow consistent height via
  shared select styles and prevent mismatched vertical spacing.
- spending-pie & chart: remove h-9 from SelectTrigger so selects adopt
  the unified control height/spacing.
- customer-select: remove h-9 from SelectTrigger wrapper to defer to
  shared sizing and keep select padding consistent.

These changes improve visual rhythm and alignment of form controls and
selects, reducing mixed heights and spacing inconsistencies across the
UI.