### PR TITLE
Make customer data changes auditable and recoverable

### DIFF
--- a/app/api/[[...route]]/customersRoutes.ts
+++ b/app/api/[[...route]]/customersRoutes.ts
@@ -1,19 +1,47 @@
 import { clerkMiddleware, getAuth } from '@hono/clerk-auth';
 import { zValidator } from '@hono/zod-validator';
 import { createId } from '@paralleldrive/cuid2';
-import { and, desc, eq, ilike, inArray, isNull, or, sql } from 'drizzle-orm';
-import { Hono } from 'hono';
+import {
+    and,
+    asc,
+    desc,
+    eq,
+    ilike,
+    inArray,
+    isNull,
+    ne,
+    or,
+    sql,
+} from 'drizzle-orm';
+import { type Context, Hono } from 'hono';
 import { z } from 'zod';
 
 import { db } from '@/db/drizzle';
 import {
+    auditEvents,
     customerIbans,
     customers,
     insertCustomerSchema,
     transactions,
 } from '@/db/schema';
+import { type AuditAction, writeAuditEvent } from '@/lib/audit';
+import {
+    createCustomerIbanRestorePatch,
+    createCustomerIbanSoftDeletePatch,
+    createCustomerProfileRevertPatch,
+    createCustomerRestorePatch,
+    createCustomerSoftDeletePatch,
+    getCustomerIbanRevertConflicts,
+    getCustomerLifecycleRevertConflicts,
+    getCustomerProfileRevertConflicts,
+    type SnapshotRecord,
+} from '@/lib/customer-lifecycle';
 
