### PR TITLE
Add reusable issue delivery skills

### DIFF
--- a/.codex/skills/issue-implementation-worker/SKILL.md
+++ b/.codex/skills/issue-implementation-worker/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: issue-implementation-worker
+description: Implement one feature-agnostic GitHub issue through a tested pull request. Use when Codex is assigned a specific issue or PR-sized slice and must inspect the codebase, create or use a branch, make scoped code changes, run verification, open/update the PR, address comments, and ensure CI is passing.
+---
+
+# Issue Implementation Worker
+
+## Purpose
+
+Implement exactly one issue-sized change with production-quality scope control. The issue is the contract; the codebase determines the implementation shape.
+
+## Intake
+
+Before editing, resolve:
+
+- Repository and issue number
+- Base branch and working branch
+- Acceptance criteria and explicit non-goals
+- Dependencies or blocked-by issues
+- Expected verification commands
+- Existing local changes that must be preserved
+
+If the issue is blocked, do not implement around the blocker. Report the blocker and wait for the coordinator or user to advance it.
+
+## Implementation Workflow
+
+1. Inspect before changing:
+   - Read the relevant routes, schema, components, tests, docs, and existing helpers.
+   - Prefer repo patterns over new abstractions.
+   - Identify the smallest coherent change that satisfies the issue.
+
+2. Edit deliberately:
+   - Keep the write set scoped to the issue.
+   - Avoid unrelated refactors and metadata churn.
+   - Preserve user or coworker changes in the working tree.
+   - Add comments only for non-obvious logic.
+
+3. Verify locally:
+   - Run the narrowest meaningful tests first.
+   - Run broader checks when shared behavior, schema, public APIs, or user flows change.
+   - If a check cannot run, record why and what risk remains.
+
+4. Prepare the PR:
+   - Commit with a concise message tied to the issue.
+   - Push the branch.
+   - Open a PR linked to the issue.
+   - Include summary, verification, risks, and rollout notes.
+   - Enable auto-merge when requested and available.
+
+5. Address review and CI:
+   - Fetch PR comments and review threads.
+   - Patch actionable feedback on the same branch.
+   - Inspect CI logs for failures and fix deterministic failures.
+   - Rerun failed jobs only when the evidence points to flakes or infrastructure.
+   - Leave the PR in a state where CI passes and comments are resolved or clearly answered.
+
+## PR Body Template
+
+```markdown
+## Summary
+
+- TBD
+
+## Verification
+
+- TBD
+
+## Risk
+
+- TBD
+
+Closes #<issue>
+```
+
+Use `Closes` only when the PR fully satisfies the issue. Use `Refs` when the PR is partial or preparatory.
+
+## Completion Criteria
+
+The issue is done only when:
+
+- The PR implements all acceptance criteria.
+- Local verification has run or a gap is explicitly documented.
+- CI is passing.
+- Actionable review comments are addressed.
+- The PR is merged or auto-merge is enabled and waiting only for required checks/reviews.

--- a/.codex/skills/issue-implementation-worker/agents/openai.yaml
+++ b/.codex/skills/issue-implementation-worker/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Issue Implementation Worker"
+  short_description: "Implement one issue through a verified PR"
+  default_prompt: "Use $issue-implementation-worker to implement this GitHub issue through a tested pull request."

