### PR TITLE
Add CSV and Markdown exports for Accounts and Transactions (respect active filters)

### DIFF
--- a/app/(dashboard)/accounts/page.tsx
+++ b/app/(dashboard)/accounts/page.tsx
@@ -17,6 +17,7 @@ import {
     ChevronRight,
     Download,
     Expand,
+    FileText,
     EyeOff,
     Loader2,
     Minimize2,
@@ -67,9 +68,17 @@ const INITIAL_IMPORT_RESULTS = {
     meta: [] as unknown[],
 };
 
-function AccountsDataTable() {
-    const [search, setSearch] = useState('');
-    const [showClosed, setShowClosed] = useState(false);
+function AccountsDataTable({
+    search,
+    onSearchChange,
+    showClosed,
+    onShowClosedChange,
+}: {
+    search: string;
+    onSearchChange: (value: string) => void;
+    showClosed: boolean;
+    onShowClosedChange: (value: boolean) => void;
+}) {
     const [expandedAccounts, setExpandedAccounts] = useState<Set<string>>(
         new Set(),
     );
@@ -198,7 +207,7 @@ function AccountsDataTable() {
                                 placeholder={`Filter accounts...`}
                                 value={search}
                                 onChange={(event) =>
-                                    setSearch(event.target.value)
+                                    onSearchChange(event.target.value)
                                 }
                                 className="max-w-sm"
                             />
@@ -215,7 +224,7 @@ function AccountsDataTable() {
                                     id="show-closed"
                                     checked={showClosed}
                                     onCheckedChange={(checked) =>
-                                        setShowClosed(checked === true)
+                                        onShowClosedChange(checked === true)
                                     }
                                 />
                             </div>
@@ -475,15 +484,18 @@ export default function AccountsPage() {
         INITIAL_IMPORT_RESULTS,
     );
     const [bulkDeleteMode, setBulkDeleteMode] = useState(false);
+    const [search, setSearch] = useState('');
+    const [showClosed, setShowClosed] = useState(false);
     const newAccount = useNewAccount();
     const yearClosingWizard = useYearClosingWizard();
     const createAccounts = useBulkCreateAccounts();
     const accountsQuery = useGetAccounts({
+        search,
         pageSize: 9999,
-        showClosed: true,
+        showClosed,
     });
 
-    const exportAccountsToCSV = useCallback(() => {
+    const exportAccounts = useCallback((format: 'csv' | 'md') => {
         const accounts = accountsQuery.data;
         if (!accounts || accounts.length === 0) {
             toast.error('No accounts to export');
@@ -497,19 +509,9 @@ export default function AccountsPage() {
             return codeA.localeCompare(codeB);
         });
 
-        // CSV header
-        const headers = [
-            'Code',
-            'Name',
-            'Status',
-            'OpeningBalance',
-            'AccountClass',
-        ];
-
-        // Convert accounts to CSV rows
         const rows = sortedAccounts.map((account) => {
             // Force code to be treated as text in Excel by using ="value" format to preserve leading zeros
-            const code = account.code ? `="${account.code}"` : '';
+            const code = account.code ?? '';
             const name =
                 account.name.includes(',') || account.name.includes('"')
                     ? `"${account.name.replace(/"/g, '""')}"`
@@ -518,31 +520,43 @@ export default function AccountsPage() {
             // Convert milliunits to units (divide by 1000)
             const openingBalance = (account.openingBalance / 1000).toFixed(2);
             const accountClass = account.accountClass ?? '';
-            return [code, name, status, openingBalance, accountClass].join(',');
+            return { code, name, status, openingBalance, accountClass };
         });
-
-        // Combine header and rows
-        const csvContent = [headers.join(','), ...rows].join('\n');
-
-        // Create and download the file with UTF-8 BOM for proper encoding
-        const BOM = '\uFEFF';
-        const blob = new Blob([BOM + csvContent], {
-            type: 'text/csv;charset=utf-8;',
-        });
+        const datePart = new Date().toISOString().split('T')[0];
+        let blob: Blob;
+        let extension: 'csv' | 'md';
+        if (format === 'csv') {
+            const headers = ['Code', 'Name', 'Status', 'OpeningBalance', 'AccountClass'];
+            const csvRows = rows.map((row) => {
+                const code = row.code ? `="${row.code}"` : '';
+                return [code, row.name, row.status, row.openingBalance, row.accountClass].join(',');
+            });
+            const csvContent = [headers.join(','), ...csvRows].join('\n');
+            blob = new Blob(['\uFEFF' + csvContent], { type: 'text/csv;charset=utf-8;' });
+            extension = 'csv';
+        } else {
+            const markdownContent = [
+                '| Code | Name | Status | Opening Balance | Account Class |',
+                '|---|---|---|---:|---|',
+                ...rows.map(
+                    (row) =>
+                        `| ${row.code || '-'} | ${row.name || '-'} | ${row.status} | ${row.openingBalance} | ${row.accountClass || '-'} |`,
+                ),
+            ].join('\n');
+            blob = new Blob([markdownContent], { type: 'text/markdown;charset=utf-8;' });
+            extension = 'md';
+        }
         const url = URL.createObjectURL(blob);
         const link = document.createElement('a');
         link.setAttribute('href', url);
-        link.setAttribute(
-            'download',
-            `accounts-export-${new Date().toISOString().split('T')[0]}.csv`,
-        );
+        link.setAttribute('download', `accounts-export-${datePart}.${extension}`);
         link.style.visibility = 'hidden';
         document.body.appendChild(link);
         link.click();
         document.body.removeChild(link);
         URL.revokeObjectURL(url);
 
-        toast.success(`Exported ${accounts.length} accounts to CSV`);
+        toast.success(`Exported ${accounts.length} accounts`);
     }, [accountsQuery.data]);
 
     const onImport = useCallback((results: CSVResult) => {
@@ -650,7 +664,7 @@ export default function AccountsPage() {
                                     variant="menu"
                                 />
                                 <DropdownMenuItem
-                                    onClick={exportAccountsToCSV}
+                                    onClick={() => exportAccounts('csv')}
                                     disabled={
                                         accountsQuery.isLoading ||
                                         !accountsQuery.data?.length
@@ -658,6 +672,16 @@ export default function AccountsPage() {
                                 >
                                     <Download className="mr-2 size-4" />
                                     Export CSV
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                    onClick={() => exportAccounts('md')}
+                                    disabled={
+                                        accountsQuery.isLoading ||
+                                        !accountsQuery.data?.length
+                                    }
+                                >
+                                    <FileText className="mr-2 size-4" />
+                                    Export Markdown
                                 </DropdownMenuItem>
                                 <DropdownMenuSeparator />
                                 <DropdownMenuItem
@@ -688,7 +712,12 @@ export default function AccountsPage() {
                             </div>
                         }
                     >
-                        <AccountsDataTable />
+                        <AccountsDataTable
+                            search={search}
+                            onSearchChange={setSearch}
+                            showClosed={showClosed}
+                            onShowClosedChange={setShowClosed}
+                        />
                     </Suspense>
                 </CardContent>
             </Card>

--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -8,7 +8,7 @@ import {
     CardTitle,
 } from '@signalco/ui-primitives/Card';
 import type { ColumnFiltersState } from '@tanstack/react-table';
-import { Archive, Loader2, MoreHorizontal, Plus } from 'lucide-react';
+import { Archive, Download, FileText, Loader2, MoreHorizontal, Plus } from 'lucide-react';
 import { Suspense, useState } from 'react';
 import { toast } from 'sonner';
 import { AccountFilter } from '@/components/account-filter';
@@ -29,6 +29,7 @@ import { useGetCustomers } from '@/features/customers/api/use-get-customers';
 import { lookupCustomerByIban } from '@/features/customers/api/use-lookup-customer-by-iban';
 import { useGetSettings } from '@/features/settings/api/use-get-settings';
 import { useBulkCreateTransactions } from '@/features/transactions/api/use-bulk-create-transactions';
+import { useGetTransactions } from '@/features/transactions/api/use-get-transactions';
 import { useNewTransaction } from '@/features/transactions/hooks/use-new-transaction';
 import { convertAmountToMiliunits } from '@/lib/utils';
 import { TransactionsDataTable } from './TransactionsDataTable';
@@ -315,8 +316,89 @@ export default function TransactionsPage() {
     const [variant, setVariant] = useState<VARIANTS>(VARIANTS.LIST);
     const [bulkDeleteMode, setBulkDeleteMode] = useState(false);
     const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+    const transactionsQuery = useGetTransactions();
 
     const newTransaction = useNewTransaction();
+
+    const exportTransactions = (format: 'csv' | 'md') => {
+        const transactions = transactionsQuery.data || [];
+        const payeeFilter = columnFilters.find(
+            (filter) => filter.id === 'payeeCustomerName',
+        )?.value;
+        const normalizedPayeeFilter =
+            typeof payeeFilter === 'string' ? payeeFilter.toLowerCase() : '';
+        const filteredTransactions = normalizedPayeeFilter
+            ? transactions.filter((transaction) =>
+                  (transaction.payeeCustomerName || transaction.payee || '')
+                      .toLowerCase()
+                      .includes(normalizedPayeeFilter),
+              )
+            : transactions;
+
+        if (filteredTransactions.length === 0) {
+            toast.error('No transactions to export with the current filters');
+            return;
+        }
+
+        const exportRows = filteredTransactions.map((transaction) => ({
+            date: new Date(transaction.date).toISOString().split('T')[0],
+            payee: transaction.payeeCustomerName || transaction.payee || '',
+            amount: transaction.amount.toFixed(2),
+            status: transaction.splitSummary?.status ?? transaction.status,
+            account:
+                transaction.account ||
+                transaction.creditAccount ||
+                transaction.debitAccount ||
+                '',
+            notes: transaction.notes || '',
+        }));
+
+        const filenameDate = new Date().toISOString().split('T')[0];
+        if (format === 'csv') {
+            const headers = ['Date', 'Payee', 'Amount', 'Status', 'Account', 'Notes'];
+            const escape = (value: string) =>
+                value.includes(',') || value.includes('"') || value.includes('\n')
+                    ? `"${value.replace(/"/g, '""')}"`
+                    : value;
+            const content = [
+                headers.join(','),
+                ...exportRows.map((row) =>
+                    [row.date, row.payee, row.amount, row.status, row.account, row.notes]
+                        .map((item) => escape(String(item)))
+                        .join(','),
+                ),
+            ].join('\n');
+            const blob = new Blob(['\uFEFF' + content], { type: 'text/csv;charset=utf-8;' });
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = `transactions-export-${filenameDate}.csv`;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            URL.revokeObjectURL(url);
+        } else {
+            const markdown = [
+                '| Date | Payee | Amount | Status | Account | Notes |',
+                '|---|---|---:|---|---|---|',
+                ...exportRows.map(
+                    (row) =>
+                        `| ${row.date} | ${row.payee || '-'} | ${row.amount} | ${row.status} | ${row.account || '-'} | ${row.notes || '-'} |`,
+                ),
+            ].join('\n');
+            const blob = new Blob([markdown], { type: 'text/markdown;charset=utf-8;' });
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = `transactions-export-${filenameDate}.md`;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            URL.revokeObjectURL(url);
+        }
+
+        toast.success(`Exported ${filteredTransactions.length} transactions`);
+    };
 
     const onUpload = (results: typeof INITIAL_IMPORT_RESULTS) => {
         if (!results?.data || results.data.length === 0) {
@@ -386,6 +468,20 @@ export default function TransactionsPage() {
                                     onUpload={onUpload}
                                     variant="menu"
                                 />
+                                <DropdownMenuItem
+                                    onClick={() => exportTransactions('csv')}
+                                    disabled={transactionsQuery.isLoading}
+                                >
+                                    <Download className="mr-2 h-4 w-4" />
+                                    Export CSV
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                    onClick={() => exportTransactions('md')}
+                                    disabled={transactionsQuery.isLoading}
+                                >
+                                    <FileText className="mr-2 h-4 w-4" />
+                                    Export Markdown
+                                </DropdownMenuItem>
                                 <DropdownMenuSeparator />
                                 <DropdownMenuItem
                                     onClick={() =>


### PR DESCRIPTION
### Motivation
- Provide users the ability to export the currently visible accounts and transactions in CSV or Markdown format from the overflow (`...`) menu. 
- Ensure exports reflect the active filters on each page so exports are "what you see" rather than the full dataset.

### Description
- Added CSV and Markdown export actions to the Transactions overflow menu and implemented client-side generation and download of CSV/MD files that apply the active payee column filter on top of the URL-filtered transactions (`app/(dashboard)/transactions/page.tsx`).
- Added CSV and Markdown export actions to the Accounts overflow menu and extended export logic to generate Markdown as well as CSV, preserving Excel-safe account codes (`app/(dashboard)/accounts/page.tsx`).
- Lifted account filter state (`search`, `showClosed`) to the Accounts page and passed it into `AccountsDataTable` so the export uses the same query and UI filters (visible results) as the table. 
- Minor UI/icon changes: imported `Download` and `FileText` icons and wired the new menu items with toast feedback on success or when no data matches filters.

### Testing
- Ran `pnpm -s exec tsc --noEmit` to validate types and the build, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25279b500832f8223fbbf9a44f8b9)