-// Helper function to check if customer data is complete
+type DeletedMode = 'include' | 'only';
+type CustomerRow = typeof customers.$inferSelect;
+type CustomerIbanRow = typeof customerIbans.$inferSelect;
+type CustomerUpdate = Partial<typeof customers.$inferInsert>;
+
 type CustomerData = {
     name?: string | null;
     vatNumber?: string | null;
@@ -22,6 +50,27 @@ type CustomerData = {
     contactTelephone?: string | null;
     country?: string | null;
 };
+
+const customerLifecycleSchema = z.object({
+    reason: z.string().max(500).optional(),
+});
+
+const customerRevertSchema = customerLifecycleSchema.extend({
+    auditEventId: z.string().min(1),
+});
+
+const customerPayloadSchema = insertCustomerSchema.omit({
+    id: true,
+    userId: true,
+    isComplete: true,
+    isDeleted: true,
+    deletedAt: true,
+    deletedBy: true,
+    deleteReason: true,
+    restoredAt: true,
+    restoredBy: true,
+    restoreReason: true,
+});
 
 const isCustomerComplete = (customer: CustomerData): boolean => {
     return !!(
@@ -37,6 +86,52 @@ const isCustomerComplete = (customer: CustomerData): boolean => {
 const escapeLikePattern = (value: string): string =>
     value.replace(/[\\%_]/g, '\\\\$&');
 
+const normalizeIban = (iban: string) => iban.toUpperCase().replace(/\s/g, '');
+
+const readJsonPayload = async (ctx: Context) => {
+    const contentType = ctx.req.header('content-type') ?? '';
+    if (!contentType.includes('application/json')) {
+        return {};
+    }
+
+    try {
+        return await ctx.req.json();
+    } catch {
+        return {};
+    }
+};
+
+const readLifecycleReason = async (ctx: Context) => {
+    const parsed = customerLifecycleSchema.safeParse(
+        await readJsonPayload(ctx),
+    );
+    return parsed.success ? (parsed.data.reason ?? null) : null;
+};
+
+const customerDeletedFilter = (deleted?: DeletedMode) => {
+    if (deleted === 'include') {
+        return undefined;
+    }
+
+    if (deleted === 'only') {
+        return eq(customers.isDeleted, true);
+    }
+
+    return eq(customers.isDeleted, false);
+};
+
+const customerIbanDeletedFilter = (deleted?: DeletedMode) => {
+    if (deleted === 'include') {
+        return undefined;
+    }
+
+    if (deleted === 'only') {
+        return eq(customerIbans.isDeleted, true);
+    }
+
+    return eq(customerIbans.isDeleted, false);
+};
+
 const enforceMinDelay = async (
     startTimeMs: number,
     minDelayMs: number,
@@ -46,6 +141,473 @@ const enforceMinDelay = async (
     if (remainingMs > 0) {
         await new Promise((resolve) => setTimeout(resolve, remainingMs));
     }
+};
+
+const getAuthorizedCustomer = async ({
+    id,
+    userId,
+    deleted,
+}: {
+    id: string;
+    userId: string;
+    deleted?: DeletedMode;
+}) => {
+    const [customer] = await db
+        .select()
+        .from(customers)
+        .where(
+            and(
+                eq(customers.id, id),
+                eq(customers.userId, userId),
+                customerDeletedFilter(deleted),
+            ),
+        );
+
+    return customer ?? null;
+};
+
+const getAuthorizedCustomerIban = async ({
+    customerId,
+    ibanId,
+    userId,
+    deleted,
+    customerDeleted,
+}: {
+    customerId: string;
+    ibanId: string;
+    userId: string;
+    deleted?: DeletedMode;
+    customerDeleted?: DeletedMode;
+}) => {
+    const customer = await getAuthorizedCustomer({
+        id: customerId,
+        userId,
+        deleted: customerDeleted,
+    });
+
+    if (!customer) {
+        return null;
+    }
+
+    const [iban] = await db
+        .select()
+        .from(customerIbans)
+        .where(
+            and(
+                eq(customerIbans.id, ibanId),
+                eq(customerIbans.customerId, customerId),
+                customerIbanDeletedFilter(deleted),
+            ),
+        );
+
+    if (!iban) {
+        return null;
+    }
+
+    return { customer, iban };
+};
+
+const writeCustomerAuditEvent = async ({
+    action,
+    userId,
+    before,
+    after,
+    reason,
+    source,
+    revertedFromEventId,
+}: {
+    action: AuditAction;
+    userId: string;
+    before?: CustomerRow | null;
+    after?: CustomerRow | null;
+    reason?: string | null;
+    source: string;
+    revertedFromEventId?: string | null;
+}) => {
+    const resource = after ?? before;
+    if (!resource) return;
+
+    await writeAuditEvent(db, {
+        userId,
+        actorUserId: userId,
+        actorType: 'user',
+        action,
+        resourceType: 'customer',
+        resourceId: resource.id,
+        resourceLabel: resource.friendlyName ?? resource.name,
+        before: before ?? null,
+        after: after ?? null,
+        sourceMetadata: {
+            source,
+            reason: reason ?? null,
+        },
+        revertedFromEventId,
+    });
+};
+
+const writeCustomerIbanAuditEvent = async ({
+    action,
+    userId,
+    before,
+    after,
+    reason,
+    source,
+    revertedFromEventId,
+}: {
+    action: AuditAction;
+    userId: string;
+    before?: CustomerIbanRow | null;
+    after?: CustomerIbanRow | null;
+    reason?: string | null;
+    source: string;
+    revertedFromEventId?: string | null;
+}) => {
+    const resource = after ?? before;
+    if (!resource) return;
+
+    await writeAuditEvent(db, {
+        userId,
+        actorUserId: userId,
+        actorType: 'user',
+        action,
+        resourceType: 'customer_iban',
+        resourceId: resource.id,
+        resourceLabel: resource.iban,
+        before: before ?? null,
+        after: after ?? null,
+        sourceMetadata: {
+            source,
+            reason: reason ?? null,
+            customerId: resource.customerId,
+        },
+        revertedFromEventId,
+    });
+};
+
+const unmarkOtherOwnFirmCustomers = async ({
+    userId,
+    exceptId,
+    source,
+}: {
+    userId: string;
+    exceptId?: string;
+    source: string;
+}) => {
+    const beforeRows = await db
+        .select()
+        .from(customers)
+        .where(
+            and(
+                eq(customers.userId, userId),
+                eq(customers.isOwnFirm, true),
+                eq(customers.isDeleted, false),
+                exceptId ? ne(customers.id, exceptId) : undefined,
+            ),
+        );
+
+    if (beforeRows.length === 0) {
+        return;
+    }
+
+    const updatedRows = await db
+        .update(customers)
+        .set({ isOwnFirm: false })
+        .where(
+            inArray(
+                customers.id,
+                beforeRows.map((customer) => customer.id),
+            ),
+        )
+        .returning();
+    const beforeById = new Map(beforeRows.map((row) => [row.id, row]));
+
+    for (const updatedRow of updatedRows) {
+        await writeCustomerAuditEvent({
+            action: 'update',
+            userId,
+            before: beforeById.get(updatedRow.id) ?? null,
+            after: updatedRow,
+            source,
+        });
+    }
+};
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> => {
+    if (!value || typeof value !== 'object') {
+        return false;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+};
+
+const toSnapshotRecord = (value: unknown): SnapshotRecord | null => {
+    if (!isPlainRecord(value)) {
+        return null;
+    }
+
+    return value as SnapshotRecord;
+};
+
+const getCustomerAuditEvent = async ({
+    auditEventId,
+    customerId,
+    userId,
+}: {
+    auditEventId: string;
+    customerId: string;
+    userId: string;
+}) => {
+    const [event] = await db
+        .select()
+        .from(auditEvents)
+        .where(
+            and(
+                eq(auditEvents.id, auditEventId),
+                eq(auditEvents.userId, userId),
+                or(
+                    and(
+                        eq(auditEvents.resourceType, 'customer'),
+                        eq(auditEvents.resourceId, customerId),
+                    ),
+                    and(
+                        eq(auditEvents.resourceType, 'customer_iban'),
+                        sql`${auditEvents.sourceMetadata}->>'customerId' = ${customerId}`,
+                    ),
+                ),
+            ),
+        );
+
+    return event ?? null;
+};
+
+const revertCustomerAuditEvent = async ({
+    ctx,
+    customer,
+    event,
+    reason,
+    userId,
+}: {
+    ctx: Context;
+    customer: CustomerRow;
+    event: typeof auditEvents.$inferSelect;
+    reason: string | null;
+    userId: string;
+}) => {
+    const before = toSnapshotRecord(event.before);
+    const after = toSnapshotRecord(event.after);
+
+    if (!after || (event.action !== 'create' && !before)) {
+        return ctx.json({ error: 'Audit event cannot be reverted.' }, 400);
+    }
+
+    const currentSnapshot = customer as unknown as SnapshotRecord;
+    const conflicts =
+        event.action === 'update'
+            ? getCustomerProfileRevertConflicts({
+                  current: currentSnapshot,
+                  eventAfter: after,
+              })
+            : getCustomerLifecycleRevertConflicts({
+                  current: currentSnapshot,
+                  eventAfter: after,
+              });
+
+    if (conflicts.length > 0) {
+        return ctx.json(
+            {
+                error: 'Customer changed since the audit event.',
+                conflicts,
+            },
+            409,
+        );
+    }
+
+    if (event.action === 'update' && before) {
+        const patch = createCustomerProfileRevertPatch(before);
+
+        if (patch.isOwnFirm === true) {
+            await unmarkOtherOwnFirmCustomers({
+                userId,
+                exceptId: customer.id,
+                source: 'customers_revert_unmark_own_firm',
+            });
+        }
+
+        const [updatedCustomer] = await db
+            .update(customers)
+            .set(patch as CustomerUpdate)
+            .where(eq(customers.id, customer.id))
+            .returning();
+
+        await writeCustomerAuditEvent({
+            action: 'update',
+            userId,
+            before: customer,
+            after: updatedCustomer,
+            reason,
+            source: 'customers_revert',
+            revertedFromEventId: event.id,
+        });
+
+        return ctx.json({ data: updatedCustomer });
+    }
+
+    if (event.action === 'delete') {
+        if (!customer.isDeleted) {
+            return ctx.json(
+                { error: 'Customer is not currently deleted.' },
+                409,
+            );
+        }
+
+        if (customer.isOwnFirm) {
+            await unmarkOtherOwnFirmCustomers({
+                userId,
+                exceptId: customer.id,
+                source: 'customers_revert_delete_unmark_own_firm',
+            });
+        }
+
+        const [updatedCustomer] = await db
+            .update(customers)
+            .set(createCustomerRestorePatch({ userId, reason }))
+            .where(eq(customers.id, customer.id))
+            .returning();
+
+        await writeCustomerAuditEvent({
+            action: 'restore',
+            userId,
+            before: customer,
+            after: updatedCustomer,
+            reason,
+            source: 'customers_revert_delete',
+            revertedFromEventId: event.id,
+        });
+
+        return ctx.json({ data: updatedCustomer });
+    }
+
+    if (event.action === 'create' || event.action === 'restore') {
+        if (customer.isDeleted) {
+            return ctx.json({ error: 'Customer is already deleted.' }, 409);
+        }
+
+        const [updatedCustomer] = await db
+            .update(customers)
+            .set(createCustomerSoftDeletePatch({ userId, reason }))
+            .where(eq(customers.id, customer.id))
+            .returning();
+
+        await writeCustomerAuditEvent({
+            action: 'delete',
+            userId,
+            before: customer,
+            after: updatedCustomer,
+            reason,
+            source:
+                event.action === 'create'
+                    ? 'customers_revert_create'
+                    : 'customers_revert_restore',
+            revertedFromEventId: event.id,
+        });
+
+        return ctx.json({ data: updatedCustomer });
+    }
+
+    return ctx.json({ error: 'Audit event action is not revertable.' }, 400);
+};
+
+const revertCustomerIbanAuditEvent = async ({
+    ctx,
+    event,
+    reason,
+    userId,
+}: {
+    ctx: Context;
+    event: typeof auditEvents.$inferSelect;
+    reason: string | null;
+    userId: string;
+}) => {
+    const before = toSnapshotRecord(event.before);
+    const after = toSnapshotRecord(event.after);
+
+    if (!after || (event.action !== 'create' && !before)) {
+        return ctx.json({ error: 'Audit event cannot be reverted.' }, 400);
+    }
+
+    const customerId = String(after.customerId ?? before?.customerId ?? '');
+    const authorizedIban = await getAuthorizedCustomerIban({
+        customerId,
+        ibanId: event.resourceId,
+        userId,
+        deleted: 'include',
+        customerDeleted: 'include',
+    });
+
+    if (!authorizedIban) {
+        return ctx.json({ error: 'IBAN not found.' }, 404);
+    }
+
+    const conflicts = getCustomerIbanRevertConflicts({
+        current: authorizedIban.iban as unknown as SnapshotRecord,
+        eventAfter: after,
+    });
+
+    if (conflicts.length > 0) {
+        return ctx.json(
+            {
+                error: 'Customer IBAN changed since the audit event.',
+                conflicts,
+            },
+            409,
+        );
+    }
+
+    if (event.action === 'delete') {
+        const [updatedIban] = await db
+            .update(customerIbans)
+            .set(createCustomerIbanRestorePatch({ userId, reason }))
+            .where(eq(customerIbans.id, authorizedIban.iban.id))
+            .returning();
+
+        await writeCustomerIbanAuditEvent({
+            action: 'restore',
+            userId,
+            before: authorizedIban.iban,
+            after: updatedIban,
+            reason,
+            source: 'customer_ibans_revert_delete',
+            revertedFromEventId: event.id,
+        });
+
+        return ctx.json({ data: updatedIban });
+    }
+
+    if (event.action === 'create' || event.action === 'restore') {
+        const [updatedIban] = await db
+            .update(customerIbans)
+            .set(createCustomerIbanSoftDeletePatch({ userId, reason }))
+            .where(eq(customerIbans.id, authorizedIban.iban.id))
+            .returning();
+
+        await writeCustomerIbanAuditEvent({
+            action: 'delete',
+            userId,
+            before: authorizedIban.iban,
+            after: updatedIban,
+            reason,
+            source:
+                event.action === 'create'
+                    ? 'customer_ibans_revert_create'
+                    : 'customer_ibans_revert_restore',
+            revertedFromEventId: event.id,
+        });
+
+        return ctx.json({ data: updatedIban });
+    }
+
+    return ctx.json({ error: 'Audit event action is not revertable.' }, 400);
 };
 
 const app = new Hono()
@@ -65,6 +627,7 @@ const app = new Hono()
                 and(
                     eq(customers.userId, auth.userId),
                     eq(customers.isComplete, false),
+                    eq(customers.isDeleted, false),
                 ),
             );
 
@@ -76,12 +639,13 @@ const app = new Hono()
             'query',
             z.object({
                 search: z.string().optional(),
+                deleted: z.enum(['include', 'only']).optional(),
             }),
         ),
         clerkMiddleware(),
         async (ctx) => {
             const auth = getAuth(ctx);
-            const { search } = ctx.req.valid('query');
+            const { search, deleted } = ctx.req.valid('query');
 
             if (!auth?.userId) {
                 return ctx.json({ error: 'Unauthorized.' }, 401);
@@ -100,6 +664,13 @@ const app = new Hono()
                     country: customers.country,
                     isComplete: customers.isComplete,
                     isOwnFirm: customers.isOwnFirm,
+                    isDeleted: customers.isDeleted,
+                    deletedAt: customers.deletedAt,
+                    deletedBy: customers.deletedBy,
+                    deleteReason: customers.deleteReason,
+                    restoredAt: customers.restoredAt,
+                    restoredBy: customers.restoredBy,
+                    restoreReason: customers.restoreReason,
                     transactionCount: sql<number>`count(${transactions.id})`.as(
                         'transaction_count',
                     ),
@@ -113,10 +684,11 @@ const app = new Hono()
                     ),
                 )
                 .where(
-                    search
-                        ? and(
-                              eq(customers.userId, auth.userId),
-                              or(
+                    and(
+                        eq(customers.userId, auth.userId),
+                        customerDeletedFilter(deleted),
+                        search
+                            ? or(
                                   ilike(customers.name, `%${escapedSearch}%`),
                                   ilike(
                                       customers.friendlyName,
@@ -126,9 +698,9 @@ const app = new Hono()
                                       customers.vatNumber,
                                       `%${escapedSearch}%`,
                                   ),
-                              ),
-                          )
-                        : eq(customers.userId, auth.userId),
+                              )
+                            : undefined,
+                    ),
                 )
                 .groupBy(customers.id)
                 .orderBy(desc(customers.name));
@@ -137,46 +709,60 @@ const app = new Hono()
         },
     )
     .get(
-        '/:id',
+        '/lookup/iban',
         zValidator(
-            'param',
+            'query',
             z.object({
-                id: z.string().optional(),
+                iban: z.string(),
             }),
         ),
         clerkMiddleware(),
         async (ctx) => {
             const auth = getAuth(ctx);
-            const { id } = ctx.req.valid('param');
-
-            if (!id) {
-                return ctx.json({ error: 'Missing id.' }, 400);
-            }
+            const { iban } = ctx.req.valid('query');
 
             if (!auth?.userId) {
                 return ctx.json({ error: 'Unauthorized.' }, 401);
             }
 
-            const [data] = await db
-                .select()
-                .from(customers)
+            const startTimeMs = Date.now();
+            const normalizedIban = normalizeIban(iban);
+
+            const [ibanRecord] = await db
+                .select({
+                    customerId: customerIbans.customerId,
+                    customerName:
+                        sql<string>`coalesce(${customers.friendlyName}, ${customers.name})`.as(
+                            'customer_name',
+                        ),
+                    iban: customerIbans.iban,
+                    bankName: customerIbans.bankName,
+                })
+                .from(customerIbans)
+                .innerJoin(
+                    customers,
+                    eq(customerIbans.customerId, customers.id),
+                )
                 .where(
                     and(
-                        eq(customers.id, id),
+                        eq(customerIbans.iban, normalizedIban),
+                        eq(customerIbans.isDeleted, false),
                         eq(customers.userId, auth.userId),
+                        eq(customers.isDeleted, false),
                     ),
                 );
 
-            if (!data) {
-                return ctx.json({ error: 'Not found.' }, 404);
+            if (!ibanRecord) {
+                await enforceMinDelay(startTimeMs, 150);
+                return ctx.json({ data: null });
             }
 
-            return ctx.json({ data });
+            await enforceMinDelay(startTimeMs, 150);
+            return ctx.json({ data: ibanRecord });
         },
     )
-    // Get IBANs for a customer
     .get(
-        '/:id/ibans',
+        '/:id/history',
         zValidator(
             'param',
             z.object({
@@ -192,16 +778,135 @@ const app = new Hono()
                 return ctx.json({ error: 'Unauthorized.' }, 401);
             }
 
-            // Verify customer belongs to user
-            const [customer] = await db
+            const customer = await getAuthorizedCustomer({
+                id,
+                userId: auth.userId,
+                deleted: 'include',
+            });
+
+            if (!customer) {
+                return ctx.json({ error: 'Customer not found.' }, 404);
+            }
+
+            const data = await db
                 .select()
-                .from(customers)
+                .from(auditEvents)
                 .where(
                     and(
-                        eq(customers.id, id),
-                        eq(customers.userId, auth.userId),
+                        eq(auditEvents.userId, auth.userId),
+                        or(
+                            and(
+                                eq(auditEvents.resourceType, 'customer'),
+                                eq(auditEvents.resourceId, id),
+                            ),
+                            and(
+                                eq(auditEvents.resourceType, 'customer_iban'),
+                                sql`${auditEvents.sourceMetadata}->>'customerId' = ${id}`,
+                            ),
+                        ),
                     ),
+                )
+                .orderBy(asc(auditEvents.createdAt));
+
+            return ctx.json({ data });
+        },
+    )
+    .post(
+        '/:id/revert',
+        clerkMiddleware(),
+        zValidator(
+            'param',
+            z.object({
+                id: z.string(),
+            }),
+        ),
+        zValidator('json', customerRevertSchema),
+        async (ctx) => {
+            const auth = getAuth(ctx);
+            const { id } = ctx.req.valid('param');
+            const values = ctx.req.valid('json');
+
+            if (!auth?.userId) {
+                return ctx.json({ error: 'Unauthorized.' }, 401);
+            }
+
+            const customer = await getAuthorizedCustomer({
+                id,
+                userId: auth.userId,
+                deleted: 'include',
+            });
+
+            if (!customer) {
+                return ctx.json({ error: 'Customer not found.' }, 404);
+            }
+
+            const event = await getCustomerAuditEvent({
+                auditEventId: values.auditEventId,
+                customerId: id,
+                userId: auth.userId,
+            });
+
+            if (!event) {
+                return ctx.json({ error: 'Audit event not found.' }, 404);
+            }
+
+            if (event.revertedFromEventId) {
+                return ctx.json(
+                    { error: 'Revert audit events cannot be reverted.' },
+                    400,
                 );
+            }
+
+            if (event.resourceType === 'customer') {
+                return await revertCustomerAuditEvent({
+                    ctx,
+                    customer,
+                    event,
+                    reason: values.reason ?? null,
+                    userId: auth.userId,
+                });
+            }
+
+            if (event.resourceType === 'customer_iban') {
+                return await revertCustomerIbanAuditEvent({
+                    ctx,
+                    event,
+                    reason: values.reason ?? null,
+                    userId: auth.userId,
+                });
+            }
+
+            return ctx.json({ error: 'Audit event is not revertable.' }, 400);
+        },
+    )
+    .get(
+        '/:id/ibans',
+        zValidator(
+            'param',
+            z.object({
+                id: z.string(),
+            }),
+        ),
+        zValidator(
+            'query',
+            z.object({
+                deleted: z.enum(['include', 'only']).optional(),
+            }),
+        ),
+        clerkMiddleware(),
+        async (ctx) => {
+            const auth = getAuth(ctx);
+            const { id } = ctx.req.valid('param');
+            const { deleted } = ctx.req.valid('query');
+
+            if (!auth?.userId) {
+                return ctx.json({ error: 'Unauthorized.' }, 401);
+            }
+
+            const customer = await getAuthorizedCustomer({
+                id,
+                userId: auth.userId,
+            });
 
             if (!customer) {
                 return ctx.json({ error: 'Customer not found.' }, 404);
@@ -210,13 +915,17 @@ const app = new Hono()
             const data = await db
                 .select()
                 .from(customerIbans)
-                .where(eq(customerIbans.customerId, id))
+                .where(
+                    and(
+                        eq(customerIbans.customerId, id),
+                        customerIbanDeletedFilter(deleted),
+                    ),
+                )
                 .orderBy(desc(customerIbans.createdAt));
 
             return ctx.json({ data });
         },
     )
-    // Add IBAN to customer
     .post(
         '/:id/ibans',
         clerkMiddleware(),
@@ -242,16 +951,10 @@ const app = new Hono()
                 return ctx.json({ error: 'Unauthorized.' }, 401);
             }
 
-            // Verify customer belongs to user
-            const [customer] = await db
-                .select()
-                .from(customers)
-                .where(
-                    and(
-                        eq(customers.id, id),
-                        eq(customers.userId, auth.userId),
-                    ),
-                );
+            const customer = await getAuthorizedCustomer({
+                id,
+                userId: auth.userId,
+            });
 
             if (!customer) {
                 return ctx.json({ error: 'Customer not found.' }, 404);
@@ -262,15 +965,22 @@ const app = new Hono()
                 .values({
                     id: createId(),
                     customerId: id,
-                    iban: values.iban.toUpperCase().replace(/\s/g, ''), // Normalize IBAN
+                    iban: normalizeIban(values.iban),
                     bankName: values.bankName || null,
                 })
                 .returning();
 
+            await writeCustomerIbanAuditEvent({
+                action: 'create',
+                userId: auth.userId,
+                before: null,
+                after: data,
+                source: 'customer_ibans_create',
+            });
+
             return ctx.json({ data });
         },
     )
-    // Delete IBAN
     .delete(
         '/:id/ibans/:ibanId',
         zValidator(
@@ -289,102 +999,139 @@ const app = new Hono()
                 return ctx.json({ error: 'Unauthorized.' }, 401);
             }
 
-            // Verify customer belongs to user
-            const [customer] = await db
-                .select()
-                .from(customers)
-                .where(
-                    and(
-                        eq(customers.id, id),
-                        eq(customers.userId, auth.userId),
-                    ),
-                );
+            const authorizedIban = await getAuthorizedCustomerIban({
+                customerId: id,
+                ibanId,
+                userId: auth.userId,
+            });
 
-            if (!customer) {
-                return ctx.json({ error: 'Customer not found.' }, 404);
-            }
-
-            const [data] = await db
-                .delete(customerIbans)
-                .where(
-                    and(
-                        eq(customerIbans.id, ibanId),
-                        eq(customerIbans.customerId, id),
-                    ),
-                )
-                .returning();
-
-            if (!data) {
+            if (!authorizedIban) {
                 return ctx.json({ error: 'IBAN not found.' }, 404);
             }
+
+            const reason = await readLifecycleReason(ctx);
+            const [data] = await db
+                .update(customerIbans)
+                .set(
+                    createCustomerIbanSoftDeletePatch({
+                        userId: auth.userId,
+                        reason,
+                    }),
+                )
+                .where(eq(customerIbans.id, ibanId))
+                .returning();
+
+            await writeCustomerIbanAuditEvent({
+                action: 'delete',
+                userId: auth.userId,
+                before: authorizedIban.iban,
+                after: data,
+                reason,
+                source: 'customer_ibans_delete',
+            });
 
             return ctx.json({ data });
         },
     )
-    // Lookup customer by IBAN (for import matching)
-    .get(
-        '/lookup/iban',
+    .post(
+        '/:id/ibans/:ibanId/restore',
         zValidator(
-            'query',
+            'param',
             z.object({
-                iban: z.string(),
+                id: z.string(),
+                ibanId: z.string(),
             }),
         ),
         clerkMiddleware(),
         async (ctx) => {
             const auth = getAuth(ctx);
-            const { iban } = ctx.req.valid('query');
+            const { id, ibanId } = ctx.req.valid('param');
 
             if (!auth?.userId) {
                 return ctx.json({ error: 'Unauthorized.' }, 401);
             }
 
-            const startTimeMs = Date.now();
-            // Normalize IBAN for lookup
-            const normalizedIban = iban.toUpperCase().replace(/\s/g, '');
+            const authorizedIban = await getAuthorizedCustomerIban({
+                customerId: id,
+                ibanId,
+                userId: auth.userId,
+                deleted: 'only',
+                customerDeleted: 'include',
+            });
 
-            const [ibanRecord] = await db
-                .select({
-                    customerId: customerIbans.customerId,
-                    customerName:
-                        sql<string>`coalesce(${customers.friendlyName}, ${customers.name})`.as(
-                            'customer_name',
-                        ),
-                    iban: customerIbans.iban,
-                    bankName: customerIbans.bankName,
-                })
-                .from(customerIbans)
-                .innerJoin(
-                    customers,
-                    eq(customerIbans.customerId, customers.id),
-                )
-                .where(
-                    and(
-                        eq(customerIbans.iban, normalizedIban),
-                        eq(customers.userId, auth.userId),
-                    ),
-                );
-
-            if (!ibanRecord) {
-                await enforceMinDelay(startTimeMs, 150);
-                return ctx.json({ data: null });
+            if (!authorizedIban) {
+                return ctx.json({ error: 'IBAN not found.' }, 404);
             }
 
-            await enforceMinDelay(startTimeMs, 150);
-            return ctx.json({ data: ibanRecord });
+            const reason = await readLifecycleReason(ctx);
+            const [data] = await db
+                .update(customerIbans)
+                .set(
+                    createCustomerIbanRestorePatch({
+                        userId: auth.userId,
+                        reason,
+                    }),
+                )
+                .where(eq(customerIbans.id, ibanId))
+                .returning();
+
+            await writeCustomerIbanAuditEvent({
+                action: 'restore',
+                userId: auth.userId,
+                before: authorizedIban.iban,
+                after: data,
+                reason,
+                source: 'customer_ibans_restore',
+            });
+
+            return ctx.json({ data });
+        },
+    )
+    .get(
+        '/:id',
+        zValidator(
+            'param',
+            z.object({
+                id: z.string().optional(),
+            }),
+        ),
+        zValidator(
+            'query',
+            z.object({
+                deleted: z.enum(['include', 'only']).optional(),
+            }),
+        ),
+        clerkMiddleware(),
+        async (ctx) => {
+            const auth = getAuth(ctx);
+            const { id } = ctx.req.valid('param');
+            const { deleted } = ctx.req.valid('query');
+
+            if (!id) {
+                return ctx.json({ error: 'Missing id.' }, 400);
+            }
+
+            if (!auth?.userId) {
+                return ctx.json({ error: 'Unauthorized.' }, 401);
+            }
+
+            const data = await getAuthorizedCustomer({
+                id,
+                userId: auth.userId,
+                deleted,
+            });
+
+            if (!data) {
+                return ctx.json({ error: 'Not found.' }, 404);
+            }
+
+            return ctx.json({ data });
         },
     )
     .post(
         '/',
         clerkMiddleware(),
-        zValidator(
-            'json',
-            insertCustomerSchema.omit({
-                id: true,
-                userId: true,
-                isComplete: true,
-            }),
-        ),
+        zValidator('json', customerPayloadSchema),
         async (ctx) => {
             const auth = getAuth(ctx);
             const values = ctx.req.valid('json');
@@ -395,17 +1142,11 @@ const app = new Hono()
 
             const isComplete = isCustomerComplete(values);
 
-            // If marking this customer as own firm, unmark all other customers
             if (values.isOwnFirm) {
-                await db
-                    .update(customers)
-                    .set({ isOwnFirm: false })
-                    .where(
-                        and(
-                            eq(customers.userId, auth.userId),
-                            eq(customers.isOwnFirm, true),
-                        ),
-                    );
+                await unmarkOtherOwnFirmCustomers({
+                    userId: auth.userId,
+                    source: 'customers_create_unmark_own_firm',
+                });
             }
 
             const [data] = await db
@@ -417,6 +1158,14 @@ const app = new Hono()
                     ...values,
                 })
                 .returning();
+
+            await writeCustomerAuditEvent({
+                action: 'create',
+                userId: auth.userId,
+                before: null,
+                after: data,
+                source: 'customers_create',
+            });
 
             return ctx.json({ data });
         },
@@ -430,14 +1179,7 @@ const app = new Hono()
                 id: z.string().optional(),
             }),
         ),
-        zValidator(
-            'json',
-            insertCustomerSchema.omit({
-                id: true,
-                userId: true,
-                isComplete: true,
-            }),
-        ),
+        zValidator('json', customerPayloadSchema),
         async (ctx) => {
             const auth = getAuth(ctx);
             const { id } = ctx.req.valid('param');
@@ -451,19 +1193,23 @@ const app = new Hono()
                 return ctx.json({ error: 'Unauthorized.' }, 401);
             }
 
+            const existingCustomer = await getAuthorizedCustomer({
+                id,
+                userId: auth.userId,
+            });
+
+            if (!existingCustomer) {
+                return ctx.json({ error: 'Not found.' }, 404);
+            }
+
             const isComplete = isCustomerComplete(values);
 
-            // If marking this customer as own firm, unmark all other customers
             if (values.isOwnFirm) {
-                await db
-                    .update(customers)
-                    .set({ isOwnFirm: false })
-                    .where(
-                        and(
-                            eq(customers.userId, auth.userId),
-                            eq(customers.isOwnFirm, true),
-                        ),
-                    );
+                await unmarkOtherOwnFirmCustomers({
+                    userId: auth.userId,
+                    exceptId: id,
+                    source: 'customers_update_unmark_own_firm',
+                });
             }
 
             const [data] = await db
@@ -472,17 +1218,16 @@ const app = new Hono()
                     isComplete,
                     ...values,
                 })