--- a/.codex/skills/issue-pr-coordinator/SKILL.md
+++ b/.codex/skills/issue-pr-coordinator/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: issue-pr-coordinator
+description: Coordinate a feature-agnostic implementation effort from GitHub issues into one pull request per issue, using Codex threads or subagents when explicitly requested or useful. Use when Codex needs to plan dependency order, create or steer worker threads, track PR comments, enable auto-merge, monitor CI, keep issue/PR state aligned, and verify that all related PRs are merged.
+---
+
+# Issue PR Coordinator
+
+## Purpose
+
+Drive a multi-issue delivery effort without encoding feature-specific architecture. Treat each issue as the source of truth, preserve its acceptance criteria, and coordinate one reviewed, passing, merged PR per issue.
+
+## Operating Rules
+
+- Resolve the repository, umbrella issue, subissues, dependency graph, base branch, and merge policy before starting implementation.
+- Keep the plan issue-agnostic: sequence work by dependencies, risk, and blast radius, not by assumed domain details.
+- Use separate branches and worktrees for parallel implementation when write scopes do not overlap.
+- Start Codex threads only when the user asked for background threads or persistent handoff. Use subagents only for bounded work that can run in parallel.
+- Never merge or mark complete until tests, CI, PR comments, and requested verification are handled.
+- Keep issue bodies, PR bodies, branch names, and final summaries linked by issue number.
+
+## Coordination Workflow
+
+1. Build the delivery map:
+   - List the umbrella issue, subissues, dependency relationships, and open questions.
+   - Mark each issue as blocked, unblocked, in progress, in review, merged, or needs follow-up.
+   - Identify the smallest first PR that improves future delivery, such as shared tooling or skills, when requested.
+
+2. Prepare workers:
+   - Give each worker exactly one issue number and one branch.
+   - Include acceptance criteria, dependency constraints, expected verification, and files/modules likely in scope.
+   - Tell workers they are not alone in the codebase and must not revert unrelated changes.
+   - Ask workers to return changed files, tests run, PR link, unresolved risks, and any follow-up needed.
+
+3. Open one PR per issue:
+   - Name branches with the repo convention, usually `feat/<short-issue-slug>`.
+   - Use a PR body with: linked issue, summary, verification, risk, and rollout notes.
+   - Link the issue with `Closes #<issue>` only when the PR fully satisfies that issue.
+   - Enable auto-merge after the PR exists if the repository supports it and the user requested it.
+
+4. Monitor feedback:
+   - Check PR conversation comments, inline review threads, requested changes, and CI status.
+   - Treat actionable comments as work items. Patch the PR branch, rerun tests, and respond or resolve when addressed.
+   - Inspect CI logs for deterministic failures. Rerun once only when evidence suggests flakes or infrastructure failures.
+
+5. Advance dependencies:
+   - Start dependent issues only after their blockers are merged or after confirming the dependency is not actually required.
+   - Rebase or update dependent branches after blockers merge when shared files or contracts changed.
+   - Keep the umbrella issue updated with merged PRs and remaining blockers when the platform does not provide native dependencies.
+
+6. Verify completion:
+   - Confirm every issue PR is merged.
+   - Confirm CI is passing on merged commits or the target branch.
+   - Confirm PR comments and review threads are resolved or intentionally documented.
+   - Confirm user-facing or operational verification was performed for the complete flow.
+
+## PR Tracking Checklist
+
+For each issue, track:
+
+- Issue number and URL
+- Branch name
+- PR number and URL
+- Blocked-by issues
+- Local tests run
+- CI state
+- Open PR comments or review threads
+- Merge state
+- Follow-up issues
+
+## Escalation
+
+Stop and ask only when a decision would change product behavior, security posture, data retention, billing, destructive migration strategy, or merge policy. Otherwise, make conservative implementation choices and keep delivery moving.

--- a/.codex/skills/issue-pr-coordinator/agents/openai.yaml
+++ b/.codex/skills/issue-pr-coordinator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Issue PR Coordinator"
+  short_description: "Coordinate issue trees into verified PRs"
+  default_prompt: "Use $issue-pr-coordinator to plan and drive a GitHub issue tree through reviewed, passing PRs."


### PR DESCRIPTION
## Summary

- Add a feature-agnostic `issue-pr-coordinator` skill for coordinating issue trees through one PR per issue.
- Add a feature-agnostic `issue-implementation-worker` skill for implementing a single issue through a verified PR.
- Include UI metadata for both skills under `agents/openai.yaml`.

## Verification

- `PYTHONPATH=/tmp/codex-skill-validate-pyyaml python3 /Users/aleks/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/issue-pr-coordinator`
- `PYTHONPATH=/tmp/codex-skill-validate-pyyaml python3 /Users/aleks/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/issue-implementation-worker`
- `git diff --cached --check`

## Risk

- Documentation-only repo-local skills; no app runtime behavior changes.

Refs #124