### PR TITLE
feat(ui): replace local UI with @signalco/ui-primitives

### DIFF
--- a/app/(dashboard)/accounts/[id]/page.tsx
+++ b/app/(dashboard)/accounts/[id]/page.tsx
@@ -1,19 +1,19 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
 import {
     Card,
     CardContent,
     CardHeader,
     CardTitle,
 } from '@signalco/ui-primitives/Card';
+import { Input } from '@signalco/ui-primitives/Input';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { format, getMonth, getYear } from 'date-fns';
 import { ArrowLeft, Calendar, Loader2, Search } from 'lucide-react';
 import Link from 'next/link';
 import { Fragment, use, useMemo, useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { useGetAccountLedger } from '@/features/accounts/api/use-get-account-ledger';
 import { useGetSettings } from '@/features/settings/api/use-get-settings';
 import { ACCOUNT_CLASS_LABELS, NORMAL_BALANCES } from '@/lib/accounting';
@@ -169,7 +169,7 @@ export default function AccountLedgerPage({ params }: Props) {
                 <CardHeader className="gap-y-2">
                     <div className="flex items-center gap-2">
                         <Link href="/accounts">
-                            <Button variant="ghost" size="icon">
+                            <Button variant="plain" className="h-10 w-10 p-0">
                                 <ArrowLeft className="size-4" />
                             </Button>
                         </Link>

--- a/app/(dashboard)/accounts/actions.tsx
+++ b/app/(dashboard)/accounts/actions.tsx
@@ -1,8 +1,8 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
 import { BookOpen, Edit, MoreHorizontal, Trash } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { Button } from '@/components/ui/button';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -45,7 +45,7 @@ export const Actions = ({ id, disabled }: Props) => {
             <DropdownMenu>
                 <DropdownMenuTrigger asChild disabled={disabled}>
                     <Button
-                        variant="ghost"
+                        variant="plain"
                         className="size-8 p-0 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
                     >
                         <MoreHorizontal className="size-4" />

--- a/app/(dashboard)/accounts/page.tsx
+++ b/app/(dashboard)/accounts/page.tsx
@@ -1,11 +1,13 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
 import {
     Card,
     CardContent,
     CardHeader,
     CardTitle,
 } from '@signalco/ui-primitives/Card';
+import { Input } from '@signalco/ui-primitives/Input';
 import { Stack } from '@signalco/ui-primitives/Stack';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useVirtualizer } from '@tanstack/react-virtual';
@@ -31,7 +33,6 @@ import {
 } from 'react';
 import { toast } from 'sonner';
 import { type CSVResult, ImportButton } from '@/components/import-button';
-import { Button } from '@/components/ui/button';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -39,7 +40,6 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import type { accounts as accountsSchema } from '@/db/schema';
@@ -223,8 +223,8 @@ function AccountsDataTable() {
 
                         <div className="flex">
                             <Button
-                                variant="ghost"
-                                size="icon"
+                                variant="plain"
+                                className="h-10 w-10 p-0"
                                 onClick={() => {
                                     // Expand all accounts that have children
                                     const accountsWithChildren = allAccounts
@@ -244,8 +244,8 @@ function AccountsDataTable() {
                                 <Expand className="size-4" />
                             </Button>
                             <Button
-                                variant="ghost"
-                                size="icon"
+                                variant="plain"
+                                className="h-10 w-10 p-0"
                                 onClick={() => setExpandedAccounts(new Set())}
                                 disabled={isDisabled}
                             >
@@ -298,7 +298,7 @@ function AccountsDataTable() {
                                                         {accountHasChildren &&
                                                         code ? (
                                                             <Button
-                                                                variant="ghost"
+                                                                variant="plain"
                                                                 size="sm"
                                                                 className="h-10 w-10 p-0 hover:bg-neutral-200"
                                                                 onClick={() =>
@@ -638,7 +638,7 @@ export default function AccountsPage() {
                             <DropdownMenuTrigger asChild>
                                 <Button
                                     size="sm"
-                                    variant="ghost"
+                                    variant="plain"
                                     className="w-full lg:w-auto"
                                 >
                                     <MoreHorizontal className="size-4" />

--- a/app/(dashboard)/customers/columns.tsx
+++ b/app/(dashboard)/customers/columns.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
+import { Checkbox } from '@signalco/ui-primitives/Checkbox';
 import type { ColumnDef } from '@tanstack/react-table';
 import type { InferResponseType } from 'hono';
 import {
@@ -9,8 +11,6 @@ import {
     TriangleAlert,
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -75,7 +75,7 @@ const ActionsCell = ({ row }: { row: { original: ResponseType } }) => {
             <ConfirmDialog />
             <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" className="h-8 w-8 p-0">
+                    <Button variant="plain" className="h-8 w-8 p-0">
                         <MoreHorizontal className="h-4 w-4" />
                     </Button>
                 </DropdownMenuTrigger>
@@ -125,7 +125,7 @@ export const columns: ColumnDef<ResponseType>[] = [
         header: ({ column }) => {
             return (
                 <Button
-                    variant="ghost"
+                    variant="plain"
                     onClick={() =>
                         column.toggleSorting(column.getIsSorted() === 'asc')
                     }
@@ -192,7 +192,7 @@ export const columns: ColumnDef<ResponseType>[] = [
         header: ({ column }) => {
             return (
                 <Button
-                    variant="ghost"
+                    variant="plain"
                     onClick={() =>
                         column.toggleSorting(column.getIsSorted() === 'asc')
                     }

--- a/app/(dashboard)/customers/page.tsx
+++ b/app/(dashboard)/customers/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
 import {
     Card,
     CardContent,
@@ -11,7 +12,6 @@ import { MoreHorizontal, Plus } from 'lucide-react';
 import { useState } from 'react';
 import { DataTable } from '@/components/data-table';
 import { DataTableSearch } from '@/components/data-table-search';
-import { Button } from '@/components/ui/button';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -87,7 +87,7 @@ const CustomersPage = () => {
                         </Button>
                         <DropdownMenu>
                             <DropdownMenuTrigger asChild>
-                                <Button size="sm" variant="ghost">
+                                <Button size="sm" variant="plain">
                                     <MoreHorizontal className="size-4" />
                                 </Button>
                             </DropdownMenuTrigger>

--- a/app/(dashboard)/documents/actions.tsx
+++ b/app/(dashboard)/documents/actions.tsx
@@ -1,7 +1,7 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
 import { Download, Trash2 } from 'lucide-react';
-import { Button } from '@/components/ui/button';
 
 interface DocumentActionsProps {
     documentId: string;
@@ -23,7 +23,7 @@ export function DocumentActions({
         >
             <Button
                 size="sm"
-                variant="ghost"
+                variant="plain"
                 onClick={(e) => {
                     e.stopPropagation();
                     onDownload(documentId);
@@ -34,7 +34,7 @@ export function DocumentActions({
             </Button>
             <Button
                 size="sm"
-                variant="ghost"
+                variant="plain"
                 onClick={(e) => {
                     e.stopPropagation();
                     onDelete(documentId);

--- a/app/(dashboard)/documents/columns.tsx
+++ b/app/(dashboard)/documents/columns.tsx
@@ -1,10 +1,10 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
 import type { ColumnDef } from '@tanstack/react-table';
 import { format } from 'date-fns';
 import type { InferResponseType } from 'hono';
 import { ArrowUpDown, FileText, Link2 } from 'lucide-react';
-import { Button } from '@/components/ui/button';
 import type { client } from '@/lib/hono';
 import { DocumentActions } from './actions';
 
@@ -37,7 +37,7 @@ export const getColumns = ({
         header: ({ column }) => {
             return (
                 <Button
-                    variant="ghost"
+                    variant="plain"
                     onClick={() =>
                         column.toggleSorting(column.getIsSorted() === 'asc')
                     }
@@ -63,7 +63,7 @@ export const getColumns = ({
         header: ({ column }) => {
             return (
                 <Button
-                    variant="ghost"
+                    variant="plain"
                     onClick={() =>
                         column.toggleSorting(column.getIsSorted() === 'asc')
                     }
@@ -82,7 +82,7 @@ export const getColumns = ({
         header: ({ column }) => {
             return (
                 <Button
-                    variant="ghost"
+                    variant="plain"
                     onClick={() =>
                         column.toggleSorting(column.getIsSorted() === 'asc')
                     }
@@ -101,7 +101,7 @@ export const getColumns = ({
         header: ({ column }) => {
             return (
                 <Button
-                    variant="ghost"
+                    variant="plain"
                     onClick={() =>
                         column.toggleSorting(column.getIsSorted() === 'asc')
                     }

--- a/app/(dashboard)/documents/page.tsx
+++ b/app/(dashboard)/documents/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
 import {
     Card,
     CardContent,
@@ -15,7 +16,6 @@ import { DataTable } from '@/components/data-table';
 import { DataTableSearch } from '@/components/data-table-search';
 import { DateFilter } from '@/components/date-filter';
 import { DocumentDropzone } from '@/components/document-dropzone';
-import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import {
     Select,
@@ -194,7 +194,7 @@ export default function DocumentsPage() {
 
                             <Button
                                 variant={
-                                    showUnattachedOnly ? 'default' : 'outline'
+                                    showUnattachedOnly ? 'solid' : 'outlined'
                                 }
                                 onClick={() =>
                                     setShowUnattachedOnly(!showUnattachedOnly)

--- a/app/(dashboard)/new/page.tsx
+++ b/app/(dashboard)/new/page.tsx
@@ -1,17 +1,22 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
 import {
     Card,
     CardContent,
     CardHeader,
     CardTitle,
 } from '@signalco/ui-primitives/Card';
+import {
+    Tabs,
+    TabsContent,
+    TabsList,
+    TabsTrigger,
+} from '@signalco/ui-primitives/Tabs';
 import { ArrowLeft, Loader2 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { Suspense, useState } from 'react';
 import { InvoiceImport } from '@/components/invoice-import';
-import { Button } from '@/components/ui/button';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useCreateCustomer } from '@/features/customers/api/use-create-customer';
 import { useCreateTag } from '@/features/tags/api/use-create-tag';
 import { useGetTags } from '@/features/tags/api/use-get-tags';
@@ -72,10 +77,9 @@ function NewTransactionContent() {
                 <CardHeader className="gap-y-2">
                     <div className="flex items-center gap-2">
                         <Button
-                            variant="ghost"
-                            size="icon"
+                            variant="plain"
+                            className="h-8 w-8 p-0"
                             onClick={() => router.back()}
-                            className="h-8 w-8"
                         >
                             <ArrowLeft className="size-4" />
                         </Button>

--- a/app/(dashboard)/reports/page.tsx
+++ b/app/(dashboard)/reports/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
 import {
     Card,
     CardContent,
@@ -10,8 +11,6 @@ import { Typography } from '@signalco/ui-primitives/Typography';
 import { FileText } from 'lucide-react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
-
-import { Button } from '@/components/ui/button';
 
 const reports = [
     {
@@ -71,7 +70,10 @@ export default function ReportsPage() {
                                             </Typography>
                                         </CardHeader>
                                         <CardContent>
-                                            <Button variant="outline" size="sm">
+                                            <Button
+                                                variant="outlined"
+                                                size="sm"
+                                            >
                                                 View Report
                                             </Button>
                                         </CardContent>

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
 import {
     Card,
     CardContent,
@@ -16,7 +17,6 @@ import { DocumentTypesSettingsCard } from '@/components/document-types-settings-
 import { OpenFinancesSettingsCard } from '@/components/open-finances-settings-card';
 import { ReconciliationSettingsCard } from '@/components/reconciliation-settings-card';
 import { StripeIntegrationCard } from '@/components/stripe-integration-card';
-import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { AccountingPeriodsSettingsCard } from '@/features/accounting-periods/components/accounting-periods-settings-card';

--- a/app/(dashboard)/settings/tag-columns.tsx
+++ b/app/(dashboard)/settings/tag-columns.tsx
@@ -1,10 +1,10 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
+import { Checkbox } from '@signalco/ui-primitives/Checkbox';
 import type { ColumnDef } from '@tanstack/react-table';
 import type { InferResponseType } from 'hono';
 import { ArrowUpDown, MoreHorizontal, Pencil, Trash } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -44,7 +44,7 @@ const Actions = ({ id }: { id: string }) => {
             <ConfirmDialog />
             <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" className="size-8 p-0">
+                    <Button variant="plain" className="size-8 p-0">
                         <MoreHorizontal className="size-4" />
                     </Button>
                 </DropdownMenuTrigger>
@@ -99,7 +99,7 @@ export const tagColumns: ColumnDef<ResponseType>[] = [
         header: ({ column }) => {
             return (
                 <Button
-                    variant="ghost"
+                    variant="plain"
                     onClick={() =>
                         column.toggleSorting(column.getIsSorted() === 'asc')
                     }
@@ -124,7 +124,7 @@ export const tagColumns: ColumnDef<ResponseType>[] = [
         header: ({ column }) => {
             return (
                 <Button
-                    variant="ghost"
+                    variant="plain"
                     onClick={() =>
                         column.toggleSorting(column.getIsSorted() === 'asc')
                     }

--- a/app/(dashboard)/transactions/actions.tsx
+++ b/app/(dashboard)/transactions/actions.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
 import {
     ArrowRight,
     Copy,
@@ -8,8 +9,6 @@ import {
     Paperclip,
     Trash,
 } from 'lucide-react';
-
-import { Button } from '@/components/ui/button';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -155,7 +154,7 @@ export const Actions = ({ transaction }: ActionsProps) => {
             <ConfirmDialog />
             <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" className="size-8 p-0">
+                    <Button variant="plain" className="size-8 p-0">
                         <MoreHorizontal className="size-4" />
                     </Button>
                 </DropdownMenuTrigger>

--- a/app/(dashboard)/transactions/columns.tsx
+++ b/app/(dashboard)/transactions/columns.tsx
@@ -1,11 +1,11 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
+import { Checkbox } from '@signalco/ui-primitives/Checkbox';
 import type { ColumnDef } from '@tanstack/react-table';
 import { format } from 'date-fns';
 import type { InferResponseType } from 'hono';
 import { ArrowUpDown } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
 import type { client } from '@/lib/hono';
 import { AccountColumn } from './account-column';
 import { Actions } from './actions';
@@ -150,7 +150,7 @@ export const columns: ColumnDef<ResponseType>[] = [
         header: ({ column }) => {
             return (
                 <Button
-                    variant="ghost"
+                    variant="plain"
                     onClick={() =>
                         column.toggleSorting(column.getIsSorted() === 'asc')
                     }
@@ -211,7 +211,7 @@ export const columns: ColumnDef<ResponseType>[] = [
         header: ({ column }) => {
             return (
                 <Button
-                    variant="ghost"
+                    variant="plain"
                     onClick={() =>
                         column.toggleSorting(column.getIsSorted() === 'asc')
                     }
@@ -231,7 +231,7 @@ export const columns: ColumnDef<ResponseType>[] = [
         header: ({ column }) => {
             return (
                 <Button
-                    variant="ghost"
+                    variant="plain"
                     onClick={() =>
                         column.toggleSorting(column.getIsSorted() === 'asc')
                     }
@@ -367,7 +367,7 @@ export const columns: ColumnDef<ResponseType>[] = [
         header: ({ column }) => {
             return (
                 <Button
-                    variant="ghost"
+                    variant="plain"
                     onClick={() =>
                         column.toggleSorting(column.getIsSorted() === 'asc')
                     }

--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
 import {
     Card,
     CardContent,
@@ -15,7 +16,6 @@ import { DataTableSearch } from '@/components/data-table-search';
 import { DateFilter } from '@/components/date-filter';
 import { ImportCard } from '@/components/import/import-card';
 import { ImportButton } from '@/components/import-button';
-import { Button } from '@/components/ui/button';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -363,7 +363,7 @@ export default function TransactionsPage() {
                             <DropdownMenuTrigger asChild>
                                 <Button
                                     size="sm"
-                                    variant="ghost"
+                                    variant="plain"
                                     className="w-full lg:w-auto"
                                 >
                                     <MoreHorizontal className="size-4" />

--- a/app/open-finances/[userId]/page.tsx
+++ b/app/open-finances/[userId]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Card } from '@signalco/ui-primitives/Card';
 import {
     ArrowDownIcon,
     ArrowUpIcon,
@@ -10,7 +11,6 @@ import {
 import Image from 'next/image';
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { Card } from '@/components/ui/card';
 
 type MetricConfig = {
     enabled: boolean;

--- a/components/bank-integration-card.tsx
+++ b/components/bank-integration-card.tsx
@@ -1,5 +1,14 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+} from '@signalco/ui-primitives/Card';
+import { Divider } from '@signalco/ui-primitives/Divider';
+import { Input } from '@signalco/ui-primitives/Input';
 import {
     AlertCircle,
     Building2,
@@ -16,14 +25,6 @@ import Image from 'next/image';
 import { useCallback, useEffect, useState } from 'react';
 import { AccountSelect } from '@/components/account-select';
 import { DatePicker } from '@/components/date-picker';
-import { Button } from '@/components/ui/button';
-import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardHeader,
-    CardTitle,
-} from '@/components/ui/card';
 import {
     Dialog,
     DialogContent,
@@ -32,7 +33,6 @@ import {
     DialogTitle,
     DialogTrigger,
 } from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
     Select,
@@ -41,7 +41,6 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
-import { Separator } from '@/components/ui/separator';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
 import {
@@ -372,11 +371,11 @@ export function BankIntegrationCard() {
                         <Building2 className="h-5 w-5" />
                         Bank Integration
                     </CardTitle>
-                    <CardDescription>
+                    <p className="text-sm text-muted-foreground">
                         Connect your bank accounts via{' '}
                         {bankingProviderConfig.name} to automatically import
                         transactions
-                    </CardDescription>
+                    </p>
                 </CardHeader>
                 <CardContent className="space-y-6">
                     {/* Connection Status */}
@@ -407,7 +406,7 @@ export function BankIntegrationCard() {
                         {isConnected && (
                             <div className="flex gap-2">
                                 <Button
-                                    variant="outline"
+                                    variant="outlined"
                                     size="sm"
                                     onClick={handleTestConnection}
                                     disabled={testConnection.isPending}
@@ -419,7 +418,8 @@ export function BankIntegrationCard() {
                                     )}
                                 </Button>
                                 <Button
-                                    variant="destructive"
+                                    variant="solid"
+                                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
                                     size="sm"
                                     onClick={handleDisconnect}
                                     disabled={disconnectBanking.isPending}
@@ -522,28 +522,22 @@ export function BankIntegrationCard() {
                                     key here
                                 </li>
                             </ol>
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                className="mt-2"
-                                asChild
+                            <a
+                                href={bankingProviderConfig.docsUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="mt-2 inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 px-3"
                             >
-                                <a
-                                    href={bankingProviderConfig.docsUrl}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                >
-                                    Open {bankingProviderConfig.name} Docs
-                                    <ExternalLink className="h-3 w-3 ml-1" />
-                                </a>
-                            </Button>
+                                Open {bankingProviderConfig.name} Docs
+                                <ExternalLink className="h-3 w-3 ml-1" />
+                            </a>
                         </div>
                     </div>
 
                     {/* Connected Banks Section - only shown when connected */}
                     {isConnected && (
                         <>
-                            <Separator />
+                            <Divider />
 
                             <div className="space-y-4">
                                 <div className="flex items-center justify-between">
@@ -560,7 +554,10 @@ export function BankIntegrationCard() {
                                         onOpenChange={setAddBankDialogOpen}
                                     >
                                         <DialogTrigger asChild>
-                                            <Button variant="outline" size="sm">
+                                            <Button
+                                                variant="outlined"
+                                                size="sm"
+                                            >
                                                 <Plus className="h-4 w-4 mr-1" />
                                                 Add Bank
                                             </Button>
@@ -735,7 +732,7 @@ export function BankIntegrationCard() {
                                                     </div>
                                                     <div className="flex gap-2">
                                                         <Button
-                                                            variant="ghost"
+                                                            variant="plain"
                                                             size="sm"
                                                             onClick={() =>
                                                                 handleDeleteConnection(
@@ -807,7 +804,7 @@ export function BankIntegrationCard() {
                                                     </div>
                                                     <div className="flex gap-2">
                                                         <Button
-                                                            variant="ghost"
+                                                            variant="plain"
                                                             size="sm"
                                                             onClick={() =>
                                                                 handleDeleteConnection(
@@ -874,7 +871,7 @@ export function BankIntegrationCard() {
                                                         </div>
                                                     </div>
                                                     <Button
-                                                        variant="ghost"
+                                                        variant="plain"
                                                         size="sm"
                                                         onClick={() =>
                                                             handleDeleteConnection(
@@ -968,7 +965,7 @@ export function BankIntegrationCard() {
                                 )}
                             </div>
 
-                            <Separator />
+                            <Divider />
 
                             {/* Default Transaction Settings */}
                             <div className="space-y-4">
@@ -1050,7 +1047,7 @@ export function BankIntegrationCard() {
                                 </div>
                             </div>
 
-                            <Separator />
+                            <Divider />
 
                             {/* Sync From Date */}
                             <div className="space-y-2">
@@ -1069,7 +1066,7 @@ export function BankIntegrationCard() {
                                 </p>
                             </div>
 
-                            <Separator />
+                            <Divider />
 
                             {/* Sync Section */}
                             <div className="space-y-3">
@@ -1093,7 +1090,7 @@ export function BankIntegrationCard() {
                                         )}
                                     </div>
                                     <Button
-                                        variant="outline"
+                                        variant="outlined"
                                         size="sm"
                                         onClick={handleSync}
                                         disabled={
@@ -1120,7 +1117,7 @@ export function BankIntegrationCard() {
                                 )}
                             </div>
 
-                            <Separator />
+                            <Divider />
 
                             {/* Enable/Disable Toggle */}
                             <div className="flex items-center justify-between">

--- a/components/custom-tooltip.tsx
+++ b/components/custom-tooltip.tsx
@@ -1,11 +1,10 @@
+import { Divider } from '@signalco/ui-primitives/Divider';
 import { format } from 'date-fns';
 import type {
     NameType,
     Payload,
     ValueType,
 } from 'recharts/types/component/DefaultTooltipContent';
-
-import { Separator } from '@/components/ui/separator';
 import { formatCurrency } from '@/lib/utils';
 
 export type CustomTooltipProps = {
@@ -26,7 +25,7 @@ export const CustomTooltip = ({ active, payload }: CustomTooltipProps) => {
                 {format(date, 'MMM dd, yyyy')}
             </div>
 
-            <Separator />
+            <Divider />
 
             <div className="space-y-1 p-2 px-3">
                 <div className="flex items-center justify-between gap-x-4">

--- a/components/customer-select.tsx
+++ b/components/customer-select.tsx
@@ -1,12 +1,12 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
+import { Input } from '@signalco/ui-primitives/Input';
 import { Typography } from '@signalco/ui-primitives/Typography';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import clsx from 'clsx';
 import { Plus } from 'lucide-react';
 import { useMemo, useRef, useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import {
     Select,
     SelectContent,
@@ -252,7 +252,7 @@ export const CustomerSelect = ({
                             void handleCreate(customerFilter);
                             setOpen(false);
                         }}
-                        variant="ghost"
+                        variant="plain"
                         className="w-full justify-start h-8"
                     >
                         <Plus className="mr-2 h-4 w-4" />
@@ -349,7 +349,7 @@ export const CustomerSelect = ({
                                     void handleCreate(customerFilter);
                                     setOpen(false);
                                 }}
-                                variant="ghost"
+                                variant="plain"
                                 className="w-full justify-start h-8"
                             >
                                 <Plus className="mr-2 h-4 w-4" />

--- a/components/dashboard/draggable-widget.tsx
+++ b/components/dashboard/draggable-widget.tsx
@@ -2,9 +2,9 @@
 
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { Button } from '@signalco/ui-primitives/Button';
 import { GripVertical, Settings, Trash2 } from 'lucide-react';
 import { useState } from 'react';
-import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { getWidgetDefinition } from '@/lib/widgets/registry';
 import { useDashboardStore } from '@/lib/widgets/store';
@@ -59,7 +59,7 @@ export function DraggableWidget({ widget, isLegacy }: DraggableWidgetProps) {
                     <div className="absolute -top-10 left-0 right-0 flex items-center justify-between opacity-0 group-hover:opacity-100 transition-opacity rounded-md bg-background/80 backdrop-blur-sm border border-border shadow-sm px-2 py-1">
                         <div className="flex items-center gap-2">
                             <Button
-                                variant="ghost"
+                                variant="plain"
                                 size="sm"
                                 className="h-8 cursor-grab active:cursor-grabbing text-foreground"
                                 {...attributes}
@@ -78,7 +78,7 @@ export function DraggableWidget({ widget, isLegacy }: DraggableWidgetProps) {
                         </div>
                         <div className="flex items-center gap-2">
                             <Button
-                                variant="ghost"
+                                variant="plain"
                                 size="sm"
                                 className="h-8 text-foreground"
                                 onClick={() => setIsConfigOpen(true)}
@@ -86,7 +86,7 @@ export function DraggableWidget({ widget, isLegacy }: DraggableWidgetProps) {
                                 <Settings className="h-4 w-4" />
                             </Button>
                             <Button
-                                variant="ghost"
+                                variant="plain"
                                 size="sm"
                                 className="h-8 text-destructive hover:text-destructive"
                                 onClick={() => removeWidget(widget.id)}

--- a/components/dashboard/widget-config-dialog.tsx
+++ b/components/dashboard/widget-config-dialog.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
+import { Input } from '@signalco/ui-primitives/Input';
 import { useState } from 'react';
 import { AccountSelect } from '@/components/account-select';
-import { Button } from '@/components/ui/button';
 import {
     Dialog,
     DialogContent,
@@ -11,7 +12,6 @@ import {
     DialogHeader,
     DialogTitle,
 } from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
     Select,
@@ -235,7 +235,7 @@ export function WidgetConfigDialog({
 
                 <DialogFooter>
                     <Button
-                        variant="outline"
+                        variant="outlined"
                         onClick={() => onOpenChange(false)}
                     >
                         Cancel

--- a/components/dashboard/widget-store-button.tsx
+++ b/components/dashboard/widget-store-button.tsx
@@ -1,15 +1,14 @@
 'use client';
 
-import { Plus } from 'lucide-react';
-import { useState } from 'react';
-import { Button } from '@/components/ui/button';
+import { Button } from '@signalco/ui-primitives/Button';
 import {
     Card,
     CardContent,
-    CardDescription,
     CardHeader,
     CardTitle,
-} from '@/components/ui/card';
+} from '@signalco/ui-primitives/Card';
+import { Plus } from 'lucide-react';
+import { useState } from 'react';
 import {
     Dialog,
     DialogContent,
@@ -35,7 +34,7 @@ export function WidgetStoreButton() {
         <Dialog open={open} onOpenChange={setOpen}>
             <DialogTrigger asChild>
                 <Button
-                    variant="outline"
+                    variant="outlined"
                     size="sm"
                     className="bg-white/10 text-white border-neutral-800 hover:bg-white/20"
                 >
@@ -70,15 +69,15 @@ export function WidgetStoreButton() {
                                                 {widget.name}
                                             </CardTitle>
                                         </div>
-                                        <Button size="sm" variant="outline">
+                                        <Button size="sm" variant="outlined">
                                             Add
                                         </Button>
                                     </div>
                                 </CardHeader>
                                 <CardContent className="pb-3">
-                                    <CardDescription>
+                                    <p className="text-sm text-muted-foreground">
                                         {widget.description}
-                                    </CardDescription>
+                                    </p>
                                 </CardContent>
                             </Card>
                         );

--- a/components/data-table-search.tsx
+++ b/components/data-table-search.tsx
@@ -1,8 +1,8 @@
 'use client';
 
+import { Input } from '@signalco/ui-primitives/Input';
 import type { ColumnFiltersState } from '@tanstack/react-table';
 import * as React from 'react';
-import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
 
 interface DataTableSearchProps {

--- a/components/data-table.tsx
+++ b/components/data-table.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
+import { Table } from '@signalco/ui-primitives/Table';
 import {
     type ColumnDef,
     type ColumnFiltersState,
@@ -16,15 +18,6 @@ import {
 import { ChevronLeft, ChevronRight, Trash } from 'lucide-react';
 import { parseAsInteger, useQueryState } from 'nuqs';
 import * as React from 'react';
-import { Button } from '@/components/ui/button';
-import {
-    Table,
-    TableBody,
-    TableCell,
-    TableHead,
-    TableHeader,
-    TableRow,
-} from '@/components/ui/table';
 import { useConfirm } from '@/hooks/use-confirm';
 import { cn } from '@/lib/utils';
 
@@ -69,7 +62,7 @@ export function DataTable<TData, TValue>({
     );
 
     const tableWrapperRef = React.useRef<HTMLDivElement>(null);
-    const tableHeaderRef = React.useRef<HTMLTableSectionElement>(null);
+    const tableHeaderRef = React.useRef<HTMLTableSectionElement | null>(null);
     const paginationRef = React.useRef<HTMLDivElement>(null);
     const [sorting, setSorting] = React.useState<SortingState>([]);
     const [internalColumnFilters, setInternalColumnFilters] =
@@ -137,6 +130,9 @@ export function DataTable<TData, TValue>({
     React.useEffect(() => {
         if (!autoPageSize) return;
 
+        // Get thead element from the table wrapper since signalco Table.Header doesn't support ref forwarding
+        tableHeaderRef.current = tableWrapperRef.current?.querySelector('thead') ?? null;
+
         recalcPageSize();
         const handleResize = () => recalcPageSize();
         window.addEventListener('resize', handleResize);
@@ -196,7 +192,7 @@ export function DataTable<TData, TValue>({
                         <Button
                             disabled={disabled}
                             size="sm"
-                            variant="outline"
+                            variant="outlined"
                             className="ml-auto"
                             onClick={async () => {
                                 const ok = await confirm();
@@ -218,12 +214,12 @@ export function DataTable<TData, TValue>({
                 )}
             <div ref={tableWrapperRef} className="rounded-md border">
                 <Table>
-                    <TableHeader ref={tableHeaderRef}>
+                    <Table.Header>
                         {table.getHeaderGroups().map((headerGroup) => (
-                            <TableRow key={headerGroup.id}>
+                            <Table.Row key={headerGroup.id}>
                                 {headerGroup.headers.map((header) => {
                                     return (
-                                        <TableHead key={header.id}>
+                                        <Table.Head key={header.id}>
                                             {header.isPlaceholder
                                                 ? null
                                                 : flexRender(
@@ -231,25 +227,25 @@ export function DataTable<TData, TValue>({
                                                           .header,
                                                       header.getContext(),
                                                   )}
-                                        </TableHead>
+                                        </Table.Head>
                                     );
                                 })}
-                            </TableRow>
+                            </Table.Row>
                         ))}
-                    </TableHeader>
-                    <TableBody>
+                    </Table.Header>
+                    <Table.Body>
                         {loading ? (
-                            <TableRow>
-                                <TableCell
+                            <Table.Row>
+                                <Table.Cell
                                     colSpan={columns.length}
                                     className="h-24 text-center"
                                 >
                                     Loading...
-                                </TableCell>
-                            </TableRow>
+                                </Table.Cell>
+                            </Table.Row>
                         ) : table.getRowModel().rows?.length ? (
                             table.getRowModel().rows.map((row) => (
-                                <TableRow
+                                <Table.Row
                                     key={row.id}
                                     data-state={
                                         row.getIsSelected() && 'selected'
@@ -277,26 +273,26 @@ export function DataTable<TData, TValue>({
                                     }}
                                 >
                                     {row.getVisibleCells().map((cell) => (
-                                        <TableCell key={cell.id}>
+                                        <Table.Cell key={cell.id}>
                                             {flexRender(
                                                 cell.column.columnDef.cell,
                                                 cell.getContext(),
                                             )}
-                                        </TableCell>
+                                        </Table.Cell>
                                     ))}
-                                </TableRow>
+                                </Table.Row>
                             ))
                         ) : (
-                            <TableRow>
-                                <TableCell
+                            <Table.Row>
+                                <Table.Cell
                                     colSpan={columns.length}
                                     className="h-24 text-center"
                                 >
                                     No results.
-                                </TableCell>
-                            </TableRow>
+                                </Table.Cell>
+                            </Table.Row>
                         )}
-                    </TableBody>
+                    </Table.Body>
                 </Table>
             </div>
             <div
@@ -309,7 +305,7 @@ export function DataTable<TData, TValue>({
                 </div>
 
                 <Button
-                    variant="outline"
+                    variant="outlined"
                     size="sm"
                     className="px-2"
                     onClick={() => table.previousPage()}
@@ -318,7 +314,7 @@ export function DataTable<TData, TValue>({
                     <ChevronLeft className="size-4" />
                 </Button>
                 <Button
-                    variant="outline"
+                    variant="outlined"
                     size="sm"
                     className="px-2"
                     onClick={() => table.nextPage()}

--- a/components/date-picker.tsx
+++ b/components/date-picker.tsx
@@ -1,7 +1,6 @@
+import { Button } from '@signalco/ui-primitives/Button';
 import { format } from 'date-fns';
 import { CalendarIcon } from 'lucide-react';
-
-import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
 import {
     Popover,
@@ -30,7 +29,7 @@ export const DatePicker = ({
             <PopoverTrigger asChild>
                 <Button
                     disabled={disabled}
-                    variant="outline"
+                    variant="outlined"
                     className={cn(
                         'w-full justify-start text-left font-normal',
                         !value && 'text-muted-foreground',

--- a/components/document-types-settings-card.tsx
+++ b/components/document-types-settings-card.tsx
@@ -1,16 +1,16 @@
 'use client';
 
-import { Plus, Trash2 } from 'lucide-react';
-import { useState } from 'react';
-import { toast } from 'sonner';
-import { Button } from '@/components/ui/button';
+import { Button } from '@signalco/ui-primitives/Button';
 import {
     Card,
     CardContent,
-    CardDescription,
     CardHeader,
     CardTitle,
-} from '@/components/ui/card';
+} from '@signalco/ui-primitives/Card';
+import { Input } from '@signalco/ui-primitives/Input';
+import { Plus, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
 import {
     Dialog,
     DialogContent,
@@ -18,7 +18,6 @@ import {
     DialogTitle,
     DialogTrigger,
 } from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
     useCreateDocumentType,
@@ -113,10 +112,10 @@ export function DocumentTypesSettingsCard() {
         <Card>
             <CardHeader>
                 <CardTitle>Document Types</CardTitle>
-                <CardDescription>
+                <p className="text-sm text-muted-foreground">
                     Define document types that can be attached to transactions
                     (e.g., Receipt, Invoice, Contract).
-                </CardDescription>
+                </p>
             </CardHeader>
             <CardContent className="space-y-4">
                 <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
@@ -205,7 +204,7 @@ export function DocumentTypesSettingsCard() {
                                 <div className="flex items-center gap-2">
                                     <Button
                                         size="sm"
-                                        variant="outline"
+                                        variant="outlined"
                                         onClick={() =>
                                             handleOpenDialog(docType)
                                         }
@@ -214,7 +213,7 @@ export function DocumentTypesSettingsCard() {
                                     </Button>
                                     <Button
                                         size="sm"
-                                        variant="ghost"
+                                        variant="plain"
                                         onClick={() => handleDelete(docType.id)}
                                         disabled={deleteDocumentType.isPending}
                                     >

--- a/components/documents-tab.tsx
+++ b/components/documents-tab.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
 import { useQueryClient } from '@tanstack/react-query';
 import { format } from 'date-fns';
 import {
@@ -13,7 +14,6 @@ import {
 import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
 import { DocumentDropzone } from '@/components/document-dropzone';
-import { Button } from '@/components/ui/button';
 import {
     Select,
     SelectContent,
@@ -354,7 +354,7 @@ export function DocumentList({
                     <div className="flex items-center gap-1">
                         <Button
                             size="sm"
-                            variant="ghost"
+                            variant="plain"
                             onClick={() => handleDownload(doc.id, doc.fileName)}
                             title="Download"
                         >
@@ -363,7 +363,7 @@ export function DocumentList({
                         {!readOnly && (
                             <Button
                                 size="sm"
-                                variant="ghost"
+                                variant="plain"
                                 onClick={() => handleDelete(doc.id)}
                                 disabled={deleteDocument.isPending}
                                 title="Delete"
@@ -454,7 +454,7 @@ function UnattachedDocuments({ transactionId }: UnattachedDocumentsProps) {
                         </div>
                         <Button
                             size="sm"
-                            variant="outline"
+                            variant="outlined"
                             onClick={() => handleLink(doc.id)}
                             disabled={linkDocument.isPending}
                             className="gap-1"

--- a/components/import-button.tsx
+++ b/components/import-button.tsx
@@ -1,7 +1,6 @@
+import { Button } from '@signalco/ui-primitives/Button';
 import { Import } from 'lucide-react';
 import { useCSVReader } from 'react-papaparse';
-
-import { Button } from '@/components/ui/button';
 import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';
 

--- a/components/import/import-card.tsx
+++ b/components/import/import-card.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@signalco/ui-primitives/Button';
 import {
     Card,
     CardContent,
@@ -6,7 +7,6 @@ import {
 } from '@signalco/ui-primitives/Card';
 import { Loader2 } from 'lucide-react';
 import { useState } from 'react';
-import { Button } from '@/components/ui/button';
 
 import { ImportTable } from './import-table';
 

--- a/components/import/import-table.tsx
+++ b/components/import/import-table.tsx
@@ -1,12 +1,5 @@
+import { Table } from '@signalco/ui-primitives/Table';
 import { TableHeadSelect } from '@/components/import/table-head-select';
-import {
-    Table,
-    TableBody,
-    TableCell,
-    TableHead,
-    TableHeader,
-    TableRow,
-} from '@/components/ui/table';
 
 type ImportTableProps = {
     headers: string[];
@@ -29,36 +22,36 @@ export const ImportTable = ({
     return (
         <div className="overflow-hidden rounded-md border">
             <Table>
-                <TableHeader className="bg-muted">
-                    <TableRow>
+                <Table.Header className="bg-muted">
+                    <Table.Row>
                         {headers.map((header, index) => (
-                            <TableHead key={`header-${index}-${header}`}>
+                            <Table.Head key={`header-${index}-${header}`}>
                                 <TableHeadSelect
                                     options={options}
                                     columnIndex={index}
                                     selectedColumns={selectedColumns}
                                     onChange={onTableHeadSelectChange}
                                 />
-                            </TableHead>
+                            </Table.Head>
                         ))}
-                    </TableRow>
-                </TableHeader>
+                    </Table.Row>
+                </Table.Header>
 
-                <TableBody>
+                <Table.Body>
                     {body.map((row: string[], rowIndex) => (
-                        <TableRow
+                        <Table.Row
                             key={`row-${rowIndex}-${row.join('-').slice(0, 50)}`}
                         >
                             {row.map((cell, cellIndex) => (
-                                <TableCell
+                                <Table.Cell
                                     key={`cell-${rowIndex}-${cellIndex}-${cell?.slice(0, 20) ?? ''}`}
                                 >
                                     {cell}
-                                </TableCell>
+                                </Table.Cell>
                             ))}
-                        </TableRow>
+                        </Table.Row>
                     ))}
-                </TableBody>
+                </Table.Body>
             </Table>
         </div>
     );

--- a/components/invoice-import.tsx
+++ b/components/invoice-import.tsx
@@ -1,9 +1,9 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
 import { Check, Loader2 } from 'lucide-react';
 import { useState } from 'react';
 import { InvoiceZipDropzone } from '@/components/invoice-zip-dropzone';
-import { Button } from '@/components/ui/button';
 import {
     type ImportedInvoiceResult,
     useImportInvoiceZip,
@@ -141,7 +141,7 @@ export function InvoiceImport({
                             </div>
                             {result.success && result.transactionId && (
                                 <Button
-                                    variant="ghost"
+                                    variant="plain"
                                     size="sm"
                                     onClick={() => {
                                         if (result.transactionId) {
@@ -161,7 +161,7 @@ export function InvoiceImport({
 
                 {/* Actions */}
                 <div className="flex justify-end gap-2">
-                    <Button variant="outline" onClick={handleReset}>
+                    <Button variant="outlined" onClick={handleReset}>
                         Import More
                     </Button>
                     <Button onClick={onComplete}>Done</Button>

--- a/components/open-finances-settings-card.tsx
+++ b/components/open-finances-settings-card.tsx
@@ -1,17 +1,16 @@
 'use client';
 
 import { useAuth } from '@clerk/nextjs';
-import { Check, Copy, ExternalLink, Info, Loader2, Share2 } from 'lucide-react';
-import { useState } from 'react';
-import { Button } from '@/components/ui/button';
+import { Button } from '@signalco/ui-primitives/Button';
 import {
     Card,
     CardContent,
-    CardDescription,
     CardHeader,
     CardTitle,
-} from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
+} from '@signalco/ui-primitives/Card';
+import { Input } from '@signalco/ui-primitives/Input';
+import { Check, Copy, ExternalLink, Info, Loader2, Share2 } from 'lucide-react';
+import { useState } from 'react';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
@@ -88,7 +87,7 @@ export function OpenFinancesSettingsCard() {
             <Card>
                 <CardHeader>
                     <CardTitle>Open Finances</CardTitle>
-                    <CardDescription>Loading...</CardDescription>
+                    <p className="text-sm text-muted-foreground">Loading...</p>
                 </CardHeader>
                 <CardContent>
                     <div className="flex items-center justify-center py-8">
@@ -103,10 +102,10 @@ export function OpenFinancesSettingsCard() {
         <Card>
             <CardHeader>
                 <CardTitle>Open Finances</CardTitle>
-                <CardDescription>
+                <p className="text-sm text-muted-foreground">
                     Share selected financial data publicly with transparency.
                     Control what information is visible and how it's displayed.
-                </CardDescription>
+                </p>
             </CardHeader>
             <CardContent className="space-y-6">
                 {/* Enable/Disable */}
@@ -352,8 +351,8 @@ export function OpenFinancesSettingsCard() {
                                             className="flex-1 bg-white"
                                         />
                                         <Button
-                                            variant="outline"
-                                            size="icon"
+                                            variant="outlined"
+                                            className="h-10 w-10 p-0"
                                             onClick={() =>
                                                 copyToClipboard(embedUrl)
                                             }
@@ -365,20 +364,15 @@ export function OpenFinancesSettingsCard() {
                                                 <Copy className="size-4" />
                                             )}
                                         </Button>
-                                        <Button
-                                            variant="outline"
-                                            size="icon"
-                                            asChild
+                                        <a
+                                            href={embedUrl}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="inline-flex items-center justify-center h-10 w-10 p-0 rounded-md border border-input bg-background hover:bg-accent hover:text-accent-foreground"
                                             title="Open in new tab"
                                         >
-                                            <a
-                                                href={embedUrl}
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                            >
-                                                <ExternalLink className="size-4" />
-                                            </a>
-                                        </Button>
+                                            <ExternalLink className="size-4" />
+                                        </a>
                                     </div>
                                 </div>
 
@@ -400,8 +394,8 @@ export function OpenFinancesSettingsCard() {
                                                 rows={3}
                                             />
                                             <Button
-                                                variant="outline"
-                                                size="icon"
+                                                variant="outlined"
+                                                className="h-10 w-10 p-0"
                                                 onClick={() =>
                                                     copyToClipboard(embedCode)
                                                 }

--- a/components/quick-assign-suggestions.tsx
+++ b/components/quick-assign-suggestions.tsx
@@ -1,7 +1,7 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
 import { Loader2 } from 'lucide-react';
-import { Button } from '@/components/ui/button';
 
 export type QuickAssignSuggestion = {
     id: string;
@@ -49,7 +49,7 @@ export const QuickAssignSuggestions = ({
                         <Button
                             key={suggestion.id}
                             type="button"
-                            variant="outline"
+                            variant="outlined"
                             size="sm"
                             className="h-6 px-2 text-xs truncate max-w-24 justify-start cursor-pointer"
                             disabled={disabled}

--- a/components/reconciliation-settings-card.tsx
+++ b/components/reconciliation-settings-card.tsx
@@ -1,16 +1,15 @@
 'use client';
 
-import { Info } from 'lucide-react';
-import { useEffect, useState } from 'react';
 import {
     Card,
     CardContent,
-    CardDescription,
     CardHeader,
     CardTitle,
-} from '@/components/ui/card';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Input } from '@/components/ui/input';
+} from '@signalco/ui-primitives/Card';
+import { Checkbox } from '@signalco/ui-primitives/Checkbox';
+import { Input } from '@signalco/ui-primitives/Input';
+import { Info } from 'lucide-react';
+import { useEffect, useState } from 'react';
 import { Label } from '@/components/ui/label';
 import {
     Tooltip,
@@ -65,10 +64,10 @@ export function ReconciliationSettingsCard() {
         <Card>
             <CardHeader>
                 <CardTitle>Reconciliation Conditions</CardTitle>
-                <CardDescription>
+                <p className="text-sm text-muted-foreground">
                     Configure what conditions must be met for a transaction to
                     be considered reconciled.
-                </CardDescription>
+                </p>
             </CardHeader>
             <CardContent className="space-y-6">
                 {/* Required Document Types for Reconciliation */}

--- a/components/status-progression.tsx
+++ b/components/status-progression.tsx
@@ -1,10 +1,10 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
+import { Card, CardContent } from '@signalco/ui-primitives/Card';
 import { AlertCircle, ArrowRight, CheckCircle, Undo2 } from 'lucide-react';
 import { Fragment, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
 import {
     Dialog,
     DialogContent,
@@ -214,7 +214,7 @@ export function StatusProgression({
                     </div>
                     <DialogFooter>
                         <Button
-                            variant="outline"
+                            variant="outlined"
                             onClick={() => {
                                 setShowUnreconcileDialog(false);
                                 setUnreconcileReason('');
@@ -224,7 +224,8 @@ export function StatusProgression({
                             Cancel
                         </Button>
                         <Button
-                            variant="destructive"
+                            variant="solid"
+                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
                             onClick={handleUnreconcile}
                             disabled={
                                 isUnreconciling || !unreconcileReason.trim()
@@ -269,7 +270,7 @@ export function StatusProgression({
                     </div>
                     <DialogFooter>
                         <Button
-                            variant="outline"
+                            variant="outlined"
                             onClick={() => {
                                 setShowUncompleteDialog(false);
                                 setUncompleteReason('');
@@ -279,7 +280,8 @@ export function StatusProgression({
                             Cancel
                         </Button>
                         <Button
-                            variant="destructive"
+                            variant="solid"
+                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
                             onClick={handleUncomplete}
                             disabled={
                                 isUncompleting || !uncompleteReason.trim()
@@ -312,7 +314,7 @@ export function StatusProgression({
                             </div>
                             {onUnreconcile && (
                                 <Button
-                                    variant="outline"
+                                    variant="outlined"
                                     size="sm"
                                     onClick={() =>
                                         setShowUnreconcileDialog(true)
@@ -423,7 +425,7 @@ export function StatusProgression({
                                         {currentStatus === 'completed' &&
                                             onUncomplete && (
                                                 <Button
-                                                    variant="outline"
+                                                    variant="outlined"
                                                     size="sm"
                                                     onClick={() =>
                                                         setShowUncompleteDialog(

--- a/components/stripe-integration-card.tsx
+++ b/components/stripe-integration-card.tsx
@@ -1,5 +1,14 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+} from '@signalco/ui-primitives/Card';
+import { Divider } from '@signalco/ui-primitives/Divider';
+import { Input } from '@signalco/ui-primitives/Input';
 import {
     AlertCircle,
     Check,
@@ -14,15 +23,6 @@ import {
 import { useState } from 'react';
 import { AccountSelect } from '@/components/account-select';
 import { DatePicker } from '@/components/date-picker';
-import { Button } from '@/components/ui/button';
-import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardHeader,
-    CardTitle,
-} from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
     Select,
@@ -31,7 +31,6 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
-import { Separator } from '@/components/ui/separator';
 import { Switch } from '@/components/ui/switch';
 import {
     useDisconnectStripe,
@@ -162,10 +161,10 @@ export function StripeIntegrationCard() {
                         <CreditCard className="h-5 w-5" />
                         Stripe Integration
                     </CardTitle>
-                    <CardDescription>
+                    <p className="text-sm text-muted-foreground">
                         Connect your Stripe account to automatically create
                         transactions from payments
-                    </CardDescription>
+                    </p>
                 </CardHeader>
                 <CardContent className="space-y-6">
                     {/* Connection Status */}
@@ -197,7 +196,7 @@ export function StripeIntegrationCard() {
                         {isConnected && (
                             <div className="flex gap-2">
                                 <Button
-                                    variant="outline"
+                                    variant="outlined"
                                     size="sm"
                                     onClick={handleTestConnection}
                                     disabled={testConnection.isPending}
@@ -209,7 +208,8 @@ export function StripeIntegrationCard() {
                                     )}
                                 </Button>
                                 <Button
-                                    variant="destructive"
+                                    variant="solid"
+                                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
                                     size="sm"
                                     onClick={handleDisconnect}
                                     disabled={disconnectStripe.isPending}
@@ -248,7 +248,7 @@ export function StripeIntegrationCard() {
                                 />
                                 <Button
                                     type="button"
-                                    variant="ghost"
+                                    variant="plain"
                                     size="sm"
                                     className="absolute right-0 top-0 h-full px-3"
                                     onClick={() =>
@@ -281,7 +281,7 @@ export function StripeIntegrationCard() {
                     {/* Webhook Section - only shown when connected */}
                     {isConnected && (
                         <>
-                            <Separator />
+                            <Divider />
 
                             <div>
                                 <h4 className="font-medium">
@@ -322,21 +322,15 @@ export function StripeIntegrationCard() {
                                         charge.refunded
                                     </span>
                                 </p>
-                                <Button
-                                    variant="outline"
-                                    size="sm"
-                                    className="mt-2"
-                                    asChild
+                                <a
+                                    href="https://dashboard.stripe.com/webhooks"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="mt-2 inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 px-3"
                                 >
-                                    <a
-                                        href="https://dashboard.stripe.com/webhooks"
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                    >
-                                        Open Stripe Webhooks
-                                        <ExternalLink className="h-3 w-3 ml-1" />
-                                    </a>
-                                </Button>
+                                    Open Stripe Webhooks
+                                    <ExternalLink className="h-3 w-3 ml-1" />
+                                </a>
                             </div>
 
                             {/* Webhook Secret Input */}
@@ -370,7 +364,7 @@ export function StripeIntegrationCard() {
                                         />
                                         <Button
                                             type="button"
-                                            variant="ghost"
+                                            variant="plain"
                                             size="sm"
                                             className="absolute right-0 top-0 h-full px-3"
                                             onClick={() =>
@@ -408,7 +402,7 @@ export function StripeIntegrationCard() {
                                 )}
                             </div>
 
-                            <Separator />
+                            <Divider />
 
                             {/* Default Transaction Settings */}
                             <div className="space-y-4">
@@ -491,7 +485,7 @@ export function StripeIntegrationCard() {
                                 </div>
                             </div>
 
-                            <Separator />
+                            <Divider />
 
                             {/* Sync From Date */}
                             <div className="space-y-2">
@@ -508,7 +502,7 @@ export function StripeIntegrationCard() {
                                 </p>
                             </div>
 
-                            <Separator />
+                            <Divider />
 
                             {/* Sync Section */}
                             <div className="space-y-3">
@@ -530,7 +524,7 @@ export function StripeIntegrationCard() {
                                         )}
                                     </div>
                                     <Button
-                                        variant="outline"
+                                        variant="outlined"
                                         size="sm"
                                         onClick={handleSync}
                                         disabled={
@@ -563,7 +557,7 @@ export function StripeIntegrationCard() {
                                 )}
                             </div>
 
-                            <Separator />
+                            <Divider />
 
                             {/* Enable/Disable Toggle - at the bottom */}
                             <div className="flex items-center justify-between">

--- a/components/tag-tooltip.tsx
+++ b/components/tag-tooltip.tsx
@@ -1,10 +1,9 @@
+import { Divider } from '@signalco/ui-primitives/Divider';
 import type {
     NameType,
     Payload,
     ValueType,
 } from 'recharts/types/component/DefaultTooltipContent';
-
-import { Separator } from '@/components/ui/separator';
 import { formatCurrency } from '@/lib/utils';
 
 export type TagTooltipProps = {
@@ -24,7 +23,7 @@ export const TagTooltip = ({ active, payload }: TagTooltipProps) => {
                 {name}
             </div>
 
-            <Separator />
+            <Divider />
 
             <div className="space-y-1 p-2 px-3">
                 <div className="flex items-center justify-between gap-x-4">

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -3,8 +3,11 @@
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import type * as React from 'react';
 import { DayPicker } from 'react-day-picker';
-import { buttonVariants } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+
+// Button variant styles (inline since signalco doesn't export buttonVariants)
+const buttonOutlineClasses = 'cursor-default inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground';
+const buttonGhostClasses = 'cursor-default inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 hover:bg-accent hover:text-accent-foreground';
 
 export type CalendarProps = React.ComponentProps<typeof DayPicker>;
 
@@ -21,15 +24,16 @@ function Calendar({
             classNames={{
                 months: 'flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0 relative',
                 month: 'space-y-4',
-                month_caption: 'flex justify-center pt-1 relative items-center h-7',
+                month_caption:
+                    'flex justify-center pt-1 relative items-center h-7',
                 caption_label: 'text-sm font-medium',
                 nav: 'flex items-center gap-1 absolute top-0 right-0 left-0 justify-between z-10 px-1',
                 button_previous: cn(
-                    buttonVariants({ variant: 'outline' }),
+                    buttonOutlineClasses,
                     'h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100',
                 ),
                 button_next: cn(
-                    buttonVariants({ variant: 'outline' }),
+                    buttonOutlineClasses,
                     'h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100',
                 ),
                 month_grid: 'w-full border-collapse space-y-1',
@@ -39,7 +43,7 @@ function Calendar({
                 week: 'flex w-full mt-2',
                 day: 'h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20',
                 day_button: cn(
-                    buttonVariants({ variant: 'ghost' }),
+                    buttonGhostClasses,
                     'h-9 w-9 p-0 font-normal rounded-md aria-selected:opacity-100 focus-visible:ring-0 focus-visible:ring-offset-0',
                 ),
                 range_end: 'day-range-end',

--- a/features/accounting-periods/components/accounting-periods-settings-card.tsx
+++ b/features/accounting-periods/components/accounting-periods-settings-card.tsx
@@ -1,28 +1,21 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
 import {
     Card,
     CardContent,
     CardHeader,
     CardTitle,
 } from '@signalco/ui-primitives/Card';
+import { Table } from '@signalco/ui-primitives/Table';
 import { format } from 'date-fns';
 import { CalendarClock, Loader2, MoreHorizontal, Trash } from 'lucide-react';
-import { Button } from '@/components/ui/button';
 import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import {
-    Table,
-    TableBody,
-    TableCell,
-    TableHead,
-    TableHeader,
-    TableRow,
-} from '@/components/ui/table';
 import { useDeleteAccountingPeriod } from '@/features/accounting-periods/api/use-delete-accounting-period';
 import { useGetAccountingPeriods } from '@/features/accounting-periods/api/use-get-accounting-periods';
 import { useYearClosingWizard } from '@/features/accounting-periods/hooks/use-year-closing-wizard';
@@ -76,18 +69,18 @@ export const AccountingPeriodsSettingsCard = () => {
                     ) : (
                         <div className="rounded-md border">
                             <Table>
-                                <TableHeader>
-                                    <TableRow>
-                                        <TableHead>Period</TableHead>
-                                        <TableHead>Status</TableHead>
-                                        <TableHead>Closed</TableHead>
-                                        <TableHead className="w-[50px]"></TableHead>
-                                    </TableRow>
-                                </TableHeader>
-                                <TableBody>
+                                <Table.Header>
+                                    <Table.Row>
+                                        <Table.Head>Period</Table.Head>
+                                        <Table.Head>Status</Table.Head>
+                                        <Table.Head>Closed</Table.Head>
+                                        <Table.Head className="w-[50px]"></Table.Head>
+                                    </Table.Row>
+                                </Table.Header>
+                                <Table.Body>
                                     {periods.map((period) => (
-                                        <TableRow key={period.id}>
-                                            <TableCell>
+                                        <Table.Row key={period.id}>
+                                            <Table.Cell>
                                                 <div className="font-medium">
                                                     {format(
                                                         new Date(
@@ -108,8 +101,8 @@ export const AccountingPeriodsSettingsCard = () => {
                                                         {period.notes}
                                                     </div>
                                                 )}
-                                            </TableCell>
-                                            <TableCell>
+                                            </Table.Cell>
+                                            <Table.Cell>
                                                 <span
                                                     className={cn(
                                                         'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold',
@@ -123,8 +116,8 @@ export const AccountingPeriodsSettingsCard = () => {
                                                         ? 'Closed'
                                                         : 'Open'}
                                                 </span>
-                                            </TableCell>
-                                            <TableCell>
+                                            </Table.Cell>
+                                            <Table.Cell>
                                                 {period.closedAt
                                                     ? format(
                                                           new Date(
@@ -133,14 +126,14 @@ export const AccountingPeriodsSettingsCard = () => {
                                                           'MMM d, yyyy',
                                                       )
                                                     : '-'}
-                                            </TableCell>
-                                            <TableCell>
+                                            </Table.Cell>
+                                            <Table.Cell>
                                                 <DropdownMenu>
                                                     <DropdownMenuTrigger
                                                         asChild
                                                     >
                                                         <Button
-                                                            variant="ghost"
+                                                            variant="plain"
                                                             size="sm"
                                                             className="h-8 w-8 p-0"
                                                         >
@@ -173,10 +166,10 @@ export const AccountingPeriodsSettingsCard = () => {
                                                         )}
                                                     </DropdownMenuContent>
                                                 </DropdownMenu>
-                                            </TableCell>
-                                        </TableRow>
+                                            </Table.Cell>
+                                        </Table.Row>
                                     ))}
-                                </TableBody>
+                                </Table.Body>
                             </Table>
                         </div>
                     )}

--- a/features/accounting-periods/components/year-closing-wizard.tsx
+++ b/features/accounting-periods/components/year-closing-wizard.tsx
@@ -1,8 +1,8 @@
+import { Button } from '@signalco/ui-primitives/Button';
 import { format } from 'date-fns';
 import { useState } from 'react';
 import { AccountSelect } from '@/components/account-select';
 import { DatePicker } from '@/components/date-picker';
-import { Button } from '@/components/ui/button';
 import {
     Sheet,
     SheetContent,
@@ -226,7 +226,7 @@ export const YearClosingWizard = () => {
                                 </div>
                                 <div className="flex gap-2">
                                     <Button
-                                        variant="outline"
+                                        variant="outlined"
                                         onClick={() => setStep(1)}
                                     >
                                         Back
@@ -294,7 +294,7 @@ export const YearClosingWizard = () => {
 
                                 <div className="flex gap-2">
                                     <Button
-                                        variant="outline"
+                                        variant="outlined"
                                         onClick={() => setStep(2)}
                                     >
                                         Back
@@ -336,7 +336,7 @@ export const YearClosingWizard = () => {
                                 </div>
                                 <div className="flex gap-2">
                                     <Button
-                                        variant="outline"
+                                        variant="outlined"
                                         onClick={handleClose}
                                     >
                                         Cancel

--- a/features/accounts/components/account-form.tsx
+++ b/features/accounts/components/account-form.tsx
@@ -1,11 +1,12 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import { Button } from '@signalco/ui-primitives/Button';
+import { Checkbox } from '@signalco/ui-primitives/Checkbox';
+import { Input } from '@signalco/ui-primitives/Input';
 import { AlertCircle, Info, Trash } from 'lucide-react';
 import CurrencyInput from 'react-currency-input-field';
 import { useForm } from 'react-hook-form';
 import type { z } from 'zod';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
 import {
     Form,
     FormControl,
@@ -15,7 +16,6 @@ import {
     FormLabel,
     FormMessage,
 } from '@/components/ui/form';
-import { Input } from '@/components/ui/input';
 import {
     Select,
     SelectContent,
@@ -332,7 +332,7 @@ export const AccountForm = ({
                             disabled={disabled}
                             onClick={handleDelete}
                             className="w-full"
-                            variant="outline"
+                            variant="outlined"
                         >
                             <Trash className="size-4 mr-2" />
                             Delete account

--- a/features/accounts/hooks/use-select-account.tsx
+++ b/features/accounts/hooks/use-select-account.tsx
@@ -1,7 +1,6 @@
+import { Button } from '@signalco/ui-primitives/Button';
 import { type ReactNode, useRef, useState } from 'react';
-
 import { Select } from '@/components/select';
-import { Button } from '@/components/ui/button';
 import {
     Dialog,
     DialogContent,
@@ -76,7 +75,7 @@ export const useSelectAccount = (): [
                 />
 
                 <DialogFooter className="pt-2">
-                    <Button onClick={handleCancel} variant="outline">
+                    <Button onClick={handleCancel} variant="outlined">
                         Cancel
                     </Button>
                     <Button onClick={handleConfirm}>Confirm</Button>

--- a/features/accounts/hooks/use-select-import-accounts.tsx
+++ b/features/accounts/hooks/use-select-import-accounts.tsx
@@ -1,7 +1,6 @@
+import { Button } from '@signalco/ui-primitives/Button';
 import { type ReactNode, useState } from 'react';
-
 import { AccountSelect } from '@/components/account-select';
-import { Button } from '@/components/ui/button';
 import {
     Dialog,
     DialogContent,
@@ -98,7 +97,7 @@ export const useSelectImportAccounts = (): [
                 </div>
 
                 <DialogFooter className="pt-2">
-                    <Button onClick={handleCancel} variant="outline">
+                    <Button onClick={handleCancel} variant="outlined">
                         Cancel
                     </Button>
                     <Button onClick={handleConfirm}>Confirm</Button>

--- a/features/customers/components/customer-form.tsx
+++ b/features/customers/components/customer-form.tsx
@@ -1,9 +1,9 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import { Button } from '@signalco/ui-primitives/Button';
+import { Checkbox } from '@signalco/ui-primitives/Checkbox';
+import { Input } from '@signalco/ui-primitives/Input';
 import { useForm } from 'react-hook-form';
 import type { z } from 'zod';
-
-import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
 import {
     Form,
     FormControl,
@@ -12,7 +12,6 @@ import {
     FormItem,
     FormLabel,
 } from '@/components/ui/form';
-import { Input } from '@/components/ui/input';
 import { SheetFooter } from '@/components/ui/sheet';
 import { Textarea } from '@/components/ui/textarea';
 import { insertCustomerSchema } from '@/db/schema';
@@ -195,7 +194,7 @@ export const CustomerForm = ({
                             disabled={disabled}
                             onClick={handleDelete}
                             className="w-full"
-                            variant="outline"
+                            variant="outlined"
                         >
                             Delete customer
                         </Button>

--- a/features/customers/components/customer-ibans-manager.tsx
+++ b/features/customers/components/customer-ibans-manager.tsx
@@ -1,8 +1,7 @@
+import { Button } from '@signalco/ui-primitives/Button';
+import { Input } from '@signalco/ui-primitives/Input';
 import { Loader2, Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
-
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useCreateCustomerIban } from '@/features/customers/api/use-create-customer-iban';
 import { useDeleteCustomerIban } from '@/features/customers/api/use-delete-customer-iban';
@@ -90,8 +89,8 @@ export const CustomerIbansManager = ({ customerId, disabled }: Props) => {
                                     </div>
                                     <Button
                                         type="button"
-                                        variant="ghost"
-                                        size="icon"
+                                        variant="plain"
+                                        className="h-10 w-10 p-0"
                                         disabled={disabled || isPending}
                                         onClick={() => handleDelete(iban.id)}
                                     >
@@ -126,11 +125,10 @@ export const CustomerIbansManager = ({ customerId, disabled }: Props) => {
                         </div>
                         <Button
                             type="button"
-                            variant="outline"
-                            size="icon"
+                            variant="outlined"
+                            className="h-10 w-10 p-0 self-start"
                             onClick={handleAdd}
                             disabled={disabled || isPending || !newIban.trim()}
-                            className="self-start"
                         >
                             {createMutation.isPending ? (
                                 <Loader2 className="size-4 animate-spin" />

--- a/features/customers/components/edit-customer-sheet.tsx
+++ b/features/customers/components/edit-customer-sheet.tsx
@@ -1,6 +1,11 @@
+import {
+    Tabs,
+    TabsContent,
+    TabsList,
+    TabsTrigger,
+} from '@signalco/ui-primitives/Tabs';
 import { Loader2 } from 'lucide-react';
 import type { z } from 'zod';
-
 import {
     Sheet,
     SheetContent,
@@ -8,7 +13,6 @@ import {
     SheetHeader,
     SheetTitle,
 } from '@/components/ui/sheet';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { insertCustomerSchema } from '@/db/schema';
 import { useDeleteCustomer } from '@/features/customers/api/use-delete-customer';
 import { useEditCustomer } from '@/features/customers/api/use-edit-customer';

--- a/features/tags/components/tag-form.tsx
+++ b/features/tags/components/tag-form.tsx
@@ -1,9 +1,9 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import { Button } from '@signalco/ui-primitives/Button';
+import { Input } from '@signalco/ui-primitives/Input';
 import { Trash } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import type { z } from 'zod';
-
-import { Button } from '@/components/ui/button';
 import {
     Form,
     FormControl,
@@ -13,7 +13,6 @@ import {
     FormLabel,
     FormMessage,
 } from '@/components/ui/form';
-import { Input } from '@/components/ui/input';
 import {
     Select,
     SelectContent,
@@ -160,7 +159,7 @@ export const TagForm = ({
                             disabled={disabled}
                             onClick={handleDelete}
                             className="w-full"
-                            variant="outline"
+                            variant="outlined"
                         >
                             <Trash className="mr-2 size-4" />
                             Delete tag

--- a/features/transactions/components/edit-transaction-sheet.tsx
+++ b/features/transactions/components/edit-transaction-sheet.tsx
@@ -1,3 +1,10 @@
+import { Button } from '@signalco/ui-primitives/Button';
+import {
+    Tabs,
+    TabsContent,
+    TabsList,
+    TabsTrigger,
+} from '@signalco/ui-primitives/Tabs';
 import { useQueries } from '@tanstack/react-query';
 import { Copy, ExternalLink, Loader2 } from 'lucide-react';
 import React, { Fragment, useMemo, useState } from 'react';
@@ -5,7 +12,6 @@ import type { z } from 'zod';
 import { DocumentsTab } from '@/components/documents-tab';
 import { StatusProgression } from '@/components/status-progression';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import {
     Sheet,
     SheetContent,
@@ -13,7 +19,6 @@ import {
     SheetHeader,
     SheetTitle,
 } from '@/components/ui/sheet';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { UserAvatar } from '@/components/user-avatar';
 import { insertTransactionSchema } from '@/db/schema';
 import { useCreateAccount } from '@/features/accounts/api/use-create-account';
@@ -758,7 +763,7 @@ export const EditTransactionSheet = () => {
                                                                         </span>
                                                                         <Button
                                                                             type="button"
-                                                                            variant="outline"
+                                                                            variant="outlined"
                                                                             size="sm"
                                                                             onClick={() =>
                                                                                 onOpenTransaction(
@@ -848,7 +853,7 @@ export const EditTransactionSheet = () => {
                                             <div className="pb-4">
                                                 <Button
                                                     type="button"
-                                                    variant="outline"
+                                                    variant="outlined"
                                                     onClick={handleDuplicate}
                                                     disabled={
                                                         isPending ||
@@ -919,7 +924,7 @@ export const EditTransactionSheet = () => {
                                                                 </div>
                                                                 <Button
                                                                     type="button"
-                                                                    variant="outline"
+                                                                    variant="outlined"
                                                                     size="sm"
                                                                     onClick={() =>
                                                                         onOpenTransaction(
@@ -998,7 +1003,7 @@ export const EditTransactionSheet = () => {
                                                                 </div>
                                                                 <Button
                                                                     type="button"
-                                                                    variant="outline"
+                                                                    variant="outlined"
                                                                     size="sm"
                                                                     onClick={() =>
                                                                         onOpenTransaction(

--- a/features/transactions/components/new-transaction-sheet.tsx
+++ b/features/transactions/components/new-transaction-sheet.tsx
@@ -1,6 +1,11 @@
+import {
+    Tabs,
+    TabsContent,
+    TabsList,
+    TabsTrigger,
+} from '@signalco/ui-primitives/Tabs';
 import { Loader2 } from 'lucide-react';
 import { useState } from 'react';
-
 import { InvoiceImport } from '@/components/invoice-import';
 import {
     Sheet,
@@ -9,7 +14,6 @@ import {
     SheetHeader,
     SheetTitle,
 } from '@/components/ui/sheet';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useCreateCustomer } from '@/features/customers/api/use-create-customer';
 import { useCreateTag } from '@/features/tags/api/use-create-tag';
 import { useGetTags } from '@/features/tags/api/use-get-tags';

--- a/features/transactions/components/unified-edit-transaction-form.tsx
+++ b/features/transactions/components/unified-edit-transaction-form.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
 import { ChevronRight, Lock, Plus, Split, Trash, X } from 'lucide-react';
 import { Fragment, useMemo, useState } from 'react';
 import { AccountSelect } from '@/components/account-select';
@@ -11,7 +12,6 @@ import {
     QuickAssignSuggestions,
 } from '@/components/quick-assign-suggestions';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { SheetFooter } from '@/components/ui/sheet';
 import { Textarea } from '@/components/ui/textarea';
@@ -595,7 +595,7 @@ export const UnifiedEditTransactionForm = ({
                     <div className="flex justify-center">
                         <Button
                             type="button"
-                            variant="outline"
+                            variant="outlined"
                             size="sm"
                             onClick={handleToggleSplitMode}
                             disabled={isPending || !amount || amount === '0'}
@@ -618,7 +618,7 @@ export const UnifiedEditTransactionForm = ({
                         </div>
                         <Button
                             type="button"
-                            variant="ghost"
+                            variant="plain"
                             size="sm"
                             onClick={handleToggleSplitMode}
                             disabled={isPending}
@@ -635,9 +635,8 @@ export const UnifiedEditTransactionForm = ({
                                     <div className="flex justify-end mt-1">
                                         <Button
                                             type="button"
-                                            variant="ghost"
-                                            size="icon"
-                                            className="h-6 w-6"
+                                            variant="plain"
+                                            className="h-6 w-6 p-0"
                                             onClick={() =>
                                                 handleRemoveSplitEntry(index)
                                             }
@@ -770,7 +769,7 @@ export const UnifiedEditTransactionForm = ({
 
                         <Button
                             type="button"
-                            variant="outline"
+                            variant="outlined"
                             size="sm"
                             className="w-full"
                             onClick={handleAddSplitEntry}
@@ -898,7 +897,7 @@ export const UnifiedEditTransactionForm = ({
                         disabled={isPending}
                         onClick={onDelete}
                         className="w-full"
-                        variant="outline"
+                        variant="outlined"
                     >
                         <Trash className="mr-2 size-4" />
                         Delete transaction

--- a/features/transactions/components/unified-transaction-form.tsx
+++ b/features/transactions/components/unified-transaction-form.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@signalco/ui-primitives/Button';
 import { ChevronRight, Plus, Trash, X } from 'lucide-react';
 import { useEffect, useId, useMemo, useState } from 'react';
 import { AccountSelect } from '@/components/account-select';
@@ -10,7 +11,6 @@ import {
     type QuickAssignSuggestion,
     QuickAssignSuggestions,
 } from '@/components/quick-assign-suggestions';
-import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { SheetFooter } from '@/components/ui/sheet';
 import { Textarea } from '@/components/ui/textarea';
@@ -493,8 +493,8 @@ export const UnifiedTransactionForm = ({
                                 {creditEntries.length > 1 && (
                                     <Button
                                         type="button"
-                                        variant="ghost"
-                                        size="icon"
+                                        variant="plain"
+                                        className="h-10 w-10 p-0"
                                         onClick={() => removeCredit(index)}
                                         disabled={isPending}
                                     >
@@ -505,7 +505,7 @@ export const UnifiedTransactionForm = ({
                         ))}
                         <Button
                             type="button"
-                            variant="outline"
+                            variant="outlined"
                             size="sm"
                             className="w-full"
                             onClick={appendCredit}
@@ -630,8 +630,8 @@ export const UnifiedTransactionForm = ({
                                 {debitEntries.length > 1 && (
                                     <Button
                                         type="button"
-                                        variant="ghost"
-                                        size="icon"
+                                        variant="plain"
+                                        className="h-10 w-10 p-0"
                                         onClick={() => removeDebit(index)}
                                         disabled={isPending}
                                     >
@@ -642,7 +642,7 @@ export const UnifiedTransactionForm = ({
                         ))}
                         <Button
                             type="button"
-                            variant="outline"
+                            variant="outlined"
                             size="sm"
                             className="w-full"
                             onClick={appendDebit}
@@ -759,7 +759,7 @@ export const UnifiedTransactionForm = ({
                         disabled={isPending}
                         onClick={onDelete}
                         className="w-full"
-                        variant="outline"
+                        variant="outlined"
                     >
                         <Trash className="mr-2 size-4" />
                         Delete transaction

--- a/hooks/use-confirm.tsx
+++ b/hooks/use-confirm.tsx
@@ -1,6 +1,5 @@
+import { Button } from '@signalco/ui-primitives/Button';
 import { type ReactNode, useState } from 'react';
-
-import { Button } from '@/components/ui/button';
 import {
     Dialog,
     DialogContent,
@@ -45,10 +44,10 @@ export const useConfirm = (
                     <DialogDescription>{message}</DialogDescription>
                 </DialogHeader>
                 <DialogFooter className="pt-2">
-                    <Button onClick={handleCancel} variant="outline">
+                    <Button onClick={handleCancel} variant="outlined">
                         Cancel
                     </Button>
-                    <Button onClick={handleConfirm} variant="outline">
+                    <Button onClick={handleConfirm} variant="outlined">
                         Confirm
                     </Button>
                 </DialogFooter>


### PR DESCRIPTION
- Replace multiple local ui component imports with shared
  @signalco/ui-primitives equivalents (Button, Tabs, Checkbox,
  Input) across dashboard, documents, invoice import, customer form,
  and transaction sheet components.
- Update Button variants and classes to match primitive API:
  use "plain" or "outlined" where appropriate and add explicit
  sizing classes (h-8 w-8 p-0) to preserve layout.
- Move Tabs imports to use the shared Tabs primitives and remove
  duplicate local tabs imports.
- Remove redundant local ui imports to consolidate on the
  primitives package and reduce duplication.
- Keep existing behavior for invoice import actions, sheet layout,
  and document action handlers while adapting to the new component
  API.

Motivation: unify UI components on the shared primitives package
for consistent styling, reduce duplication, and simplify future
maintenance.