-                .where(
-                    and(
-                        eq(customers.id, id),
-                        eq(customers.userId, auth.userId),
-                    ),
-                )
+                .where(eq(customers.id, id))
                 .returning();
 
-            if (!data) {
-                return ctx.json({ error: 'Not found.' }, 404);
-            }
+            await writeCustomerAuditEvent({
+                action: 'update',
+                userId: auth.userId,
+                before: existingCustomer,
+                after: data,
+                source: 'customers_update',
+            });
 
             return ctx.json({ data });
         },
@@ -492,7 +1237,7 @@ const app = new Hono()
         clerkMiddleware(),
         zValidator(
             'json',
-            z.object({
+            customerLifecycleSchema.extend({
                 ids: z.array(z.string()),
             }),
         ),
@@ -504,14 +1249,18 @@ const app = new Hono()
                 return ctx.json({ error: 'Unauthorized.' }, 401);
             }
 
-            // Verify all customers belong to the user
+            if (values.ids.length === 0) {
+                return ctx.json({ data: [] });
+            }
+
             const customersToDelete = await db
-                .select({ id: customers.id })
+                .select()
                 .from(customers)
                 .where(
                     and(
                         inArray(customers.id, values.ids),
                         eq(customers.userId, auth.userId),
+                        eq(customers.isDeleted, false),
                     ),
                 );
 
@@ -524,18 +1273,35 @@ const app = new Hono()
                 );
             }
 
