### PR TITLE
fix(transactions): compare numeric and reliablyAdjust update change detection to performcomparisons amount and date fields. Convert amount values toNumber before comparing to avoid false positives one value isa string. Compare dates by time (getTime()) after constructing Dateobjects to handle different string formats or object types.

### DIFF
--- a/app/api/[[...route]]/transactionsRoutes.ts
+++ b/app/api/[[...route]]/transactionsRoutes.ts
@@ -1648,12 +1648,14 @@ const app = new Hono()
                         values.debitAccountId !==
                             existingTransaction.debitAccountId) ||
                     (values.amount !== undefined &&
-                        values.amount !== existingTransaction.amount) ||
+                        Number(values.amount) !==
+                            Number(existingTransaction.amount)) ||
                     (values.payeeCustomerId !== undefined &&
                         values.payeeCustomerId !==
                             existingTransaction.payeeCustomerId) ||
                     (values.date !== undefined &&
-                        values.date !== existingTransaction.date);
+                        new Date(values.date).getTime() !==
+                            new Date(existingTransaction.date).getTime());
 
                 if (financialFieldsChanged) {
                     console.error(


### PR DESCRIPTION
This prevents unnecessary branch execution and ensures updates arerecognized only when the underlying numeric timestampactually differ.