### PR TITLE
Instrument mutation endpoints for audit events

### DIFF
--- a/app/api/[[...route]]/route.ts
+++ b/app/api/[[...route]]/route.ts
@@ -2,6 +2,8 @@ import { Redis } from '@upstash/redis';
 import { type Context, Hono } from 'hono';
 import { handle } from 'hono/vercel';
 
+import { auditMutationMiddleware } from '@/lib/audit-hono';
+
 import accountingPeriodsRoutes from './accountingPeriodsRoutes';
 import accountsRoutes from './accountsRoutes';
 import bankingRoutes from './bankingRoutes';
@@ -84,6 +86,8 @@ app.use('*', async (ctx, next) => {
 
     await next();
 });
+
+app.use('*', auditMutationMiddleware);
 
 const routes = app
     .route('/accounting-periods', accountingPeriodsRoutes)

--- a/app/api/stripe/cron/route.ts
+++ b/app/api/stripe/cron/route.ts
@@ -11,6 +11,7 @@ import {
     transactions,
     transactionTags,
 } from '@/db/schema';
+import { writeAuditEvent } from '@/lib/audit';
 import { safeDecrypt } from '@/lib/crypto';
 
 // Verify cron secret to prevent unauthorized access
@@ -118,6 +119,26 @@ const processStripeCharge = async (
         userId,
         'Transaction created from Stripe hourly sync',
     );
+
+    await writeAuditEvent(db, {
+        userId,
+        actorType: 'integration',
+        action: 'create',
+        resourceType: 'transaction',
+        resourceId: transactionId,
+        resourceLabel: payee,
+        after: {
+            id: transactionId,
+            amount,
+            payee,
+            status: 'pending',
+            stripePaymentId: charge.id,
+        },
+        sourceMetadata: {
+            source: 'stripe_cron',
+            stripePaymentId: charge.id,
+        },
+    });
 
     return { id: transactionId, created: true };
 };