-            // Delete all customers (transactions will have payeeCustomerId set to null via cascade)
             const data = await db
-                .delete(customers)
+                .update(customers)
+                .set(
+                    createCustomerSoftDeletePatch({
+                        userId: auth.userId,
+                        reason: values.reason ?? null,
+                    }),
+                )
                 .where(
                     and(
                         eq(customers.userId, auth.userId),
                         inArray(customers.id, values.ids),
                     ),
                 )
-                .returning({
-                    id: customers.id,
+                .returning();
+            const beforeById = new Map(
+                customersToDelete.map((customer) => [customer.id, customer]),
+            );
+
+            for (const updatedCustomer of data) {
+                await writeCustomerAuditEvent({
+                    action: 'delete',
+                    userId: auth.userId,
+                    before: beforeById.get(updatedCustomer.id) ?? null,
+                    after: updatedCustomer,
+                    reason: values.reason ?? null,
+                    source: 'customers_bulk_delete',
                 });
+            }
 
             return ctx.json({ data });
         },
@@ -561,40 +1327,98 @@ const app = new Hono()
                 return ctx.json({ error: 'Unauthorized.' }, 401);
             }
 
-            // Check if customer has linked transactions
-            const [linkedTransaction] = await db
-                .select({ id: transactions.id })
-                .from(transactions)
-                .where(
-                    and(
-                        eq(transactions.payeeCustomerId, id),
-                        isNull(transactions.deletedAt),
-                    ),
-                )
-                .limit(1);
+            const customer = await getAuthorizedCustomer({
+                id,
+                userId: auth.userId,
+            });
 
