### PR TITLE
Complete document trash recovery lifecycle

### DIFF
--- a/app/api/[[...route]]/documentTypesRoutes.ts
+++ b/app/api/[[...route]]/documentTypesRoutes.ts
@@ -7,6 +7,37 @@ import { z } from 'zod';
 
 import { db } from '@/db/drizzle';
 import { documentTypes, insertDocumentTypeSchema } from '@/db/schema';
+import { writeAuditEvent } from '@/lib/audit';
+
+const writeDocumentTypeAuditEvent = async ({
+    action,
+    userId,
+    before,
+    after,
+    source,
+}: {
+    action: 'create' | 'update' | 'delete';
+    userId: string;
+    before?: typeof documentTypes.$inferSelect | null;
+    after?: typeof documentTypes.$inferSelect | null;
+    source: string;
+}) => {
+    const resource = after ?? before;
+    if (!resource) return;
+
+    await writeAuditEvent(db, {
+        userId,
+        actorUserId: userId,
+        actorType: 'user',
+        action,
+        resourceType: 'document_type',
+        resourceId: resource.id,
+        resourceLabel: resource.name,
+        before: before ?? null,
+        after: after ?? null,
+        sourceMetadata: { source },
+    });
+};
 
 const app = new Hono()
     // Get all document types for user
@@ -75,6 +106,13 @@ const app = new Hono()
                     })
                     .returning();
 
+                await writeDocumentTypeAuditEvent({
+                    action: 'create',
+                    userId: auth.userId,
+                    after: data,
+                    source: 'document_types_create',
+                });
+
                 return ctx.json({ data }, 201);
             } catch (error) {
                 console.error('Error creating document type:', error);
@@ -108,6 +146,20 @@ const app = new Hono()
             }
 
             try {
+                const [before] = await db
+                    .select()
+                    .from(documentTypes)
+                    .where(
+                        and(
+                            eq(documentTypes.id, id),
+                            eq(documentTypes.userId, auth.userId),
+                        ),
+                    );
+
+                if (!before) {
+                    return ctx.json({ error: 'Document type not found.' }, 404);
+                }
+
                 const [data] = await db
                     .update(documentTypes)
                     .set(values)
@@ -119,9 +171,13 @@ const app = new Hono()
                     )
                     .returning();
 