@@ -230,6 +251,24 @@ export async function GET(request: NextRequest) {
                     .update(stripeSettings)
                     .set(updateData)
                     .where(eq(stripeSettings.userId, settings.userId));
+
+                await writeAuditEvent(db, {
+                    userId: settings.userId,
+                    actorType: 'integration',
+                    action: 'sync',
+                    resourceType: 'stripe',
+                    resourceId: `stripe-cron:${settings.userId}`,
+                    after: {
+                        created,
+                        skipped,
+                        lastSyncAt: updateData.lastSyncAt,
+                        syncFromDate: updateData.syncFromDate ?? null,
+                    },
+                    sourceMetadata: {
+                        source: 'stripe_cron',
+                        syncStartTime,
+                    },
+                });
 
                 totalCreated += created;
                 totalSkipped += skipped;

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -11,6 +11,7 @@ import {
     transactions,
     transactionTags,
 } from '@/db/schema';
+import { writeAuditEvent } from '@/lib/audit';
 import { safeDecrypt } from '@/lib/crypto';
 
 // Helper function to record status change
@@ -126,6 +127,26 @@ const processStripePayment = async (
         userId,
         'Transaction created from Stripe payment',
     );
+
+    await writeAuditEvent(db, {
+        userId,
+        actorType: 'integration',
+        action: 'create',
+        resourceType: 'transaction',
+        resourceId: transactionId,
+        resourceLabel: payee,
+        after: {
+            id: transactionId,
+            amount,
+            payee,
+            status: 'pending',
+            stripePaymentId: charge.id,
+        },
+        sourceMetadata: {
+            source: 'stripe_webhook',
+            stripePaymentId: charge.id,
+        },
+    });
 
     console.log(
         `[Stripe Webhook] Created transaction ${transactionId} for payment ${charge.id}`,
@@ -305,6 +326,27 @@ export async function POST(request: NextRequest) {
                         'Refund transaction created from Stripe',
                     );
 
+                    await writeAuditEvent(db, {
+                        userId: verifiedSettings.userId,
+                        actorType: 'integration',
+                        action: 'create',
+                        resourceType: 'transaction',
+                        resourceId: transactionId,
+                        resourceLabel: existingTransaction.payee,
+                        after: {
+                            id: transactionId,
+                            amount: -refundAmount,
+                            payee: existingTransaction.payee,
+                            status: 'pending',
+                            stripePaymentId: `refund_${charge.id}`,
+                        },
+                        sourceMetadata: {
+                            source: 'stripe_webhook',
+                            stripeEventType: event.type,
+                            stripePaymentId: charge.id,
+                        },
+                    });
+
                     console.log(
                         `[Stripe Webhook] Created refund transaction ${transactionId} for payment ${charge.id}`,
                     );
@@ -319,10 +361,29 @@ export async function POST(request: NextRequest) {
         }
 
         // Update last sync timestamp
+        const lastSyncAt = new Date();
+
         await db
             .update(stripeSettings)
-            .set({ lastSyncAt: new Date() })
+            .set({ lastSyncAt })
             .where(eq(stripeSettings.userId, verifiedSettings.userId));
+
+        await writeAuditEvent(db, {
+            userId: verifiedSettings.userId,
+            actorType: 'integration',
+            action: 'integration_event',
+            resourceType: 'stripe',
+            resourceId: event.id,
+            resourceLabel: event.type,
+            after: {
+                lastSyncAt,
+            },
+            sourceMetadata: {
+                source: 'stripe_webhook',
+                stripeEventId: event.id,
+                stripeEventType: event.type,
+            },
+        });
 
         return NextResponse.json({ received: true });
     } catch (error) {

--- a/lib/audit-hono.ts
+++ b/lib/audit-hono.ts
@@ -1,0 +1,56 @@
+import { getAuth } from '@hono/clerk-auth';
+import type { Context, MiddlewareHandler } from 'hono';
+
+import { db } from '@/db/drizzle';
+import { writeAuditEvent } from '@/lib/audit';
+import { buildMutationAuditEvents } from '@/lib/audit-route-core';
+
+const getAuthenticatedUserId = (ctx: Context) => {
+    try {
+        return getAuth(ctx)?.userId ?? null;
+    } catch {
+        return null;
+    }
+};
+
+const readJsonResponse = async (ctx: Context) => {
+    const contentType = ctx.res.headers.get('content-type') ?? '';
+    if (!contentType.includes('application/json')) {
+        return undefined;
+    }
+
+    try {
+        return await ctx.res.clone().json();
+    } catch {
+        return undefined;
+    }
+};
+
+export const auditMutationMiddleware: MiddlewareHandler = async (ctx, next) => {
+    await next();
+
+    const userId = getAuthenticatedUserId(ctx);
+    if (!userId) {
+        return;
+    }
+
+    const responseJson = await readJsonResponse(ctx);
+    const requestId =
+        ctx.req.header('x-request-id') ??
+        ctx.req.header('x-vercel-id') ??
+        ctx.req.header('cf-ray') ??
+        null;
+
+    const events = buildMutationAuditEvents({
+        method: ctx.req.method,
+        path: ctx.req.path,
+        status: ctx.res.status,
+        userId,
+        requestId,
+        responseJson,
+    });
+
+    for (const event of events) {
+        await writeAuditEvent(db, event);
+    }
+};

--- a/lib/audit-route-core.ts
+++ b/lib/audit-route-core.ts
@@ -1,0 +1,194 @@
+import { createId } from '@paralleldrive/cuid2';
+import type {
+    AuditAction,
+    AuditActorType,
+    AuditEventInput,
+} from './audit-core';
+
+type MutationAuditContext = {
+    method: string;
+    path: string;
+    status: number;
+    userId: string;
+    actorUserId?: string | null;
+    actorType?: AuditActorType;
+    requestId?: string | null;
+    responseJson?: unknown;
+    source?: string;
+};
+
+const mutationMethods = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+const collectionActionSegments = new Set([
+    'bulk-create',
+    'bulk-delete',
+    'generate-upload-url',
+    'generate-standalone-upload-url',
+    'standalone',
+    'sync',
+    'test',
+    'types',
+]);
+
+const getPathSegments = (path: string) =>
+    path
+        .split('?')[0]
+        .split('/')
+        .filter(Boolean)
+        .filter((segment) => segment !== 'api');
+
+const getRecordId = (value: unknown): string | null => {
+    if (!value || typeof value !== 'object' || !('id' in value)) {
+        return null;
+    }
+
+    const id = (value as { id?: unknown }).id;
+    return typeof id === 'string' && id ? id : null;
+};
+
+const getResponseData = (responseJson: unknown) => {
+    if (
+        responseJson &&
+        typeof responseJson === 'object' &&
+        'data' in responseJson
+    ) {
+        return (responseJson as { data?: unknown }).data;
+    }
+
+    return undefined;
+};
+
+export const shouldAuditHttpMutation = (method: string, status: number) =>
+    mutationMethods.has(method.toUpperCase()) && status >= 200 && status < 400;
+
+export const inferAuditAction = (method: string, path: string): AuditAction => {
+    const segments = getPathSegments(path);
+    const methodName = method.toUpperCase();
+
+    if (segments.includes('sync')) {
+        return 'sync';
+    }
+
+    if (segments.includes('link')) {
+        return 'link';
+    }
+
+    if (segments.includes('unlink')) {
+        return 'unlink';
+    }
+
+    if (segments.includes('bulk-delete') || methodName === 'DELETE') {
+        return 'delete';
+    }
+
+    if (methodName === 'PATCH' || methodName === 'PUT') {
+        return 'update';
+    }
+
+    if (segments.includes('test') || segments.includes('generate-upload-url')) {
+        return 'integration_event';
+    }
+
+    return 'create';
+};
+
+export const inferAuditResourceType = (path: string) =>
+    getPathSegments(path)[0]?.replaceAll('-', '_') ?? 'unknown';
+
+export const inferAuditResourceId = (
+    path: string,
+    responseJson: unknown,
+    requestId: string,
+) => {
+    const responseData = getResponseData(responseJson);
+    const responseId = Array.isArray(responseData)
+        ? null
+        : getRecordId(responseData);
+
+    if (responseId) {
+        return responseId;
+    }
+
+    const [, maybeId] = getPathSegments(path);
+    if (maybeId && !collectionActionSegments.has(maybeId)) {
+        return maybeId;
+    }
+
+    return `operation:${requestId}`;
+};
+
+export const getAuditResponseRecords = (responseJson: unknown) => {
+    const responseData = getResponseData(responseJson);
+
+    if (Array.isArray(responseData)) {
+        return responseData.filter((entry) => getRecordId(entry));
+    }
+
+    return getRecordId(responseData) ? [responseData] : [];
+};
+
+export const buildMutationAuditEvents = ({
+    method,
+    path,
+    status,
+    userId,
+    actorUserId = userId,
+    actorType = 'user',
+    requestId = createId(),
+    responseJson,
+    source = 'hono_route',
+}: MutationAuditContext): AuditEventInput[] => {
+    if (!shouldAuditHttpMutation(method, status)) {
+        return [];
+    }
+
+    const resolvedRequestId = requestId || createId();
+    const action = inferAuditAction(method, path);
+    const resourceType = inferAuditResourceType(path);
+    const sourceMetadata = {
+        method,
+        path,
+        status,
+        source,
+    };
+    const events: AuditEventInput[] = [
+        {
+            userId,
+            actorUserId,
+            actorType,
+            action,
+            resourceType,
+            resourceId: inferAuditResourceId(
+                path,
+                responseJson,
+                resolvedRequestId,
+            ),
+            sourceMetadata: {
+                ...sourceMetadata,
+                auditLevel: 'operation',
+            },
+            requestId: resolvedRequestId,
+        },
+    ];
+
+    for (const record of getAuditResponseRecords(responseJson)) {
+        const recordId = getRecordId(record);
+        if (!recordId) continue;
+
+        events.push({
+            userId,
+            actorUserId,
+            actorType,
+            action,
+            resourceType,
+            resourceId: recordId,
+            after: record,
+            sourceMetadata: {
+                ...sourceMetadata,
+                auditLevel: 'record',
+            },
+            requestId: resolvedRequestId,
+        });
+    }
+
+    return events;
+};

--- a/tests/audit.test.mjs
+++ b/tests/audit.test.mjs
@@ -8,6 +8,12 @@ import {
     redactAuditPayload,
     runAuditedMutation,
 } from '../lib/audit-core.ts';
+import {
+    buildMutationAuditEvents,
+    inferAuditAction,
+    inferAuditResourceId,
+    inferAuditResourceType,
+} from '../lib/audit-route-core.ts';
 
 test('redactAuditPayload redacts nested sensitive fields', () => {
     assert.deepEqual(
@@ -149,4 +155,45 @@ test('runAuditedMutation lets transaction runner roll back callback failures', a
     );
 
     assert.deepEqual(calls, ['begin', 'rollback']);
+});
+
+test('inferAuditAction maps common mutation routes', () => {
+    assert.equal(inferAuditAction('POST', '/api/transactions'), 'create');
+    assert.equal(
+        inferAuditAction('POST', '/api/transactions/bulk-delete'),
+        'delete',
+    );
+    assert.equal(inferAuditAction('PATCH', '/api/customers/cus_1'), 'update');
+    assert.equal(inferAuditAction('DELETE', '/api/documents/doc_1'), 'delete');
+    assert.equal(inferAuditAction('POST', '/api/documents/doc_1/link'), 'link');
+    assert.equal(inferAuditAction('POST', '/api/stripe/sync'), 'sync');
+});
+
+test('buildMutationAuditEvents creates operation and record events', () => {
+    const events = buildMutationAuditEvents({
+        method: 'POST',
+        path: '/api/accounts/bulk-create',
+        status: 201,
+        userId: 'user_1',
+        requestId: 'req_1',
+        responseJson: {
+            data: [{ id: 'acc_1', name: 'Checking' }],
+        },
+    });
+
+    assert.equal(events.length, 2);
+    assert.equal(events[0]?.resourceId, 'operation:req_1');
+    assert.equal(events[1]?.resourceId, 'acc_1');
+    assert.deepEqual(events[1]?.after, { id: 'acc_1', name: 'Checking' });
+});
+
+test('audit route inference resolves resource type and path ids', () => {
+    assert.equal(
+        inferAuditResourceType('/api/document-types/dt_1'),
+        'document_types',
+    );
+    assert.equal(
+        inferAuditResourceId('/api/customers/cus_1', undefined, 'req_1'),
+        'cus_1',
+    );
 });


### PR DESCRIPTION
## Summary

- Adds a central Hono middleware that records audit events for successful POST/PUT/PATCH/DELETE app mutations.
- Adds route inference helpers for mutation action/resource metadata and record-level audit payload capture from JSON responses.
- Adds explicit integration audit events for Stripe webhook-created transactions, refunds, webhook processing, and cron syncs.
- Extends audit tests to cover mutation route inference and generated operation/record events.

## Verification

- `PATH=/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/biome check lib/audit-route-core.ts lib/audit-hono.ts 'app/api/[[...route]]/route.ts' app/api/stripe/webhook/route.ts app/api/stripe/cron/route.ts tests/audit.test.mjs`
- `PATH=/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node --experimental-strip-types --test tests/audit.test.mjs`
- `PATH=/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --check`

## Risk

- The central middleware records successful operations and returned records, but fine-grained before/after/revert behavior remains in the dependent audit-history and recoverability issues.
- Audit writes currently use the database client directly because transaction-capable audited mutations are blocked by the Neon HTTP transaction limitation documented in the foundation PR.

Closes #126