-            if (linkedTransaction) {
-                return ctx.json(
-                    {
-                        error: 'Cannot delete customer with linked transactions. Please reassign or delete the transactions first.',
-                    },
-                    400,
-                );
-            }
-
-            const [data] = await db
-                .delete(customers)
-                .where(
-                    and(
-                        eq(customers.id, id),
-                        eq(customers.userId, auth.userId),
-                    ),
-                )
-                .returning();
-
-            if (!data) {
+            if (!customer) {
                 return ctx.json({ error: 'Not found.' }, 404);
             }
+
+            const reason = await readLifecycleReason(ctx);
+            const [data] = await db
+                .update(customers)
+                .set(
+                    createCustomerSoftDeletePatch({
+                        userId: auth.userId,
+                        reason,
+                    }),
+                )
+                .where(eq(customers.id, id))
+                .returning();
+
+            await writeCustomerAuditEvent({
+                action: 'delete',
+                userId: auth.userId,
+                before: customer,
+                after: data,
+                reason,
+                source: 'customers_delete',
+            });
+
+            return ctx.json({ data });
+        },
+    )
+    .post(
+        '/:id/restore',
+        clerkMiddleware(),
+        zValidator(
+            'param',
+            z.object({
+                id: z.string().optional(),
+            }),
+        ),
+        async (ctx) => {
+            const auth = getAuth(ctx);
+            const { id } = ctx.req.valid('param');
+
+            if (!id) {
+                return ctx.json({ error: 'Missing id.' }, 400);
+            }
+
+            if (!auth?.userId) {
+                return ctx.json({ error: 'Unauthorized.' }, 401);
+            }
+
+            const customer = await getAuthorizedCustomer({
+                id,
+                userId: auth.userId,
+                deleted: 'only',
+            });
+
+            if (!customer) {
+                return ctx.json({ error: 'Not found.' }, 404);
+            }
+
+            if (customer.isOwnFirm) {
+                await unmarkOtherOwnFirmCustomers({
+                    userId: auth.userId,
+                    exceptId: id,
+                    source: 'customers_restore_unmark_own_firm',
+                });
+            }
+
+            const reason = await readLifecycleReason(ctx);
+            const [data] = await db
+                .update(customers)
+                .set(
+                    createCustomerRestorePatch({
+                        userId: auth.userId,
+                        reason,
+                    }),
+                )
+                .where(eq(customers.id, id))
+                .returning();
+
+            await writeCustomerAuditEvent({
+                action: 'restore',
+                userId: auth.userId,
+                before: customer,
+                after: data,
+                reason,
+                source: 'customers_restore',
+            });
 
             return ctx.json({ data });
         },

--- a/app/api/[[...route]]/stripeRoutes.ts
+++ b/app/api/[[...route]]/stripeRoutes.ts
@@ -82,7 +82,11 @@ const processStripeCharge = async (
         .select({ id: customers.id })
         .from(customers)
         .where(
-            and(eq(customers.userId, userId), eq(customers.isOwnFirm, true)),
+            and(
+                eq(customers.userId, userId),
+                eq(customers.isOwnFirm, true),
+                eq(customers.isDeleted, false),
+            ),
         );
 
     // Convert amount from Stripe cents to milliunits (app stores amounts * 1000)

--- a/app/api/[[...route]]/transactionsRoutes.ts
+++ b/app/api/[[...route]]/transactionsRoutes.ts
@@ -656,6 +656,7 @@ const app = new Hono()
                     and(
                         eq(customers.id, customerId),
                         eq(customers.userId, auth.userId),
+                        eq(customers.isDeleted, false),
                     ),
                 );
 
@@ -875,6 +876,7 @@ const app = new Hono()
                     .where(
                         and(
                             eq(customers.userId, auth.userId),
+                            eq(customers.isDeleted, false),
                             or(
                                 ilike(customers.name, `%${escapedQuery}%`),
                                 ilike(
@@ -937,6 +939,7 @@ const app = new Hono()
                         .where(
                             and(
                                 eq(customers.userId, auth.userId),
+                                eq(customers.isDeleted, false),
                                 or(
                                     ilike(customers.name, `%${escapedWord}%`),
                                     ilike(
@@ -983,6 +986,7 @@ const app = new Hono()
                     .where(
                         and(
                             eq(customers.userId, auth.userId),
+                            eq(customers.isDeleted, false),
                             isNotNull(transactions.payeeCustomerId),
                             isNull(transactions.deletedAt),
                             or(
@@ -1046,6 +1050,7 @@ const app = new Hono()
                     and(
                         eq(customers.id, customerId),
                         eq(customers.userId, auth.userId),
+                        eq(customers.isDeleted, false),
                     ),
                 );
 

--- a/app/api/stripe/cron/route.ts
+++ b/app/api/stripe/cron/route.ts
@@ -74,7 +74,11 @@ const processStripeCharge = async (
         .select({ id: customers.id })
         .from(customers)
         .where(
-            and(eq(customers.userId, userId), eq(customers.isOwnFirm, true)),
+            and(
+                eq(customers.userId, userId),
+                eq(customers.isOwnFirm, true),
+                eq(customers.isDeleted, false),
+            ),
         );
 
     // Convert amount from Stripe cents to milliunits (app stores amounts * 1000)

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -81,7 +81,11 @@ const processStripePayment = async (
         .select({ id: customers.id })
         .from(customers)
         .where(
-            and(eq(customers.userId, userId), eq(customers.isOwnFirm, true)),
+            and(
+                eq(customers.userId, userId),
+                eq(customers.isOwnFirm, true),
+                eq(customers.isDeleted, false),
+            ),
         );
 
     // Convert amount from Stripe cents to milliunits (app stores amounts * 1000)

--- a/components/customer-select.tsx
+++ b/components/customer-select.tsx
@@ -43,6 +43,13 @@ const ALL_CUSTOMERS_OPTION = {
     contactEmail: null,
     contactTelephone: null,
     country: null,
+    isDeleted: false,
+    deletedAt: null,
+    deletedBy: null,
+    deleteReason: null,
+    restoredAt: null,
+    restoredBy: null,
+    restoreReason: null,
     transactionCount: 0,
 } as const;
 

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -154,12 +154,23 @@ export const customers = pgTable(
         isComplete: boolean('is_complete').notNull().default(false),
         // Flag to mark this customer as the user's own firm/company
         isOwnFirm: boolean('is_own_firm').notNull().default(false),
+        // Soft-delete lifecycle fields
+        isDeleted: boolean('is_deleted').notNull().default(false),
+        deletedAt: timestamp('deleted_at', { mode: 'date' }),
+        deletedBy: text('deleted_by'),
+        deleteReason: text('delete_reason'),
+        restoredAt: timestamp('restored_at', { mode: 'date' }),
+        restoredBy: text('restored_by'),
+        restoreReason: text('restore_reason'),
     },
     (table) => [
         index('customers_userid_idx').on(table.userId),
         index('customers_name_idx').on(table.name),
         index('customers_iscomplete_idx').on(table.isComplete),
         index('customers_isownfirm_idx').on(table.isOwnFirm),
+        index('customers_isdeleted_idx').on(table.isDeleted),
+        index('customers_deletedat_idx').on(table.deletedAt),
+        index('customers_deletedby_idx').on(table.deletedBy),
     ],
 );
 
@@ -185,10 +196,21 @@ export const customerIbans = pgTable(
         createdAt: timestamp('created_at', { mode: 'date' })
             .notNull()
             .defaultNow(),
+        // Soft-delete lifecycle fields
+        isDeleted: boolean('is_deleted').notNull().default(false),
+        deletedAt: timestamp('deleted_at', { mode: 'date' }),
+        deletedBy: text('deleted_by'),
+        deleteReason: text('delete_reason'),
+        restoredAt: timestamp('restored_at', { mode: 'date' }),
+        restoredBy: text('restored_by'),
+        restoreReason: text('restore_reason'),
     },
     (table) => [
         index('customer_ibans_customerid_idx').on(table.customerId),
         index('customer_ibans_iban_idx').on(table.iban),
+        index('customer_ibans_isdeleted_idx').on(table.isDeleted),
+        index('customer_ibans_deletedat_idx').on(table.deletedAt),
+        index('customer_ibans_deletedby_idx').on(table.deletedBy),
     ],
 );
 

--- a/drizzle/0046_colorful_rumiko_fujikawa.sql
+++ b/drizzle/0046_colorful_rumiko_fujikawa.sql
@@ -1,0 +1,20 @@
+ALTER TABLE "customer_ibans" ADD COLUMN "is_deleted" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "customer_ibans" ADD COLUMN "deleted_at" timestamp;--> statement-breakpoint
+ALTER TABLE "customer_ibans" ADD COLUMN "deleted_by" text;--> statement-breakpoint
+ALTER TABLE "customer_ibans" ADD COLUMN "delete_reason" text;--> statement-breakpoint
+ALTER TABLE "customer_ibans" ADD COLUMN "restored_at" timestamp;--> statement-breakpoint
+ALTER TABLE "customer_ibans" ADD COLUMN "restored_by" text;--> statement-breakpoint
+ALTER TABLE "customer_ibans" ADD COLUMN "restore_reason" text;--> statement-breakpoint
+ALTER TABLE "customers" ADD COLUMN "is_deleted" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "customers" ADD COLUMN "deleted_at" timestamp;--> statement-breakpoint
+ALTER TABLE "customers" ADD COLUMN "deleted_by" text;--> statement-breakpoint
+ALTER TABLE "customers" ADD COLUMN "delete_reason" text;--> statement-breakpoint
+ALTER TABLE "customers" ADD COLUMN "restored_at" timestamp;--> statement-breakpoint
+ALTER TABLE "customers" ADD COLUMN "restored_by" text;--> statement-breakpoint
+ALTER TABLE "customers" ADD COLUMN "restore_reason" text;--> statement-breakpoint
+CREATE INDEX "customer_ibans_isdeleted_idx" ON "customer_ibans" USING btree ("is_deleted");--> statement-breakpoint
+CREATE INDEX "customer_ibans_deletedat_idx" ON "customer_ibans" USING btree ("deleted_at");--> statement-breakpoint
+CREATE INDEX "customer_ibans_deletedby_idx" ON "customer_ibans" USING btree ("deleted_by");--> statement-breakpoint
+CREATE INDEX "customers_isdeleted_idx" ON "customers" USING btree ("is_deleted");--> statement-breakpoint
+CREATE INDEX "customers_deletedat_idx" ON "customers" USING btree ("deleted_at");--> statement-breakpoint
+CREATE INDEX "customers_deletedby_idx" ON "customers" USING btree ("deleted_by");

--- a/drizzle/meta/0046_snapshot.json
+++ b/drizzle/meta/0046_snapshot.json
@@ -1,0 +1,2812 @@
+{
+  "id": "f9e7129b-ec84-4d18-89df-2a761afe4640",
+  "prevId": "03080a10-afba-4835-bb0e-a890e54baf78",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounting_periods": {
+      "name": "accounting_periods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by": {
+          "name": "closed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounting_periods_userid_idx": {
+          "name": "accounting_periods_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounting_periods_status_idx": {
+          "name": "accounting_periods_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounting_periods_startdate_idx": {
+          "name": "accounting_periods_startdate_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounting_periods_enddate_idx": {
+          "name": "accounting_periods_enddate_idx",
+          "columns": [
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plaid_id": {
+          "name": "plaid_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_open": {
+          "name": "is_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_read_only": {
+          "name": "is_read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'neutral'"
+        },
+        "account_class": {
+          "name": "account_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_role": {
+          "name": "system_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_balance": {
+          "name": "opening_balance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "accounts_userid_idx": {
+          "name": "accounts_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_isopen_idx": {
+          "name": "accounts_isopen_idx",
+          "columns": [
+            {
+              "expression": "is_open",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_code_idx": {
+          "name": "accounts_code_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_systemrole_idx": {
+          "name": "accounts_systemrole_idx",
+          "columns": [
+            {
+              "expression": "system_role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_label": {
+          "name": "resource_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "field_delta": {
+          "name": "field_delta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reverted_from_event_id": {
+          "name": "reverted_from_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_events_userid_idx": {
+          "name": "audit_events_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_actoruserid_idx": {
+          "name": "audit_events_actoruserid_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_action_idx": {
+          "name": "audit_events_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_resource_idx": {
+          "name": "audit_events_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_createdat_idx": {
+          "name": "audit_events_createdat_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_requestid_idx": {
+          "name": "audit_events_requestid_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_revertedfromeventid_idx": {
+          "name": "audit_events_revertedfromeventid_idx",
+          "columns": [
+            {
+              "expression": "reverted_from_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_events_actor_type_check": {
+          "name": "audit_events_actor_type_check",
+          "value": "\"audit_events\".\"actor_type\" in ('user', 'system', 'integration')"
+        },
+        "audit_events_action_check": {
+          "name": "audit_events_action_check",
+          "value": "\"audit_events\".\"action\" in ('create', 'update', 'delete', 'restore', 'purge', 'import', 'sync', 'status_change', 'link', 'unlink', 'settings_update', 'integration_event')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bank_accounts": {
+      "name": "bank_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gocardless_account_id": {
+          "name": "gocardless_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iban": {
+          "name": "iban",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_name": {
+          "name": "owner_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'EUR'"
+        },
+        "linked_account_id": {
+          "name": "linked_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_transaction_date": {
+          "name": "last_transaction_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bank_accounts_connectionid_idx": {
+          "name": "bank_accounts_connectionid_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_accounts_userid_idx": {
+          "name": "bank_accounts_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_accounts_gocardlessaccountid_idx": {
+          "name": "bank_accounts_gocardlessaccountid_idx",
+          "columns": [
+            {
+              "expression": "gocardless_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_accounts_linkedaccountid_idx": {
+          "name": "bank_accounts_linkedaccountid_idx",
+          "columns": [
+            {
+              "expression": "linked_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_accounts_isactive_idx": {
+          "name": "bank_accounts_isactive_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bank_accounts_connection_id_bank_connections_id_fk": {
+          "name": "bank_accounts_connection_id_bank_connections_id_fk",
+          "tableFrom": "bank_accounts",
+          "tableTo": "bank_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bank_accounts_linked_account_id_accounts_id_fk": {
+          "name": "bank_accounts_linked_account_id_accounts_id_fk",
+          "tableFrom": "bank_accounts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "linked_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_connections": {
+      "name": "bank_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requisition_id": {
+          "name": "requisition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_name": {
+          "name": "institution_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_logo": {
+          "name": "institution_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreement_id": {
+          "name": "agreement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreement_expires_at": {
+          "name": "agreement_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bank_connections_userid_idx": {
+          "name": "bank_connections_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_connections_requisitionid_idx": {
+          "name": "bank_connections_requisitionid_idx",
+          "columns": [
+            {
+              "expression": "requisition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_connections_institutionid_idx": {
+          "name": "bank_connections_institutionid_idx",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_connections_status_idx": {
+          "name": "bank_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_ibans": {
+      "name": "customer_ibans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iban": {
+          "name": "iban",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bank_name": {
+          "name": "bank_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delete_reason": {
+          "name": "delete_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restored_at": {
+          "name": "restored_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restored_by": {
+          "name": "restored_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restore_reason": {
+          "name": "restore_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "customer_ibans_customerid_idx": {
+          "name": "customer_ibans_customerid_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customer_ibans_iban_idx": {
+          "name": "customer_ibans_iban_idx",
+          "columns": [
+            {
+              "expression": "iban",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customer_ibans_isdeleted_idx": {
+          "name": "customer_ibans_isdeleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customer_ibans_deletedat_idx": {
+          "name": "customer_ibans_deletedat_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customer_ibans_deletedby_idx": {
+          "name": "customer_ibans_deletedby_idx",
+          "columns": [
+            {
+              "expression": "deleted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_ibans_customer_id_customers_id_fk": {
+          "name": "customer_ibans_customer_id_customers_id_fk",
+          "tableFrom": "customer_ibans",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friendly_name": {
+          "name": "friendly_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_telephone": {
+          "name": "contact_telephone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_complete": {
+          "name": "is_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_own_firm": {
+          "name": "is_own_firm",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delete_reason": {
+          "name": "delete_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restored_at": {
+          "name": "restored_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restored_by": {
+          "name": "restored_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restore_reason": {
+          "name": "restore_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "customers_userid_idx": {
+          "name": "customers_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_name_idx": {
+          "name": "customers_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_iscomplete_idx": {
+          "name": "customers_iscomplete_idx",
+          "columns": [
+            {
+              "expression": "is_complete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_isownfirm_idx": {
+          "name": "customers_isownfirm_idx",
+          "columns": [
+            {
+              "expression": "is_own_firm",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_isdeleted_idx": {
+          "name": "customers_isdeleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_deletedat_idx": {
+          "name": "customers_deletedat_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_deletedby_idx": {
+          "name": "customers_deletedby_idx",
+          "columns": [
+            {
+              "expression": "deleted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_layouts": {
+      "name": "dashboard_layouts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "widgets_config": {
+          "name": "widgets_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dashboard_layouts_userid_idx": {
+          "name": "dashboard_layouts_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_types": {
+      "name": "document_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_types_userid_idx": {
+          "name": "document_types_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_types_name_idx": {
+          "name": "document_types_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_type_id": {
+          "name": "document_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delete_reason": {
+          "name": "delete_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restored_at": {
+          "name": "restored_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restored_by": {
+          "name": "restored_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restore_reason": {
+          "name": "restore_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "documents_transactionid_idx": {
+          "name": "documents_transactionid_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_documenttypeid_idx": {
+          "name": "documents_documenttypeid_idx",
+          "columns": [
+            {
+              "expression": "document_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_uploadedby_idx": {
+          "name": "documents_uploadedby_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_isdeleted_idx": {
+          "name": "documents_isdeleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_deletedat_idx": {
+          "name": "documents_deletedat_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_deletedby_idx": {
+          "name": "documents_deletedby_idx",
+          "columns": [
+            {
+              "expression": "deleted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "documents_document_type_id_document_types_id_fk": {
+          "name": "documents_document_type_id_document_types_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "document_types",
+          "columnsFrom": [
+            "document_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "documents_transaction_id_transactions_id_fk": {
+          "name": "documents_transaction_id_transactions_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gocardless_settings": {
+      "name": "gocardless_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_key": {
+          "name": "secret_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_credit_account_id": {
+          "name": "default_credit_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_debit_account_id": {
+          "name": "default_debit_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_tag_id": {
+          "name": "default_tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sync_from_date": {
+          "name": "sync_from_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gocardless_settings_userid_idx": {
+          "name": "gocardless_settings_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gocardless_settings_default_credit_account_id_accounts_id_fk": {
+          "name": "gocardless_settings_default_credit_account_id_accounts_id_fk",
+          "tableFrom": "gocardless_settings",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "default_credit_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gocardless_settings_default_debit_account_id_accounts_id_fk": {
+          "name": "gocardless_settings_default_debit_account_id_accounts_id_fk",
+          "tableFrom": "gocardless_settings",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "default_debit_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gocardless_settings_default_tag_id_tags_id_fk": {
+          "name": "gocardless_settings_default_tag_id_tags_id_fk",
+          "tableFrom": "gocardless_settings",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "default_tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.open_finances_settings": {
+      "name": "open_finances_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "exposed_metrics": {
+          "name": "exposed_metrics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_description": {
+          "name": "page_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_embedding": {
+          "name": "allow_embedding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "open_finances_settings_userid_idx": {
+          "name": "open_finances_settings_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "double_entry_mode": {
+          "name": "double_entry_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_draft_to_pending": {
+          "name": "auto_draft_to_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reconciliation_conditions": {
+          "name": "reconciliation_conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"hasReceipt\"]'"
+        },
+        "min_required_documents": {
+          "name": "min_required_documents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "required_document_type_ids": {
+          "name": "required_document_type_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "default_customer_country": {
+          "name": "default_customer_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "settings_userid_idx": {
+          "name": "settings_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_settings": {
+      "name": "stripe_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_secret_key": {
+          "name": "stripe_secret_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_credit_account_id": {
+          "name": "default_credit_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_debit_account_id": {
+          "name": "default_debit_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_tag_id": {
+          "name": "default_tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sync_from_date": {
+          "name": "sync_from_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_settings_userid_idx": {
+          "name": "stripe_settings_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_settings_stripeaccountid_idx": {
+          "name": "stripe_settings_stripeaccountid_idx",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_settings_default_credit_account_id_accounts_id_fk": {
+          "name": "stripe_settings_default_credit_account_id_accounts_id_fk",
+          "tableFrom": "stripe_settings",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "default_credit_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stripe_settings_default_debit_account_id_accounts_id_fk": {
+          "name": "stripe_settings_default_debit_account_id_accounts_id_fk",
+          "tableFrom": "stripe_settings",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "default_debit_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stripe_settings_default_tag_id_tags_id_fk": {
+          "name": "stripe_settings_default_tag_id_tags_id_fk",
+          "tableFrom": "stripe_settings",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "default_tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_type": {
+          "name": "tag_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tags_userid_idx": {
+          "name": "tags_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_tagtype_idx": {
+          "name": "tags_tagtype_idx",
+          "columns": [
+            {
+              "expression": "tag_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction_status_history": {
+      "name": "transaction_status_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "transaction_status_history_transactionid_idx": {
+          "name": "transaction_status_history_transactionid_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transaction_status_history_changedat_idx": {
+          "name": "transaction_status_history_changedat_idx",
+          "columns": [
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_status_history_transaction_id_transactions_id_fk": {
+          "name": "transaction_status_history_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_status_history",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction_tags": {
+      "name": "transaction_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transaction_tags_transactionid_idx": {
+          "name": "transaction_tags_transactionid_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transaction_tags_tagid_idx": {
+          "name": "transaction_tags_tagid_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_tags_transaction_id_transactions_id_fk": {
+          "name": "transaction_tags_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_tags",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_tags_tag_id_tags_id_fk": {
+          "name": "transaction_tags_tag_id_tags_id_fk",
+          "tableFrom": "transaction_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payee": {
+          "name": "payee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payee_customer_id": {
+          "name": "payee_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_account_id": {
+          "name": "credit_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debit_account_id": {
+          "name": "debit_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_changed_at": {
+          "name": "status_changed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status_changed_by": {
+          "name": "status_changed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "split_group_id": {
+          "name": "split_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "split_type": {
+          "name": "split_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_id": {
+          "name": "stripe_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_url": {
+          "name": "stripe_payment_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gocardless_transaction_id": {
+          "name": "gocardless_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closing_period_id": {
+          "name": "closing_period_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delete_reason": {
+          "name": "delete_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restored_at": {
+          "name": "restored_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restored_by": {
+          "name": "restored_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restore_reason": {
+          "name": "restore_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "transactions_accountid_idx": {
+          "name": "transactions_accountid_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_creditaccountid_idx": {
+          "name": "transactions_creditaccountid_idx",
+          "columns": [
+            {
+              "expression": "credit_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_debutaccountid_idx": {
+          "name": "transactions_debutaccountid_idx",
+          "columns": [
+            {
+              "expression": "debit_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_payeecustomerid_idx": {
+          "name": "transactions_payeecustomerid_idx",
+          "columns": [
+            {
+              "expression": "payee_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_date_idx": {
+          "name": "transactions_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_status_idx": {
+          "name": "transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_splitgroupid_idx": {
+          "name": "transactions_splitgroupid_idx",
+          "columns": [
+            {
+              "expression": "split_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_splittype_idx": {
+          "name": "transactions_splittype_idx",
+          "columns": [
+            {
+              "expression": "split_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_stripepaymentid_idx": {
+          "name": "transactions_stripepaymentid_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_gocardlesstransactionid_idx": {
+          "name": "transactions_gocardlesstransactionid_idx",
+          "columns": [
+            {
+              "expression": "gocardless_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_closingperiodid_idx": {
+          "name": "transactions_closingperiodid_idx",
+          "columns": [
+            {
+              "expression": "closing_period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_deletedat_idx": {
+          "name": "transactions_deletedat_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_deletedby_idx": {
+          "name": "transactions_deletedby_idx",
+          "columns": [
+            {
+              "expression": "deleted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_payee_customer_id_customers_id_fk": {
+          "name": "transactions_payee_customer_id_customers_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "payee_customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_credit_account_id_accounts_id_fk": {
+          "name": "transactions_credit_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "credit_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_debit_account_id_accounts_id_fk": {
+          "name": "transactions_debit_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "debit_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1782770564400,
       "tag": "0045_misty_sauron",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1782771257541,
+      "tag": "0046_colorful_rumiko_fujikawa",
+      "breakpoints": true
     }
   ]
 }

--- a/features/customers/api/use-get-customer-ibans.ts
+++ b/features/customers/api/use-get-customer-ibans.ts
@@ -9,6 +9,7 @@ export const useGetCustomerIbans = (customerId?: string) => {
             if (!customerId) throw new Error('Customer ID is required');
             const response = await client.api.customers[':id'].ibans.$get({
                 param: { id: customerId },
+                query: {},
             });
 
             if (!response.ok) {

--- a/features/customers/api/use-get-customer.ts
+++ b/features/customers/api/use-get-customer.ts
@@ -13,6 +13,7 @@ export const useGetCustomer = (id?: string, options?: GetCustomerOptions) => {
         queryFn: async () => {
             const response = await client.api.customers[':id'].$get({
                 param: { id },
+                query: {},
             });
 
             if (!response.ok) {

--- a/lib/customer-lifecycle.ts
+++ b/lib/customer-lifecycle.ts
@@ -1,0 +1,160 @@
+export const CUSTOMER_PROFILE_REVERT_FIELDS = [
+    'name',
+    'friendlyName',
+    'vatNumber',
+    'address',
+    'contactEmail',
+    'contactTelephone',
+    'country',
+    'isComplete',
+    'isOwnFirm',
+] as const;
+
+export const CUSTOMER_IBAN_REVERT_FIELDS = [
+    'iban',
+    'bankName',
+    'isDeleted',
+    'deletedAt',
+    'deletedBy',
+    'deleteReason',
+    'restoredAt',
+    'restoredBy',
+    'restoreReason',
+] as const;
+
+export const CUSTOMER_LIFECYCLE_REVERT_FIELDS = [
+    ...CUSTOMER_PROFILE_REVERT_FIELDS,
+    'isDeleted',
+    'deletedAt',
+    'deletedBy',
+    'deleteReason',
+    'restoredAt',
+    'restoredBy',
+    'restoreReason',
+] as const;
+
+type CustomerLifecyclePatchInput = {
+    userId: string;
+    reason?: string | null;
+    now?: Date;
+};
+
+export type RecordValue = string | number | boolean | null | Date | undefined;
+export type SnapshotRecord = Record<string, RecordValue>;
+
+const comparableValue = (value: unknown) => {
+    if (value === undefined) {
+        return null;
+    }
+
+    if (value instanceof Date) {
+        return value.toISOString();
+    }
+
+    return value;
+};
+
+const collectRevertConflicts = (
+    fields: readonly string[],
+    current: SnapshotRecord,
+    eventAfter: SnapshotRecord,
+) =>
+    fields.filter(
+        (field) =>
+            field in eventAfter &&
+            comparableValue(current[field]) !==
+                comparableValue(eventAfter[field]),
+    );
+
+export const createCustomerSoftDeletePatch = ({
+    userId,
+    reason = null,
+    now = new Date(),
+}: CustomerLifecyclePatchInput) => ({
+    isDeleted: true,
+    deletedAt: now,
+    deletedBy: userId,
+    deleteReason: reason,
+    restoredAt: null,
+    restoredBy: null,
+    restoreReason: null,
+});
+
+export const createCustomerRestorePatch = ({
+    userId,
+    reason = null,
+    now = new Date(),
+}: CustomerLifecyclePatchInput) => ({
+    isDeleted: false,
+    deletedAt: null,
+    deletedBy: null,
+    deleteReason: null,
+    restoredAt: now,
+    restoredBy: userId,
+    restoreReason: reason,
+});
+
+export const createCustomerIbanSoftDeletePatch = ({
+    userId,
+    reason = null,
+    now = new Date(),
+}: CustomerLifecyclePatchInput) => ({
+    isDeleted: true,
+    deletedAt: now,
+    deletedBy: userId,
+    deleteReason: reason,
+    restoredAt: null,
+    restoredBy: null,
+    restoreReason: null,
+});
+
+export const createCustomerIbanRestorePatch = ({
+    userId,
+    reason = null,
+    now = new Date(),
+}: CustomerLifecyclePatchInput) => ({
+    isDeleted: false,
+    deletedAt: null,
+    deletedBy: null,
+    deleteReason: null,
+    restoredAt: now,
+    restoredBy: userId,
+    restoreReason: reason,
+});
+
+export const createCustomerProfileRevertPatch = (eventBefore: SnapshotRecord) =>
+    Object.fromEntries(
+        CUSTOMER_PROFILE_REVERT_FIELDS.filter(
+            (field) => field in eventBefore,
+        ).map((field) => [field, eventBefore[field] ?? null]),
+    );
+
+export const getCustomerProfileRevertConflicts = ({
+    current,
+    eventAfter,
+}: {
+    current: SnapshotRecord;
+    eventAfter: SnapshotRecord;
+}) =>
+    collectRevertConflicts(CUSTOMER_PROFILE_REVERT_FIELDS, current, eventAfter);
+
+export const getCustomerLifecycleRevertConflicts = ({
+    current,
+    eventAfter,
+}: {
+    current: SnapshotRecord;
+    eventAfter: SnapshotRecord;
+}) =>
+    collectRevertConflicts(
+        CUSTOMER_LIFECYCLE_REVERT_FIELDS,
+        current,
+        eventAfter,
+    );
+
+export const getCustomerIbanRevertConflicts = ({
+    current,
+    eventAfter,
+}: {
+    current: SnapshotRecord;
+    eventAfter: SnapshotRecord;
+}) => collectRevertConflicts(CUSTOMER_IBAN_REVERT_FIELDS, current, eventAfter);

--- a/tests/customer-lifecycle.test.mjs
+++ b/tests/customer-lifecycle.test.mjs
@@ -1,0 +1,173 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+    createCustomerIbanRestorePatch,
+    createCustomerIbanSoftDeletePatch,
+    createCustomerProfileRevertPatch,
+    createCustomerRestorePatch,
+    createCustomerSoftDeletePatch,
+    getCustomerIbanRevertConflicts,
+    getCustomerLifecycleRevertConflicts,
+    getCustomerProfileRevertConflicts,
+} from '../lib/customer-lifecycle.ts';
+
+test('customer soft delete patch records user, time, and reason', () => {
+    const now = new Date('2026-06-29T12:00:00.000Z');
+    const patch = createCustomerSoftDeletePatch({
+        userId: 'user_1',
+        reason: 'Duplicate customer',
+        now,
+    });
+
+    assert.deepEqual(patch, {
+        isDeleted: true,
+        deletedAt: now,
+        deletedBy: 'user_1',
+        deleteReason: 'Duplicate customer',
+        restoredAt: null,
+        restoredBy: null,
+        restoreReason: null,
+    });
+});
+
+test('customer restore patch clears delete fields and records restore metadata', () => {
+    const now = new Date('2026-06-29T12:10:00.000Z');
+    const patch = createCustomerRestorePatch({
+        userId: 'user_1',
+        reason: 'Needed for transaction history',
+        now,
+    });
+
+    assert.deepEqual(patch, {
+        isDeleted: false,
+        deletedAt: null,
+        deletedBy: null,
+        deleteReason: null,
+        restoredAt: now,
+        restoredBy: 'user_1',
+        restoreReason: 'Needed for transaction history',
+    });
+});
+
+test('customer profile revert patch is limited to editable customer fields', () => {
+    const patch = createCustomerProfileRevertPatch({
+        id: 'cus_1',
+        name: 'Before',
+        friendlyName: null,
+        vatNumber: 'HR123',
+        address: 'Old address',
+        contactEmail: 'old@example.com',
+        contactTelephone: '+3851',
+        country: 'HR',
+        isComplete: true,
+        isOwnFirm: false,
+        userId: 'user_1',
+        deletedAt: '2026-06-29T12:00:00.000Z',
+    });
+
+    assert.deepEqual(patch, {
+        name: 'Before',
+        friendlyName: null,
+        vatNumber: 'HR123',
+        address: 'Old address',
+        contactEmail: 'old@example.com',
+        contactTelephone: '+3851',
+        country: 'HR',
+        isComplete: true,
+        isOwnFirm: false,
+    });
+});
+
+test('customer profile revert detects conflicting current changes', () => {
+    const conflicts = getCustomerProfileRevertConflicts({
+        current: {
+            name: 'Changed again',
+            vatNumber: 'HR123',
+            isOwnFirm: true,
+        },
+        eventAfter: {
+            name: 'After',
+            vatNumber: 'HR123',
+            isOwnFirm: true,
+        },
+    });
+
+    assert.deepEqual(conflicts, ['name']);
+});
+
+test('customer lifecycle revert detects later delete changes', () => {
+    const conflicts = getCustomerLifecycleRevertConflicts({
+        current: {
+            name: 'Customer',
+            isDeleted: true,
+            deletedAt: '2026-06-29T12:10:00.000Z',
+            deletedBy: 'user_1',
+            deleteReason: 'Deleted again',
+        },
+        eventAfter: {
+            name: 'Customer',
+            isDeleted: true,
+            deletedAt: '2026-06-29T12:00:00.000Z',
+            deletedBy: 'user_1',
+            deleteReason: 'Original delete',
+        },
+    });
+
+    assert.deepEqual(conflicts, ['deletedAt', 'deleteReason']);
+});
+
+test('customer IBAN lifecycle patches support delete and restore', () => {
+    const now = new Date('2026-06-29T12:00:00.000Z');
+
+    assert.deepEqual(
+        createCustomerIbanSoftDeletePatch({
+            userId: 'user_1',
+            reason: 'Closed account',
+            now,
+        }),
+        {
+            isDeleted: true,
+            deletedAt: now,
+            deletedBy: 'user_1',
+            deleteReason: 'Closed account',
+            restoredAt: null,
+            restoredBy: null,
+            restoreReason: null,
+        },
+    );
+
+    assert.deepEqual(
+        createCustomerIbanRestorePatch({
+            userId: 'user_1',
+            reason: 'Account active again',
+            now,
+        }),
+        {
+            isDeleted: false,
+            deletedAt: null,
+            deletedBy: null,
+            deleteReason: null,
+            restoredAt: now,
+            restoredBy: 'user_1',
+            restoreReason: 'Account active again',
+        },
+    );
+});
+
+test('customer IBAN revert detects conflicts before restore or delete', () => {
+    const conflicts = getCustomerIbanRevertConflicts({
+        current: {
+            iban: 'HR1210010051863000160',
+            bankName: 'Changed Bank',
+            isDeleted: true,
+        },
+        eventAfter: {
+            iban: 'HR1210010051863000160',
+            bankName: 'Original Bank',
+            isDeleted: true,
+        },
+    });
+
+    assert.deepEqual(conflicts, ['bankName']);
+});


### PR DESCRIPTION
## Summary

- Adds soft-delete lifecycle metadata for customers and customer IBANs, with restore paths and active/trash filtering.
- Records explicit before/after audit events for customer create/update/delete/restore, bulk delete, own-firm unmarking, and IBAN create/delete/restore.
- Adds customer history and conflict-checked revert APIs for customer profile/lifecycle and IBAN audit events.
- Keeps normal customer suggestion, IBAN lookup, and Stripe own-firm selection paths limited to active customers while preserving existing transaction references.

## Verification

- `./node_modules/.bin/biome check 'app/api/[[...route]]/customersRoutes.ts' 'app/api/[[...route]]/transactionsRoutes.ts' 'app/api/[[...route]]/stripeRoutes.ts' 'app/api/stripe/webhook/route.ts' 'app/api/stripe/cron/route.ts' components/customer-select.tsx db/schema.ts features/customers/api/use-get-customer-ibans.ts features/customers/api/use-get-customer.ts lib/customer-lifecycle.ts tests/customer-lifecycle.test.mjs`
- `node --experimental-strip-types --test tests/audit.test.mjs tests/transaction-lifecycle.test.mjs tests/document-lifecycle.test.mjs tests/customer-lifecycle.test.mjs`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/db ./node_modules/.bin/drizzle-kit check --config=drizzle.config.ts`
- `git diff --check`

## Risk

- Customer and IBAN deletes are now soft deletes; permanent purge is intentionally left to the later trash/history UI work.
- Revert endpoints reject conflicting current state instead of overwriting later changes.

Closes #129