-                if (!data) {
-                    return ctx.json({ error: 'Document type not found.' }, 404);
-                }
+                await writeDocumentTypeAuditEvent({
+                    action: 'update',
+                    userId: auth.userId,
+                    before,
+                    after: data,
+                    source: 'document_types_update',
+                });
 
                 return ctx.json({ data });
             } catch (error) {
@@ -146,6 +202,20 @@ const app = new Hono()
         try {
             // Check if document type is in use
             // This would require a check in the documents table
+            const [before] = await db
+                .select()
+                .from(documentTypes)
+                .where(
+                    and(
+                        eq(documentTypes.id, id),
+                        eq(documentTypes.userId, auth.userId),
+                    ),
+                );
+
+            if (!before) {
+                return ctx.json({ error: 'Document type not found.' }, 404);
+            }
+
             const [data] = await db
                 .delete(documentTypes)
                 .where(
@@ -156,9 +226,13 @@ const app = new Hono()
                 )
                 .returning();
 
-            if (!data) {
-                return ctx.json({ error: 'Document type not found.' }, 404);
-            }
+            await writeDocumentTypeAuditEvent({
+                action: 'delete',
+                userId: auth.userId,
+                before,
+                after: null,
+                source: 'document_types_delete',
+            });
 
             return ctx.json({ data });
         } catch (error) {

--- a/app/api/[[...route]]/documentsRoutes.ts
+++ b/app/api/[[...route]]/documentsRoutes.ts
@@ -2,18 +2,25 @@ import { clerkMiddleware, getAuth } from '@hono/clerk-auth';
 import { zValidator } from '@hono/zod-validator';
 import { createId } from '@paralleldrive/cuid2';
 import { aliasedTable, and, desc, eq, gte, isNull, lte, or } from 'drizzle-orm';
-import { Hono } from 'hono';
+import { type Context, Hono } from 'hono';
 import { z } from 'zod';
 
 import { db } from '@/db/drizzle';
 import { accounts, documents, documentTypes, transactions } from '@/db/schema';
+import { writeAuditEvent } from '@/lib/audit';
 import {
+    deleteDocument,
     generateDownloadUrl,
     generateStandaloneUploadUrl,
     generateUploadUrl,
     verifyStoragePathOwnership,
 } from '@/lib/azure-storage';
 import { categorizeDocument } from '@/lib/document-categorization';
+import {
+    createDocumentRestorePatch,
+    createDocumentSoftDeletePatch,
+    DOCUMENT_SOFT_DELETE_BLOB_POLICY,
+} from '@/lib/document-lifecycle';
 
 const getAuthorizedTransaction = async (
     transactionId: string,
@@ -53,6 +60,133 @@ const getAuthorizedTransaction = async (
         );
 
     return transaction;
+};
+
+const documentLifecycleSchema = z.object({
+    reason: z.string().max(500).optional(),
+});
+
+const documentPurgeSchema = documentLifecycleSchema.extend({
+    confirm: z.literal(true),
+});
+
+const readJsonPayload = async (ctx: Context) => {
+    const contentType = ctx.req.header('content-type') ?? '';
+    if (!contentType.includes('application/json')) {
+        return {};
+    }
+
+    try {
+        return await ctx.req.json();
+    } catch {
+        return {};
+    }
+};
+
+const readLifecycleReason = async (ctx: Context) => {
+    const parsed = documentLifecycleSchema.safeParse(
+        await readJsonPayload(ctx),
+    );
+    return parsed.success ? (parsed.data.reason ?? null) : null;
+};
+
+const readPurgePayload = async (ctx: Context) =>
+    documentPurgeSchema.safeParse(await readJsonPayload(ctx));
+
+const parseDeletedMode = (ctx: Context) => {
+    const parsed = z
+        .enum(['include', 'only'])
+        .optional()
+        .safeParse(ctx.req.query('deleted'));
+    return parsed.success ? parsed.data : undefined;
+};
+
+const documentDeletedFilter = (deleted?: 'include' | 'only') => {
+    if (deleted === 'include') {
+        return undefined;
+    }
+
+    if (deleted === 'only') {
+        return eq(documents.isDeleted, true);
+    }
+
+    return eq(documents.isDeleted, false);
+};
+
+const getAuthorizedDocument = async ({
+    id,
+    userId,
+    deleted,
+}: {
+    id: string;
+    userId: string;
+    deleted?: 'include' | 'only';
+}) => {
+    const [doc] = await db
+        .select()
+        .from(documents)
+        .where(and(eq(documents.id, id), documentDeletedFilter(deleted)));
+
+    if (!doc) {
+        return null;
+    }
+
+    if (doc.uploadedBy === userId) {
+        return doc;
+    }
+
+    if (doc.transactionId) {
+        const transaction = await getAuthorizedTransaction(
+            doc.transactionId,
+            userId,
+        );
+        return transaction ? doc : null;
+    }
+
+    return null;
+};
+
+const writeDocumentAuditEvent = async ({
+    action,
+    userId,
+    before,
+    after,
+    reason,
+    source,
+}: {
+    action:
+        | 'create'
+        | 'update'
+        | 'delete'
+        | 'restore'
+        | 'purge'
+        | 'link'
+        | 'unlink';
+    userId: string;
+    before?: typeof documents.$inferSelect | null;
+    after?: typeof documents.$inferSelect | null;
+    reason?: string | null;
+    source: string;
+}) => {
+    const resource = after ?? before;
+    if (!resource) return;
+
+    await writeAuditEvent(db, {
+        userId,
+        actorUserId: userId,
+        actorType: 'user',
+        action,
+        resourceType: 'document',
+        resourceId: resource.id,
+        resourceLabel: resource.fileName,
+        before: before ?? null,
+        after: after ?? null,
+        sourceMetadata: {
+            source,
+            reason: reason ?? null,
+            blobPolicy: DOCUMENT_SOFT_DELETE_BLOB_POLICY,
+        },
+    });
 };
 
 /**
@@ -117,25 +251,31 @@ const app = new Hono()
                 from: z.string().optional(),
                 to: z.string().optional(),
                 unattached: z.string().optional(),
+                deleted: z.enum(['include', 'only']).optional(),
             }),
         ),
         async (ctx) => {
             const auth = getAuth(ctx);
-            const { documentTypeId, from, to, unattached } =
+            const { documentTypeId, from, to, unattached, deleted } =
                 ctx.req.valid('query');
 
             if (!auth?.userId) {
                 return ctx.json({ error: 'Unauthorized.' }, 401);
             }
 
-            const conditions = [
-                eq(documents.uploadedBy, auth.userId),
-                eq(documents.isDeleted, false),
-                or(
+            const conditions = [eq(documents.uploadedBy, auth.userId)];
+            const deletedFilter = documentDeletedFilter(deleted);
+            if (deletedFilter) conditions.push(deletedFilter);
+
+            if (!deleted) {
+                const activeTransactionFilter = or(
                     isNull(documents.transactionId),
                     isNull(transactions.deletedAt),
-                ),
-            ];
+                );
+                if (activeTransactionFilter) {
+                    conditions.push(activeTransactionFilter);
+                }
+            }
 
             if (documentTypeId) {
                 conditions.push(eq(documents.documentTypeId, documentTypeId));
@@ -166,6 +306,13 @@ const app = new Hono()
                     uploadedBy: documents.uploadedBy,
                     uploadedAt: documents.uploadedAt,
                     storagePath: documents.storagePath,
+                    isDeleted: documents.isDeleted,
+                    deletedAt: documents.deletedAt,
+                    deletedBy: documents.deletedBy,
+                    deleteReason: documents.deleteReason,
+                    restoredAt: documents.restoredAt,
+                    restoredBy: documents.restoredBy,
+                    restoreReason: documents.restoreReason,
                     transactionDate: transactions.date,
                     transactionPayee: transactions.payee,
                 })
@@ -194,6 +341,7 @@ const app = new Hono()
     .get('/transaction/:transactionId', clerkMiddleware(), async (ctx) => {
         const auth = getAuth(ctx);
         const { transactionId } = ctx.req.param();
+        const deleted = parseDeletedMode(ctx);
 
         if (!auth?.userId) {
             return ctx.json({ error: 'Unauthorized.' }, 401);
@@ -220,6 +368,13 @@ const app = new Hono()
                 uploadedBy: documents.uploadedBy,
                 uploadedAt: documents.uploadedAt,
                 storagePath: documents.storagePath,
+                isDeleted: documents.isDeleted,
+                deletedAt: documents.deletedAt,
+                deletedBy: documents.deletedBy,
+                deleteReason: documents.deleteReason,
+                restoredAt: documents.restoredAt,
+                restoredBy: documents.restoredBy,
+                restoreReason: documents.restoreReason,
             })
             .from(documents)
             .leftJoin(
@@ -229,7 +384,7 @@ const app = new Hono()
             .where(
                 and(
                     eq(documents.transactionId, transactionId),
-                    eq(documents.isDeleted, false),
+                    documentDeletedFilter(deleted),
                 ),
             );
 
@@ -397,6 +552,13 @@ const app = new Hono()
                     })
                     .returning();
 
+                await writeDocumentAuditEvent({
+                    action: 'create',
+                    userId: auth.userId,
+                    after: data,
+                    source: 'documents_upload',
+                });
+
                 return ctx.json({ data }, 201);
             } catch (error) {
                 console.error('Error saving document metadata:', error);
@@ -409,40 +571,21 @@ const app = new Hono()
     .get('/:id/download-url', clerkMiddleware(), async (ctx) => {
         const auth = getAuth(ctx);
         const { id } = ctx.req.param();
+        const deleted = parseDeletedMode(ctx);
 
         if (!auth?.userId) {
             return ctx.json({ error: 'Unauthorized.' }, 401);
         }
 
         try {
-            const [doc] = await db
-                .select({
-                    storagePath: documents.storagePath,
-                    fileName: documents.fileName,
-                    transactionId: documents.transactionId,
-                })
-                .from(documents)
-                .where(eq(documents.id, id));
+            const doc = await getAuthorizedDocument({
+                id,
+                userId: auth.userId,
+                deleted,
+            });
 
             if (!doc) {
                 return ctx.json({ error: 'Document not found.' }, 404);
-            }
-
-            // Verify ownership through transaction
-            if (!doc.transactionId) {
-                return ctx.json(
-                    { error: 'Document not linked to a transaction.' },
-                    400,
-                );
-            }
-
-            const transaction = await getAuthorizedTransaction(
-                doc.transactionId,
-                auth.userId,
-            );
-
-            if (!transaction) {
-                return ctx.json({ error: 'Unauthorized.' }, 403);
             }
 
             const downloadUrl = generateDownloadUrl(doc.storagePath);
@@ -479,32 +622,13 @@ const app = new Hono()
             }
 
             try {
-                const [doc] = await db
-                    .select({
-                        transactionId: documents.transactionId,
-                    })
-                    .from(documents)
-                    .where(eq(documents.id, id));
+                const doc = await getAuthorizedDocument({
+                    id,
+                    userId: auth.userId,
+                });
 
                 if (!doc) {
                     return ctx.json({ error: 'Document not found.' }, 404);
-                }
-
-                // Verify ownership through transaction
-                if (!doc.transactionId) {
-                    return ctx.json(
-                        { error: 'Document not linked to a transaction.' },
-                        400,
-                    );
-                }
-
-                const transaction = await getAuthorizedTransaction(
-                    doc.transactionId,
-                    auth.userId,
-                );
-
-                if (!transaction) {
-                    return ctx.json({ error: 'Unauthorized.' }, 403);
                 }
 
                 // If updating document type, verify it belongs to user
@@ -536,6 +660,14 @@ const app = new Hono()
                     .where(eq(documents.id, id))
                     .returning();
 
+                await writeDocumentAuditEvent({
+                    action: 'update',
+                    userId: auth.userId,
+                    before: doc,
+                    after: updatedDoc,
+                    source: 'documents_update',
+                });
+
                 return ctx.json({ data: updatedDoc });
             } catch (error) {
                 console.error('Error updating document:', error);
@@ -554,43 +686,141 @@ const app = new Hono()
         }
 
         try {
-            const [doc] = await db
-                .select({
-                    storagePath: documents.storagePath,
-                    transactionId: documents.transactionId,
-                    uploadedBy: documents.uploadedBy,
-                })
-                .from(documents)
-                .where(eq(documents.id, id));
+            const doc = await getAuthorizedDocument({
+                id,
+                userId: auth.userId,
+            });
 
             if (!doc) {
                 return ctx.json({ error: 'Document not found.' }, 404);
             }
 
-            // Verify ownership - either through transaction or uploadedBy for standalone docs
-            if (doc.transactionId) {
-                const transaction = await getAuthorizedTransaction(
-                    doc.transactionId,
-                    auth.userId,
-                );
-
-                if (!transaction) {
-                    return ctx.json({ error: 'Unauthorized.' }, 403);
-                }
-            } else if (doc.uploadedBy !== auth.userId) {
-                return ctx.json({ error: 'Unauthorized.' }, 403);
-            }
+            const reason = await readLifecycleReason(ctx);
 
             // Soft delete the document (retain blob to avoid inconsistency)
-            await db
+            const [updatedDoc] = await db
                 .update(documents)
-                .set({ isDeleted: true })
-                .where(eq(documents.id, id));
+                .set(
+                    createDocumentSoftDeletePatch({
+                        userId: auth.userId,
+                        reason,
+                    }),
+                )
+                .where(eq(documents.id, id))
+                .returning();
 
-            return ctx.json({ data: { id } });
+            await writeDocumentAuditEvent({
+                action: 'delete',
+                userId: auth.userId,
+                before: doc,
+                after: updatedDoc,
+                reason,
+                source: 'documents_delete',
+            });
+
+            return ctx.json({ data: updatedDoc });
         } catch (error) {
             console.error('Error deleting document:', error);
             return ctx.json({ error: 'Failed to delete document' }, 500);
+        }
+    })
+
+    // Restore a deleted document
+    .post('/:id/restore', clerkMiddleware(), async (ctx) => {
+        const auth = getAuth(ctx);
+        const { id } = ctx.req.param();
+
+        if (!auth?.userId) {
+            return ctx.json({ error: 'Unauthorized.' }, 401);
+        }
+
+        try {
+            const doc = await getAuthorizedDocument({
+                id,
+                userId: auth.userId,
+                deleted: 'only',
+            });
+
+            if (!doc) {
+                return ctx.json({ error: 'Document not found.' }, 404);
+            }
+
+            const reason = await readLifecycleReason(ctx);
+            const [updatedDoc] = await db
+                .update(documents)
+                .set(
+                    createDocumentRestorePatch({
+                        userId: auth.userId,
+                        reason,
+                    }),
+                )
+                .where(eq(documents.id, id))
+                .returning();
+
+            await writeDocumentAuditEvent({
+                action: 'restore',
+                userId: auth.userId,
+                before: doc,
+                after: updatedDoc,
+                reason,
+                source: 'documents_restore',
+            });
+
+            return ctx.json({ data: updatedDoc });
+        } catch (error) {
+            console.error('Error restoring document:', error);
+            return ctx.json({ error: 'Failed to restore document' }, 500);
+        }
+    })
+
+    // Permanently purge a deleted document and its blob
+    .post('/:id/purge', clerkMiddleware(), async (ctx) => {
+        const auth = getAuth(ctx);
+        const { id } = ctx.req.param();
+
+        if (!auth?.userId) {
+            return ctx.json({ error: 'Unauthorized.' }, 401);
+        }
+
+        try {
+            const parsedPayload = await readPurgePayload(ctx);
+            if (!parsedPayload.success) {
+                return ctx.json(
+                    { error: 'Permanent purge requires confirm: true.' },
+                    400,
+                );
+            }
+
+            const doc = await getAuthorizedDocument({
+                id,
+                userId: auth.userId,
+                deleted: 'only',
+            });
+
+            if (!doc) {
+                return ctx.json({ error: 'Document not found.' }, 404);
+            }
+
+            await deleteDocument(doc.storagePath);
+
+            const [purgedDoc] = await db
+                .delete(documents)
+                .where(eq(documents.id, id))
+                .returning();
+
+            await writeDocumentAuditEvent({
+                action: 'purge',
+                userId: auth.userId,
+                before: doc,
+                after: null,
+                reason: parsedPayload.data.reason ?? null,
+                source: 'documents_purge',
+            });
+
+            return ctx.json({ data: purgedDoc });
+        } catch (error) {
+            console.error('Error purging document:', error);
+            return ctx.json({ error: 'Failed to purge document' }, 500);
         }
     })
 
@@ -705,6 +935,13 @@ const app = new Hono()
                     })
                     .returning();
 
+                await writeDocumentAuditEvent({
+                    action: 'create',
+                    userId: auth.userId,
+                    after: data,
+                    source: 'documents_standalone_upload',
+                });
+
                 return ctx.json({ data }, 201);
             } catch (error) {
                 console.error(
@@ -743,20 +980,13 @@ const app = new Hono()
 
             try {
                 // Verify document exists and belongs to user
-                const [doc] = await db
-                    .select({
-                        uploadedBy: documents.uploadedBy,
-                        transactionId: documents.transactionId,
-                    })
-                    .from(documents)
-                    .where(eq(documents.id, id));
+                const doc = await getAuthorizedDocument({
+                    id,
+                    userId: auth.userId,
+                });
 
                 if (!doc) {
                     return ctx.json({ error: 'Document not found.' }, 404);
-                }
-
-                if (doc.uploadedBy !== auth.userId) {
-                    return ctx.json({ error: 'Unauthorized.' }, 403);
                 }
 
                 if (doc.transactionId) {
@@ -785,10 +1015,75 @@ const app = new Hono()
                     .where(eq(documents.id, id))
                     .returning();
 
+                await writeDocumentAuditEvent({
+                    action: 'link',
+                    userId: auth.userId,
+                    before: doc,
+                    after: updatedDoc,
+                    source: 'documents_link',
+                });
+
                 return ctx.json({ data: updatedDoc });
             } catch (error) {
                 console.error('Error linking document:', error);
                 return ctx.json({ error: 'Failed to link document' }, 500);
+            }
+        },
+    )
+
+    // Unlink a document from its transaction
+    .post(
+        '/:id/unlink',
+        clerkMiddleware(),
+        zValidator(
+            'param',
+            z.object({
+                id: z.string(),
+            }),
+        ),
+        async (ctx) => {
+            const auth = getAuth(ctx);
+            const { id } = ctx.req.valid('param');
+
+            if (!auth?.userId) {
+                return ctx.json({ error: 'Unauthorized.' }, 401);
+            }
+
+            try {
+                const doc = await getAuthorizedDocument({
+                    id,
+                    userId: auth.userId,
+                });
+
+                if (!doc) {
+                    return ctx.json({ error: 'Document not found.' }, 404);
+                }
+
+                if (!doc.transactionId) {
+                    return ctx.json(
+                        { error: 'Document is not attached to a transaction.' },
+                        400,
+                    );
+                }
+
+                const [updatedDoc] = await db
+                    .update(documents)
+                    .set({ transactionId: null })
+                    .where(eq(documents.id, id))
+                    .returning();
+
+                await writeDocumentAuditEvent({
+                    action: 'unlink',
+                    userId: auth.userId,
+                    before: doc,
+                    after: updatedDoc,
+                    source: 'documents_unlink',
+                });
+
+                return ctx.json({ data: updatedDoc });
+            } catch (error) {
+                console.error('Error unlinking document:', error);
+                return ctx.json({ error: 'Failed to unlink document' }, 500);
             }
         },
     );

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -281,12 +281,20 @@ export const documents = pgTable(
             .defaultNow(),
         // For managing document lifecycle
         isDeleted: boolean('is_deleted').notNull().default(false),
+        deletedAt: timestamp('deleted_at', { mode: 'date' }),
+        deletedBy: text('deleted_by'),
+        deleteReason: text('delete_reason'),
+        restoredAt: timestamp('restored_at', { mode: 'date' }),
+        restoredBy: text('restored_by'),
+        restoreReason: text('restore_reason'),
     },
     (table) => [
         index('documents_transactionid_idx').on(table.transactionId),
         index('documents_documenttypeid_idx').on(table.documentTypeId),
         index('documents_uploadedby_idx').on(table.uploadedBy),
         index('documents_isdeleted_idx').on(table.isDeleted),
+        index('documents_deletedat_idx').on(table.deletedAt),
+        index('documents_deletedby_idx').on(table.deletedBy),
     ],
 );
 

--- a/drizzle/0045_misty_sauron.sql
+++ b/drizzle/0045_misty_sauron.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "documents" ADD COLUMN "deleted_at" timestamp;--> statement-breakpoint
+ALTER TABLE "documents" ADD COLUMN "deleted_by" text;--> statement-breakpoint
+ALTER TABLE "documents" ADD COLUMN "delete_reason" text;--> statement-breakpoint
+ALTER TABLE "documents" ADD COLUMN "restored_at" timestamp;--> statement-breakpoint
+ALTER TABLE "documents" ADD COLUMN "restored_by" text;--> statement-breakpoint
+ALTER TABLE "documents" ADD COLUMN "restore_reason" text;--> statement-breakpoint
+CREATE INDEX "documents_deletedat_idx" ON "documents" USING btree ("deleted_at");--> statement-breakpoint
+CREATE INDEX "documents_deletedby_idx" ON "documents" USING btree ("deleted_by");

--- a/drizzle/meta/0045_snapshot.json
+++ b/drizzle/meta/0045_snapshot.json
@@ -1,0 +1,2636 @@
+{
+  "id": "03080a10-afba-4835-bb0e-a890e54baf78",
+  "prevId": "5f72e95d-806b-4f56-ad8a-53570f30db1c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounting_periods": {
+      "name": "accounting_periods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by": {
+          "name": "closed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounting_periods_userid_idx": {
+          "name": "accounting_periods_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounting_periods_status_idx": {
+          "name": "accounting_periods_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounting_periods_startdate_idx": {
+          "name": "accounting_periods_startdate_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounting_periods_enddate_idx": {
+          "name": "accounting_periods_enddate_idx",
+          "columns": [
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plaid_id": {
+          "name": "plaid_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_open": {
+          "name": "is_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_read_only": {
+          "name": "is_read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'neutral'"
+        },
+        "account_class": {
+          "name": "account_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_role": {
+          "name": "system_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_balance": {
+          "name": "opening_balance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "accounts_userid_idx": {
+          "name": "accounts_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_isopen_idx": {
+          "name": "accounts_isopen_idx",
+          "columns": [
+            {
+              "expression": "is_open",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_code_idx": {
+          "name": "accounts_code_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_systemrole_idx": {
+          "name": "accounts_systemrole_idx",
+          "columns": [
+            {
+              "expression": "system_role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_label": {
+          "name": "resource_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "field_delta": {
+          "name": "field_delta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reverted_from_event_id": {
+          "name": "reverted_from_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_events_userid_idx": {
+          "name": "audit_events_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_actoruserid_idx": {
+          "name": "audit_events_actoruserid_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_action_idx": {
+          "name": "audit_events_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_resource_idx": {
+          "name": "audit_events_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_createdat_idx": {
+          "name": "audit_events_createdat_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_requestid_idx": {
+          "name": "audit_events_requestid_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_revertedfromeventid_idx": {
+          "name": "audit_events_revertedfromeventid_idx",
+          "columns": [
+            {
+              "expression": "reverted_from_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_events_actor_type_check": {
+          "name": "audit_events_actor_type_check",
+          "value": "\"audit_events\".\"actor_type\" in ('user', 'system', 'integration')"
+        },
+        "audit_events_action_check": {
+          "name": "audit_events_action_check",
+          "value": "\"audit_events\".\"action\" in ('create', 'update', 'delete', 'restore', 'purge', 'import', 'sync', 'status_change', 'link', 'unlink', 'settings_update', 'integration_event')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bank_accounts": {
+      "name": "bank_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gocardless_account_id": {
+          "name": "gocardless_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iban": {
+          "name": "iban",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_name": {
+          "name": "owner_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'EUR'"
+        },
+        "linked_account_id": {
+          "name": "linked_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_transaction_date": {
+          "name": "last_transaction_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bank_accounts_connectionid_idx": {
+          "name": "bank_accounts_connectionid_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_accounts_userid_idx": {
+          "name": "bank_accounts_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_accounts_gocardlessaccountid_idx": {
+          "name": "bank_accounts_gocardlessaccountid_idx",
+          "columns": [
+            {
+              "expression": "gocardless_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_accounts_linkedaccountid_idx": {
+          "name": "bank_accounts_linkedaccountid_idx",
+          "columns": [
+            {
+              "expression": "linked_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_accounts_isactive_idx": {
+          "name": "bank_accounts_isactive_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bank_accounts_connection_id_bank_connections_id_fk": {
+          "name": "bank_accounts_connection_id_bank_connections_id_fk",
+          "tableFrom": "bank_accounts",
+          "tableTo": "bank_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bank_accounts_linked_account_id_accounts_id_fk": {
+          "name": "bank_accounts_linked_account_id_accounts_id_fk",
+          "tableFrom": "bank_accounts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "linked_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_connections": {
+      "name": "bank_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requisition_id": {
+          "name": "requisition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_name": {
+          "name": "institution_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_logo": {
+          "name": "institution_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreement_id": {
+          "name": "agreement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreement_expires_at": {
+          "name": "agreement_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bank_connections_userid_idx": {
+          "name": "bank_connections_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_connections_requisitionid_idx": {
+          "name": "bank_connections_requisitionid_idx",
+          "columns": [
+            {
+              "expression": "requisition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_connections_institutionid_idx": {
+          "name": "bank_connections_institutionid_idx",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_connections_status_idx": {
+          "name": "bank_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_ibans": {
+      "name": "customer_ibans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iban": {
+          "name": "iban",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bank_name": {
+          "name": "bank_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "customer_ibans_customerid_idx": {
+          "name": "customer_ibans_customerid_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customer_ibans_iban_idx": {
+          "name": "customer_ibans_iban_idx",
+          "columns": [
+            {
+              "expression": "iban",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_ibans_customer_id_customers_id_fk": {
+          "name": "customer_ibans_customer_id_customers_id_fk",
+          "tableFrom": "customer_ibans",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friendly_name": {
+          "name": "friendly_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_telephone": {
+          "name": "contact_telephone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_complete": {
+          "name": "is_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_own_firm": {
+          "name": "is_own_firm",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "customers_userid_idx": {
+          "name": "customers_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_name_idx": {
+          "name": "customers_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_iscomplete_idx": {
+          "name": "customers_iscomplete_idx",
+          "columns": [
+            {
+              "expression": "is_complete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_isownfirm_idx": {
+          "name": "customers_isownfirm_idx",
+          "columns": [
+            {
+              "expression": "is_own_firm",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_layouts": {
+      "name": "dashboard_layouts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "widgets_config": {
+          "name": "widgets_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dashboard_layouts_userid_idx": {
+          "name": "dashboard_layouts_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_types": {
+      "name": "document_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_types_userid_idx": {
+          "name": "document_types_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_types_name_idx": {
+          "name": "document_types_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_type_id": {
+          "name": "document_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delete_reason": {
+          "name": "delete_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restored_at": {
+          "name": "restored_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restored_by": {
+          "name": "restored_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restore_reason": {
+          "name": "restore_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "documents_transactionid_idx": {
+          "name": "documents_transactionid_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_documenttypeid_idx": {
+          "name": "documents_documenttypeid_idx",
+          "columns": [
+            {
+              "expression": "document_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_uploadedby_idx": {
+          "name": "documents_uploadedby_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_isdeleted_idx": {
+          "name": "documents_isdeleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_deletedat_idx": {
+          "name": "documents_deletedat_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_deletedby_idx": {
+          "name": "documents_deletedby_idx",
+          "columns": [
+            {
+              "expression": "deleted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "documents_document_type_id_document_types_id_fk": {
+          "name": "documents_document_type_id_document_types_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "document_types",
+          "columnsFrom": [
+            "document_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "documents_transaction_id_transactions_id_fk": {
+          "name": "documents_transaction_id_transactions_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gocardless_settings": {
+      "name": "gocardless_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_key": {
+          "name": "secret_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_credit_account_id": {
+          "name": "default_credit_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_debit_account_id": {
+          "name": "default_debit_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_tag_id": {
+          "name": "default_tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sync_from_date": {
+          "name": "sync_from_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gocardless_settings_userid_idx": {
+          "name": "gocardless_settings_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gocardless_settings_default_credit_account_id_accounts_id_fk": {
+          "name": "gocardless_settings_default_credit_account_id_accounts_id_fk",
+          "tableFrom": "gocardless_settings",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "default_credit_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gocardless_settings_default_debit_account_id_accounts_id_fk": {
+          "name": "gocardless_settings_default_debit_account_id_accounts_id_fk",
+          "tableFrom": "gocardless_settings",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "default_debit_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gocardless_settings_default_tag_id_tags_id_fk": {
+          "name": "gocardless_settings_default_tag_id_tags_id_fk",
+          "tableFrom": "gocardless_settings",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "default_tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.open_finances_settings": {
+      "name": "open_finances_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "exposed_metrics": {
+          "name": "exposed_metrics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_description": {
+          "name": "page_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_embedding": {
+          "name": "allow_embedding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "open_finances_settings_userid_idx": {
+          "name": "open_finances_settings_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "double_entry_mode": {
+          "name": "double_entry_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_draft_to_pending": {
+          "name": "auto_draft_to_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reconciliation_conditions": {
+          "name": "reconciliation_conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"hasReceipt\"]'"
+        },
+        "min_required_documents": {
+          "name": "min_required_documents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "required_document_type_ids": {
+          "name": "required_document_type_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "default_customer_country": {
+          "name": "default_customer_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "settings_userid_idx": {
+          "name": "settings_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_settings": {
+      "name": "stripe_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_secret_key": {
+          "name": "stripe_secret_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_credit_account_id": {
+          "name": "default_credit_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_debit_account_id": {
+          "name": "default_debit_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_tag_id": {
+          "name": "default_tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sync_from_date": {
+          "name": "sync_from_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_settings_userid_idx": {
+          "name": "stripe_settings_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_settings_stripeaccountid_idx": {
+          "name": "stripe_settings_stripeaccountid_idx",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_settings_default_credit_account_id_accounts_id_fk": {
+          "name": "stripe_settings_default_credit_account_id_accounts_id_fk",
+          "tableFrom": "stripe_settings",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "default_credit_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stripe_settings_default_debit_account_id_accounts_id_fk": {
+          "name": "stripe_settings_default_debit_account_id_accounts_id_fk",
+          "tableFrom": "stripe_settings",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "default_debit_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stripe_settings_default_tag_id_tags_id_fk": {
+          "name": "stripe_settings_default_tag_id_tags_id_fk",
+          "tableFrom": "stripe_settings",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "default_tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_type": {
+          "name": "tag_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tags_userid_idx": {
+          "name": "tags_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_tagtype_idx": {
+          "name": "tags_tagtype_idx",
+          "columns": [
+            {
+              "expression": "tag_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction_status_history": {
+      "name": "transaction_status_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "transaction_status_history_transactionid_idx": {
+          "name": "transaction_status_history_transactionid_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transaction_status_history_changedat_idx": {
+          "name": "transaction_status_history_changedat_idx",
+          "columns": [
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_status_history_transaction_id_transactions_id_fk": {
+          "name": "transaction_status_history_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_status_history",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction_tags": {
+      "name": "transaction_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transaction_tags_transactionid_idx": {
+          "name": "transaction_tags_transactionid_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transaction_tags_tagid_idx": {
+          "name": "transaction_tags_tagid_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_tags_transaction_id_transactions_id_fk": {
+          "name": "transaction_tags_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_tags",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_tags_tag_id_tags_id_fk": {
+          "name": "transaction_tags_tag_id_tags_id_fk",
+          "tableFrom": "transaction_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payee": {
+          "name": "payee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payee_customer_id": {
+          "name": "payee_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_account_id": {
+          "name": "credit_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debit_account_id": {
+          "name": "debit_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_changed_at": {
+          "name": "status_changed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status_changed_by": {
+          "name": "status_changed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "split_group_id": {
+          "name": "split_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "split_type": {
+          "name": "split_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_id": {
+          "name": "stripe_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_url": {
+          "name": "stripe_payment_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gocardless_transaction_id": {
+          "name": "gocardless_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closing_period_id": {
+          "name": "closing_period_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delete_reason": {
+          "name": "delete_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restored_at": {
+          "name": "restored_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restored_by": {
+          "name": "restored_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restore_reason": {
+          "name": "restore_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "transactions_accountid_idx": {
+          "name": "transactions_accountid_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_creditaccountid_idx": {
+          "name": "transactions_creditaccountid_idx",
+          "columns": [
+            {
+              "expression": "credit_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_debutaccountid_idx": {
+          "name": "transactions_debutaccountid_idx",
+          "columns": [
+            {
+              "expression": "debit_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_payeecustomerid_idx": {
+          "name": "transactions_payeecustomerid_idx",
+          "columns": [
+            {
+              "expression": "payee_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_date_idx": {
+          "name": "transactions_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_status_idx": {
+          "name": "transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_splitgroupid_idx": {
+          "name": "transactions_splitgroupid_idx",
+          "columns": [
+            {
+              "expression": "split_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_splittype_idx": {
+          "name": "transactions_splittype_idx",
+          "columns": [
+            {
+              "expression": "split_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_stripepaymentid_idx": {
+          "name": "transactions_stripepaymentid_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_gocardlesstransactionid_idx": {
+          "name": "transactions_gocardlesstransactionid_idx",
+          "columns": [
+            {
+              "expression": "gocardless_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_closingperiodid_idx": {
+          "name": "transactions_closingperiodid_idx",
+          "columns": [
+            {
+              "expression": "closing_period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_deletedat_idx": {
+          "name": "transactions_deletedat_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_deletedby_idx": {
+          "name": "transactions_deletedby_idx",
+          "columns": [
+            {
+              "expression": "deleted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_payee_customer_id_customers_id_fk": {
+          "name": "transactions_payee_customer_id_customers_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "payee_customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_credit_account_id_accounts_id_fk": {
+          "name": "transactions_credit_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "credit_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_debit_account_id_accounts_id_fk": {
+          "name": "transactions_debit_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "debit_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1782770065359,
       "tag": "0044_quick_spiral",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1782770564400,
+      "tag": "0045_misty_sauron",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/document-lifecycle.ts
+++ b/lib/document-lifecycle.ts
@@ -1,0 +1,38 @@
+export const DOCUMENT_SOFT_DELETE_BLOB_POLICY =
+    'Soft-deleted documents retain their blob storage object; blobs are removed only by explicit purge.';
+
+export const createDocumentSoftDeletePatch = ({
+    userId,
+    reason = null,
+    now = new Date(),
+}: {
+    userId: string;
+    reason?: string | null;
+    now?: Date;
+}) => ({
+    isDeleted: true,
+    deletedAt: now,
+    deletedBy: userId,
+    deleteReason: reason,
+    restoredAt: null,
+    restoredBy: null,
+    restoreReason: null,
+});
+
+export const createDocumentRestorePatch = ({
+    userId,
+    reason = null,
+    now = new Date(),
+}: {
+    userId: string;
+    reason?: string | null;
+    now?: Date;
+}) => ({
+    isDeleted: false,
+    deletedAt: null,
+    deletedBy: null,
+    deleteReason: null,
+    restoredAt: now,
+    restoredBy: userId,
+    restoreReason: reason,
+});

--- a/tests/document-lifecycle.test.mjs
+++ b/tests/document-lifecycle.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+    createDocumentRestorePatch,
+    createDocumentSoftDeletePatch,
+    DOCUMENT_SOFT_DELETE_BLOB_POLICY,
+} from '../lib/document-lifecycle.ts';
+
+test('document soft delete patch records actor, time, and reason while retaining blob policy', () => {
+    const now = new Date('2026-06-29T12:00:00.000Z');
+    const patch = createDocumentSoftDeletePatch({
+        userId: 'user_1',
+        reason: 'Wrong file',
+        now,
+    });
+
+    assert.deepEqual(patch, {
+        isDeleted: true,
+        deletedAt: now,
+        deletedBy: 'user_1',
+        deleteReason: 'Wrong file',
+        restoredAt: null,
+        restoredBy: null,
+        restoreReason: null,
+    });
+    assert.match(DOCUMENT_SOFT_DELETE_BLOB_POLICY, /retain/);
+});
+
+test('document restore patch clears delete fields and records restore metadata', () => {
+    const now = new Date('2026-06-29T12:10:00.000Z');
+    const patch = createDocumentRestorePatch({
+        userId: 'user_1',
+        reason: 'Needed for reconciliation',
+        now,
+    });
+
+    assert.deepEqual(patch, {
+        isDeleted: false,
+        deletedAt: null,
+        deletedBy: null,
+        deleteReason: null,
+        restoredAt: now,
+        restoredBy: 'user_1',
+        restoreReason: 'Needed for reconciliation',
+    });
+});


### PR DESCRIPTION
## Summary

- Adds document lifecycle metadata and migration for delete/restore actors, timestamps, and reasons.
- Adds explicit document trash modes with `deleted=only` / `deleted=include` for document lists, transaction document lists, and downloads.
- Keeps normal document views and required-document validation on non-deleted documents by default.
- Replaces document delete with audited soft-delete metadata while retaining blobs.
- Adds restore and guarded purge endpoints; purge requires `confirm: true` and is the only path that removes the blob.
- Adds standalone and linked document authorization for download/restore/purge, plus explicit link and unlink audit events.
- Adds explicit audit events for document uploads, metadata updates, deletes, restores, purges, link/unlink, and document type create/update/delete.

## Verification

- `PATH=/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/biome check --write 'app/api/[[...route]]/documentsRoutes.ts' 'app/api/[[...route]]/documentTypesRoutes.ts' db/schema.ts lib/document-lifecycle.ts tests/document-lifecycle.test.mjs`
- `PATH=/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/tsc --noEmit --pretty false`
- `PATH=/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node --experimental-strip-types --test tests/audit.test.mjs tests/transaction-lifecycle.test.mjs tests/document-lifecycle.test.mjs`
- `PATH=/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH DATABASE_URL=postgresql://user:pass@localhost:5432/db ./node_modules/.bin/drizzle-kit check --config=drizzle.config.ts`
- `git diff --check`

## Risk

- Purge coordinates a database delete with Azure blob deletion without a cross-system transaction; the implementation deletes the blob only through the explicit purge path.
- Trash/history UI remains for #130; this PR provides the API and audit foundation for it.

Closes #128