### PR TITLE
Add audit history and trash recovery UI

### DIFF
--- a/app/(dashboard)/audit/page.tsx
+++ b/app/(dashboard)/audit/page.tsx
@@ -1,0 +1,341 @@
+'use client';
+
+import { Button } from '@signalco/ui-primitives/Button';
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+} from '@signalco/ui-primitives/Card';
+import { Input } from '@signalco/ui-primitives/Input';
+import {
+    Tabs,
+    TabsContent,
+    TabsList,
+    TabsTrigger,
+} from '@signalco/ui-primitives/Tabs';
+import { format } from 'date-fns';
+import { RotateCcw } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { Label } from '@/components/ui/label';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import type { AuditEvent } from '@/features/audit/api/use-get-audit-events';
+import { useGetAuditEvents } from '@/features/audit/api/use-get-audit-events';
+import { useGetDeletedDocuments } from '@/features/audit/api/use-get-deleted-documents';
+import { useGetDeletedTransactions } from '@/features/audit/api/use-get-deleted-transactions';
+import { useRestoreDocument } from '@/features/audit/api/use-restore-document';
+import { useRestoreTransaction } from '@/features/audit/api/use-restore-transaction';
+import { useRevertCustomerAuditEvent } from '@/features/audit/api/use-revert-customer-audit-event';
+import { AuditEventList } from '@/features/audit/components/audit-event-list';
+import { formatCurrency } from '@/lib/utils';
+
+const resourceTypes = [
+    'transaction',
+    'document',
+    'customer',
+    'customer_iban',
+    'account',
+    'tag',
+] as const;
+
+const actions = [
+    'create',
+    'update',
+    'delete',
+    'restore',
+    'purge',
+    'import',
+    'sync',
+    'status_change',
+    'link',
+    'unlink',
+] as const;
+
+const formatDateTime = (value?: string | Date | null) =>
+    value ? format(new Date(value), 'MMM d, yyyy HH:mm') : 'Unknown';
+
+export default function AuditPage() {
+    const [resourceType, setResourceType] = useState('all');
+    const [action, setAction] = useState('all');
+    const [resourceId, setResourceId] = useState('');
+    const [source, setSource] = useState('');
+    const [revertingEventId, setRevertingEventId] = useState<string | null>(
+        null,
+    );
+
+    const filters = useMemo(
+        () => ({
+            resourceType: resourceType === 'all' ? undefined : resourceType,
+            action: action === 'all' ? undefined : action,
+            resourceId: resourceId.trim() || undefined,
+            source: source.trim() || undefined,
+            limit: 100,
+        }),
+        [action, resourceId, resourceType, source],
+    );
+
+    const auditEventsQuery = useGetAuditEvents(filters);
+    const deletedTransactionsQuery = useGetDeletedTransactions();
+    const deletedDocumentsQuery = useGetDeletedDocuments();
+    const restoreTransaction = useRestoreTransaction();
+    const restoreDocument = useRestoreDocument();
+    const revertCustomerAuditEvent = useRevertCustomerAuditEvent();
+
+    const handleRevertCustomerEvent = async (
+        event: AuditEvent,
+        customerId: string,
+    ) => {
+        if (!window.confirm('Revert this customer change?')) {
+            return;
+        }
+
+        setRevertingEventId(event.id);
+        try {
+            await revertCustomerAuditEvent.mutateAsync({
+                customerId,
+                auditEventId: event.id,
+                reason: 'Reverted from audit log',
+            });
+        } finally {
+            setRevertingEventId(null);
+        }
+    };
+
+    return (
+        <div className="mx-auto -mt-24 w-full max-w-screen-2xl pb-10">
+            <Card>
+                <CardHeader>
+                    <CardTitle>Audit</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <Tabs defaultValue="log" className="space-y-6">
+                        <TabsList>
+                            <TabsTrigger value="log">Log</TabsTrigger>
+                            <TabsTrigger value="trash">Trash</TabsTrigger>
+                        </TabsList>
+
+                        <TabsContent value="log" className="space-y-4">
+                            <div className="grid gap-3 md:grid-cols-4">
+                                <div className="space-y-1.5">
+                                    <Label>Resource</Label>
+                                    <Select
+                                        value={resourceType}
+                                        onValueChange={setResourceType}
+                                    >
+                                        <SelectTrigger>
+                                            <SelectValue />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value="all">
+                                                All resources
+                                            </SelectItem>
+                                            {resourceTypes.map((type) => (
+                                                <SelectItem
+                                                    key={type}
+                                                    value={type}
+                                                >
+                                                    {type}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                                <div className="space-y-1.5">
+                                    <Label>Action</Label>
+                                    <Select
+                                        value={action}
+                                        onValueChange={setAction}
+                                    >
+                                        <SelectTrigger>
+                                            <SelectValue />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value="all">
+                                                All actions
+                                            </SelectItem>
+                                            {actions.map((item) => (
+                                                <SelectItem
+                                                    key={item}
+                                                    value={item}
+                                                >
+                                                    {item}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                                <div className="space-y-1.5">
+                                    <Label>Resource ID</Label>
+                                    <Input
+                                        value={resourceId}
+                                        onChange={(event) =>
+                                            setResourceId(event.target.value)
+                                        }
+                                    />
+                                </div>
+                                <div className="space-y-1.5">
+                                    <Label>Source</Label>
+                                    <Input
+                                        value={source}
+                                        onChange={(event) =>
+                                            setSource(event.target.value)
+                                        }
+                                    />
+                                </div>
+                            </div>
+
+                            <AuditEventList
+                                events={auditEventsQuery.data}
+                                isLoading={auditEventsQuery.isLoading}
+                                isError={auditEventsQuery.isError}
+                                onRevertCustomerEvent={
+                                    handleRevertCustomerEvent
+                                }
+                                revertingEventId={revertingEventId}
+                            />
+                        </TabsContent>
+
+                        <TabsContent value="trash" className="space-y-6">
+                            <section className="space-y-3">
+                                <div className="flex items-center justify-between gap-3">
+                                    <h2 className="text-base font-semibold">
+                                        Transactions
+                                    </h2>
+                                    <span className="text-sm text-muted-foreground">
+                                        {deletedTransactionsQuery.data
+                                            ?.length ?? 0}
+                                    </span>
+                                </div>
+                                {deletedTransactionsQuery.isLoading ? (
+                                    <div className="h-24 animate-pulse rounded-md border bg-muted/30" />
+                                ) : deletedTransactionsQuery.isError ? (
+                                    <div className="rounded-md border border-destructive/30 p-4 text-sm text-destructive">
+                                        Failed to load deleted transactions.
+                                    </div>
+                                ) : deletedTransactionsQuery.data?.length ? (
+                                    <div className="divide-y rounded-md border">
+                                        {deletedTransactionsQuery.data.map(
+                                            (transaction) => (
+                                                <div
+                                                    key={transaction.id}
+                                                    className="flex items-center justify-between gap-3 p-3"
+                                                >
+                                                    <div className="min-w-0">
+                                                        <div className="truncate text-sm font-medium">
+                                                            {transaction.payeeCustomerName ||
+                                                                transaction.payee ||
+                                                                'Untitled transaction'}
+                                                        </div>
+                                                        <div className="text-xs text-muted-foreground">
+                                                            {formatDateTime(
+                                                                transaction.deletedAt,
+                                                            )}{' '}
+                                                            -{' '}
+                                                            {formatCurrency(
+                                                                transaction.amount,
+                                                            )}
+                                                        </div>
+                                                    </div>
+                                                    <Button
+                                                        type="button"
+                                                        size="sm"
+                                                        variant="outlined"
+                                                        disabled={
+                                                            restoreTransaction.isPending
+                                                        }
+                                                        onClick={() =>
+                                                            restoreTransaction.mutate(
+                                                                transaction.id,
+                                                            )
+                                                        }
+                                                    >
+                                                        <RotateCcw className="mr-2 size-4" />
+                                                        Restore
+                                                    </Button>
+                                                </div>
+                                            ),
+                                        )}
+                                    </div>
+                                ) : (
+                                    <div className="rounded-md border p-4 text-sm text-muted-foreground">
+                                        No deleted transactions.
+                                    </div>
+                                )}
+                            </section>
+
+                            <section className="space-y-3">
+                                <div className="flex items-center justify-between gap-3">
+                                    <h2 className="text-base font-semibold">
+                                        Documents
+                                    </h2>
+                                    <span className="text-sm text-muted-foreground">
+                                        {deletedDocumentsQuery.data?.length ??
+                                            0}
+                                    </span>
+                                </div>
+                                {deletedDocumentsQuery.isLoading ? (
+                                    <div className="h-24 animate-pulse rounded-md border bg-muted/30" />
+                                ) : deletedDocumentsQuery.isError ? (
+                                    <div className="rounded-md border border-destructive/30 p-4 text-sm text-destructive">
+                                        Failed to load deleted documents.
+                                    </div>
+                                ) : deletedDocumentsQuery.data?.length ? (
+                                    <div className="divide-y rounded-md border">
+                                        {deletedDocumentsQuery.data.map(
+                                            (document) => (
+                                                <div
+                                                    key={document.id}
+                                                    className="flex items-center justify-between gap-3 p-3"
+                                                >
+                                                    <div className="min-w-0">
+                                                        <div className="truncate text-sm font-medium">
+                                                            {document.fileName}
+                                                        </div>
+                                                        <div className="text-xs text-muted-foreground">
+                                                            {formatDateTime(
+                                                                document.deletedAt,
+                                                            )}{' '}
+                                                            -{' '}
+                                                            {document.documentTypeName ||
+                                                                'Unknown type'}
+                                                        </div>
+                                                    </div>
+                                                    <Button
+                                                        type="button"
+                                                        size="sm"
+                                                        variant="outlined"
+                                                        disabled={
+                                                            restoreDocument.isPending
+                                                        }
+                                                        onClick={() =>
+                                                            restoreDocument.mutate(
+                                                                document.id,
+                                                            )
+                                                        }
+                                                    >
+                                                        <RotateCcw className="mr-2 size-4" />
+                                                        Restore
+                                                    </Button>
+                                                </div>
+                                            ),
+                                        )}
+                                    </div>
+                                ) : (
+                                    <div className="rounded-md border p-4 text-sm text-muted-foreground">
+                                        No deleted documents.
+                                    </div>
+                                )}
+                            </section>
+                        </TabsContent>
+                    </Tabs>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/app/(dashboard)/documents/actions.tsx
+++ b/app/(dashboard)/documents/actions.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { Button } from '@signalco/ui-primitives/Button';
-import { Download, Trash2 } from 'lucide-react';
+import { Download, History, Trash2 } from 'lucide-react';
 
 interface DocumentActionsProps {
     documentId: string;
     onDownload: (documentId: string) => void;
     onDelete: (documentId: string) => void;
+    onHistory: (documentId: string) => void;
     isDeleting?: boolean;
 }
 
@@ -14,6 +15,7 @@ export function DocumentActions({
     documentId,
     onDownload,
     onDelete,
+    onHistory,
     isDeleting,
 }: DocumentActionsProps) {
     return (
@@ -31,6 +33,17 @@ export function DocumentActions({
                 title="Download"
             >
                 <Download className="h-4 w-4" />
+            </Button>
+            <Button
+                size="sm"
+                variant="plain"
+                onClick={(e) => {
+                    e.stopPropagation();
+                    onHistory(documentId);
+                }}
+                title="History"
+            >
+                <History className="h-4 w-4" />
             </Button>
             <Button
                 size="sm"

--- a/app/(dashboard)/documents/columns.tsx
+++ b/app/(dashboard)/documents/columns.tsx
@@ -24,12 +24,14 @@ const MAX_PAYEE_LENGTH = 15;
 interface GetColumnsProps {
     onDownload: (documentId: string) => void;
     onDelete: (documentId: string) => void;
+    onHistory: (documentId: string) => void;
     isDeleting?: boolean;
 }
 
 export const getColumns = ({
     onDownload,
     onDelete,
+    onHistory,
     isDeleting,
 }: GetColumnsProps): ColumnDef<ResponseType>[] => [
     {
@@ -149,6 +151,7 @@ export const getColumns = ({
                     documentId={row.original.id}
                     onDownload={onDownload}
                     onDelete={onDelete}
+                    onHistory={onHistory}
                     isDeleting={isDeleting}
                 />
             );

--- a/app/(dashboard)/documents/page.tsx
+++ b/app/(dashboard)/documents/page.tsx
@@ -32,6 +32,7 @@ import {
     SheetTitle,
 } from '@/components/ui/sheet';
 import { Skeleton } from '@/components/ui/skeleton';
+import { AuditHistoryPanel } from '@/features/audit/components/audit-history-panel';
 import { useCreateStandaloneDocument } from '@/features/documents/api/use-create-standalone-document';
 import { useGetAllDocuments } from '@/features/documents/api/use-get-all-documents';
 import {
@@ -44,6 +45,9 @@ import { getColumns, type ResponseType } from './columns';
 
 export default function DocumentsPage() {
     const [showUploadSheet, setShowUploadSheet] = useState(false);
+    const [historyDocumentId, setHistoryDocumentId] = useState<string | null>(
+        null,
+    );
     const [selectedTypeFilter, setSelectedTypeFilter] = useState<string>('all');
     const [showUnattachedOnly, setShowUnattachedOnly] = useState(false);
     const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -113,14 +117,19 @@ export default function DocumentsPage() {
         }
     };
 
+    const handleHistory = useCallback((documentId: string) => {
+        setHistoryDocumentId(documentId);
+    }, []);
+
     const columns = useMemo(
         () =>
             getColumns({
                 onDownload: handleDownload,
                 onDelete: handleDelete,
+                onHistory: handleHistory,
                 isDeleting,
             }),
-        [isDeleting, handleDownload, handleDelete],
+        [isDeleting, handleDownload, handleDelete, handleHistory],
     );
 
     const skeletonColumns = useMemo(
@@ -228,7 +237,44 @@ export default function DocumentsPage() {
                 onOpenChange={setShowUploadSheet}
                 documentTypes={documentTypes}
             />
+            <DocumentHistorySheet
+                documentId={historyDocumentId}
+                onOpenChange={(open) => {
+                    if (!open) {
+                        setHistoryDocumentId(null);
+                    }
+                }}
+            />
         </div>
+    );
+}
+
+function DocumentHistorySheet({
+    documentId,
+    onOpenChange,
+}: {
+    documentId: string | null;
+    onOpenChange: (open: boolean) => void;
+}) {
+    return (
+        <Sheet open={Boolean(documentId)} onOpenChange={onOpenChange}>
+            <SheetContent className="flex h-full flex-col p-0">
+                <div className="px-6 pt-6">
+                    <SheetHeader>
+                        <SheetTitle>Document History</SheetTitle>
+                        <SheetDescription>
+                            Audit events for this document.
+                        </SheetDescription>
+                    </SheetHeader>
+                </div>
+                <div className="flex-1 overflow-y-auto px-6 py-4">
+                    <AuditHistoryPanel
+                        resourceType="document"
+                        resourceId={documentId}
+                    />
+                </div>
+            </SheetContent>
+        </Sheet>
     );
 }
 

--- a/app/api/[[...route]]/auditEventsRoutes.ts
+++ b/app/api/[[...route]]/auditEventsRoutes.ts
@@ -1,0 +1,90 @@
+import { clerkMiddleware, getAuth } from '@hono/clerk-auth';
+import { zValidator } from '@hono/zod-validator';
+import { and, desc, eq, gte, lte, sql } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { z } from 'zod';
+
+import { db } from '@/db/drizzle';
+import { auditEvents } from '@/db/schema';
+import {
+    normalizeAuditEventDate,
+    normalizeAuditEventLimit,
+    normalizeAuditEventSource,
+} from '@/lib/audit-query';
+
+const auditEventQuerySchema = z.object({
+    resourceType: z.string().optional(),
+    resourceId: z.string().optional(),
+    actorUserId: z.string().optional(),
+    actorType: z.enum(['user', 'system', 'integration']).optional(),
+    action: z.string().optional(),
+    from: z.string().optional(),
+    to: z.string().optional(),
+    source: z.string().optional(),
+    limit: z.coerce.number().optional(),
+});
+
+const app = new Hono().get(
+    '/',
+    clerkMiddleware(),
+    zValidator('query', auditEventQuerySchema),
+    async (ctx) => {
+        const auth = getAuth(ctx);
+        const query = ctx.req.valid('query');
+
+        if (!auth?.userId) {
+            return ctx.json({ error: 'Unauthorized.' }, 401);
+        }
+
+        const source = normalizeAuditEventSource(query.source);
+        const from = normalizeAuditEventDate(query.from);
+        const to = normalizeAuditEventDate(query.to);
+
+        const conditions = [eq(auditEvents.userId, auth.userId)];
+
+        if (query.resourceType) {
+            conditions.push(eq(auditEvents.resourceType, query.resourceType));
+        }
+
+        if (query.resourceId) {
+            conditions.push(eq(auditEvents.resourceId, query.resourceId));
+        }
+
+        if (query.actorUserId) {
+            conditions.push(eq(auditEvents.actorUserId, query.actorUserId));
+        }
+
+        if (query.actorType) {
+            conditions.push(eq(auditEvents.actorType, query.actorType));
+        }
+
+        if (query.action) {
+            conditions.push(eq(auditEvents.action, query.action));
+        }
+
+        if (from) {
+            conditions.push(gte(auditEvents.createdAt, from));
+        }
+
+        if (to) {
+            conditions.push(lte(auditEvents.createdAt, to));
+        }
+
+        if (source) {
+            conditions.push(
+                sql`${auditEvents.sourceMetadata}->>'source' = ${source}`,
+            );
+        }
+
+        const data = await db
+            .select()
+            .from(auditEvents)
+            .where(and(...conditions))
+            .orderBy(desc(auditEvents.createdAt))
+            .limit(normalizeAuditEventLimit(query.limit));
+
+        return ctx.json({ data });
+    },
+);
+
+export default app;

--- a/app/api/[[...route]]/route.ts
+++ b/app/api/[[...route]]/route.ts
@@ -6,6 +6,7 @@ import { auditMutationMiddleware } from '@/lib/audit-hono';
 
 import accountingPeriodsRoutes from './accountingPeriodsRoutes';
 import accountsRoutes from './accountsRoutes';
+import auditEventsRoutes from './auditEventsRoutes';
 import bankingRoutes from './bankingRoutes';
 import customersRoutes from './customersRoutes';
 import dashboardRoutes from './dashboardRoutes';
@@ -92,6 +93,7 @@ app.use('*', auditMutationMiddleware);
 const routes = app
     .route('/accounting-periods', accountingPeriodsRoutes)
     .route('/accounts', accountsRoutes)
+    .route('/audit-events', auditEventsRoutes)
     .route('/customers', customersRoutes)
     .route('/dashboard', dashboardRoutes)
     .route('/summary', summaryRoutes)

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -5,6 +5,7 @@ import {
     ArrowLeftRight,
     BarChart3,
     FileText,
+    History,
     Landmark,
     LayoutDashboard,
     Menu,
@@ -49,6 +50,11 @@ const routes = [
         href: '/customers',
         label: 'Customers',
         icon: Users,
+    },
+    {
+        href: '/audit',
+        label: 'Audit',
+        icon: History,
     },
     {
         href: '/accounts',

--- a/features/audit/api/use-get-audit-events.ts
+++ b/features/audit/api/use-get-audit-events.ts
@@ -1,0 +1,49 @@
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import type { InferResponseType } from 'hono';
+
+import { client } from '@/lib/hono';
+
+export type AuditEventFilters = {
+    resourceType?: string;
+    resourceId?: string;
+    actorUserId?: string;
+    actorType?: 'user' | 'system' | 'integration';
+    action?: string;
+    from?: string;
+    to?: string;
+    source?: string;
+    limit?: number;
+};
+
+export type AuditEvent = InferResponseType<
+    (typeof client.api)['audit-events']['$get'],
+    200
+>['data'][0];
+
+export const useGetAuditEvents = (filters?: AuditEventFilters) =>
+    useQuery({
+        queryKey: ['audit-events', filters],
+        placeholderData: keepPreviousData,
+        queryFn: async () => {
+            const response = await client.api['audit-events'].$get({
+                query: {
+                    resourceType: filters?.resourceType,
+                    resourceId: filters?.resourceId,
+                    actorUserId: filters?.actorUserId,
+                    actorType: filters?.actorType,
+                    action: filters?.action,
+                    from: filters?.from,
+                    to: filters?.to,
+                    source: filters?.source,
+                    limit: filters?.limit?.toString(),
+                },
+            });
+
+            if (!response.ok) {
+                throw new Error('Failed to fetch audit events.');
+            }
+
+            const { data } = await response.json();
+            return data;
+        },
+    });

--- a/features/audit/api/use-get-customer-history.ts
+++ b/features/audit/api/use-get-customer-history.ts
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query';
+import type { InferResponseType } from 'hono';
+
+import { client } from '@/lib/hono';
+
+export type CustomerHistoryEvent = InferResponseType<
+    (typeof client.api.customers)[':id']['history']['$get'],
+    200
+>['data'][0];
+
+export const useGetCustomerHistory = (customerId?: string | null) =>
+    useQuery({
+        enabled: Boolean(customerId),
+        queryKey: ['audit-events', { resourceType: 'customer', customerId }],
+        queryFn: async () => {
+            if (!customerId) {
+                throw new Error('Customer ID is required.');
+            }
+
+            const response = await client.api.customers[':id'].history.$get({
+                param: { id: customerId },
+            });
+
+            if (!response.ok) {
+                throw new Error('Failed to fetch customer history.');
+            }
+
+            const { data } = await response.json();
+            return data;
+        },
+    });

--- a/features/audit/api/use-get-deleted-documents.ts
+++ b/features/audit/api/use-get-deleted-documents.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { client } from '@/lib/hono';
+
+export const useGetDeletedDocuments = () =>
+    useQuery({
+        queryKey: ['all-documents', { deleted: 'only' }],
+        queryFn: async () => {
+            const response = await client.api.documents.$get({
+                query: {
+                    documentTypeId: undefined,
+                    from: undefined,
+                    to: undefined,
+                    unattached: undefined,
+                    deleted: 'only',
+                },
+            });
+
+            if (!response.ok) {
+                throw new Error('Failed to fetch deleted documents.');
+            }
+
+            const { data } = await response.json();
+            return data;
+        },
+    });

--- a/features/audit/api/use-get-deleted-transactions.ts
+++ b/features/audit/api/use-get-deleted-transactions.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { client } from '@/lib/hono';
+import { convertAmountFromMiliunits } from '@/lib/utils';
+
+export const useGetDeletedTransactions = () =>
+    useQuery({
+        queryKey: ['transactions', { deleted: 'only' }],
+        queryFn: async () => {
+            const response = await client.api.transactions.$get({
+                query: {
+                    from: '1970-01-01',
+                    to: '2999-12-31',
+                    accountId: undefined,
+                    payeeCustomerId: undefined,
+                    deleted: 'only',
+                },
+            });
+
+            if (!response.ok) {
+                throw new Error('Failed to fetch deleted transactions.');
+            }
+
+            const { data } = await response.json();
+            return data.map((transaction) => ({
+                ...transaction,
+                amount: convertAmountFromMiliunits(transaction.amount),
+            }));
+        },
+    });

--- a/features/audit/api/use-restore-document.ts
+++ b/features/audit/api/use-restore-document.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { client } from '@/lib/hono';
+
+export const useRestoreDocument = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async (id: string) => {
+            const response = await client.api.documents[':id'].restore.$post({
+                param: { id },
+            });
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => null);
+                throw new Error(
+                    (errorData as { error?: string } | null)?.error ??
+                        'Failed to restore document.',
+                );
+            }
+
+            return await response.json();
+        },
+        onSuccess: () => {
+            toast.success('Document restored.');
+            queryClient.invalidateQueries({ queryKey: ['all-documents'] });
+            queryClient.invalidateQueries({ queryKey: ['documents'] });
+            queryClient.invalidateQueries({ queryKey: ['audit-events'] });
+        },
+        onError: (error) => {
+            toast.error(error.message);
+        },
+    });
+};

--- a/features/audit/api/use-restore-transaction.ts
+++ b/features/audit/api/use-restore-transaction.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { client } from '@/lib/hono';
+
+export const useRestoreTransaction = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async (id: string) => {
+            const response = await client.api.transactions[':id'].restore.$post(
+                {
+                    param: { id },
+                },
+            );
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => null);
+                throw new Error(
+                    (errorData as { error?: string } | null)?.error ??
+                        'Failed to restore transaction.',
+                );
+            }
+
+            return await response.json();
+        },
+        onSuccess: () => {
+            toast.success('Transaction restored.');
+            queryClient.invalidateQueries({ queryKey: ['transactions'] });
+            queryClient.invalidateQueries({ queryKey: ['summary'] });
+            queryClient.invalidateQueries({ queryKey: ['audit-events'] });
+        },
+        onError: (error) => {
+            toast.error(error.message);
+        },
+    });
+};

--- a/features/audit/api/use-revert-customer-audit-event.ts
+++ b/features/audit/api/use-revert-customer-audit-event.ts
@@ -1,0 +1,64 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { client } from '@/lib/hono';
+
+export type RevertCustomerAuditEventInput = {
+    customerId: string;
+    auditEventId: string;
+    reason?: string;
+};
+
+export const useRevertCustomerAuditEvent = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async ({
+            customerId,
+            auditEventId,
+            reason,
+        }: RevertCustomerAuditEventInput) => {
+            const response = await client.api.customers[':id'].revert.$post({
+                param: { id: customerId },
+                json: {
+                    auditEventId,
+                    reason,
+                },
+            });
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => null);
+                const conflicts =
+                    (errorData as { conflicts?: string[] } | null)?.conflicts ??
+                    [];
+                const conflictText =
+                    conflicts.length > 0 ? ` (${conflicts.join(', ')})` : '';
+                throw new Error(
+                    `${
+                        (errorData as { error?: string } | null)?.error ??
+                        'Failed to revert customer change.'
+                    }${conflictText}`,
+                );
+            }
+
+            return await response.json();
+        },
+        onSuccess: (_, variables) => {
+            toast.success('Customer change reverted.');
+            queryClient.invalidateQueries({ queryKey: ['audit-events'] });
+            queryClient.invalidateQueries({
+                queryKey: ['customer', { id: variables.customerId }],
+            });
+            queryClient.invalidateQueries({ queryKey: ['customers'] });
+            queryClient.invalidateQueries({
+                queryKey: [
+                    'customer-ibans',
+                    { customerId: variables.customerId },
+                ],
+            });
+        },
+        onError: (error) => {
+            toast.error(error.message);
+        },
+    });
+};

--- a/features/audit/components/audit-event-list.tsx
+++ b/features/audit/components/audit-event-list.tsx
@@ -1,0 +1,244 @@
+'use client';
+
+import { Button } from '@signalco/ui-primitives/Button';
+import { format } from 'date-fns';
+import { RotateCcw } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import type { AuditEvent } from '@/features/audit/api/use-get-audit-events';
+
+type AuditJsonObject = Record<string, unknown>;
+
+type AuditEventListProps = {
+    events?: AuditEvent[];
+    isLoading?: boolean;
+    isError?: boolean;
+    emptyMessage?: string;
+    onRevertCustomerEvent?: (event: AuditEvent, customerId: string) => void;
+    revertingEventId?: string | null;
+};
+
+const skeletonKeys = [
+    'audit-event-skeleton-1',
+    'audit-event-skeleton-2',
+    'audit-event-skeleton-3',
+    'audit-event-skeleton-4',
+];
+
+const isObject = (value: unknown): value is AuditJsonObject =>
+    !!value && typeof value === 'object' && !Array.isArray(value);
+
+const isFieldDelta = (
+    value: unknown,
+): value is { before: unknown; after: unknown } =>
+    isObject(value) && 'before' in value && 'after' in value;
+
+const getSource = (event: AuditEvent) =>
+    isObject(event.sourceMetadata) &&
+    typeof event.sourceMetadata.source === 'string'
+        ? event.sourceMetadata.source
+        : null;
+
+export const getAuditEventCustomerId = (event: AuditEvent) => {
+    if (event.resourceType === 'customer') {
+        return event.resourceId;
+    }
+
+    if (
+        event.resourceType === 'customer_iban' &&
+        isObject(event.sourceMetadata) &&
+        typeof event.sourceMetadata.customerId === 'string'
+    ) {
+        return event.sourceMetadata.customerId;
+    }
+
+    return null;
+};
+
+const getChangedFields = (event: AuditEvent) => {
+    if (!isObject(event.fieldDelta)) {
+        return [];
+    }
+
+    return Object.keys(event.fieldDelta);
+};
+
+const formatDateTime = (value: string | Date) =>
+    format(new Date(value), 'MMM d, yyyy HH:mm');
+
+const formatValue = (value: unknown) => {
+    if (value === null || value === undefined) {
+        return 'empty';
+    }
+
+    if (typeof value === 'string') {
+        return value;
+    }
+
+    if (typeof value === 'number' || typeof value === 'boolean') {
+        return String(value);
+    }
+
+    return JSON.stringify(value);
+};
+
+const FieldDelta = ({ event }: { event: AuditEvent }) => {
+    if (!isObject(event.fieldDelta)) {
+        return null;
+    }
+
+    const entries = Object.entries(event.fieldDelta).filter(
+        (entry): entry is [string, { before: unknown; after: unknown }] =>
+            isFieldDelta(entry[1]),
+    );
+
+    if (entries.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="mt-3 space-y-1.5">
+            {entries.slice(0, 8).map(([field, delta]) => (
+                <div
+                    key={field}
+                    className="grid grid-cols-[120px_1fr] gap-2 text-xs"
+                >
+                    <div className="font-medium text-muted-foreground">
+                        {field}
+                    </div>
+                    <div className="min-w-0">
+                        <span className="break-words text-muted-foreground">
+                            {formatValue(delta.before)}
+                        </span>
+                        <span className="px-1.5 text-muted-foreground">
+                            -&gt;
+                        </span>
+                        <span className="break-words">
+                            {formatValue(delta.after)}
+                        </span>
+                    </div>
+                </div>
+            ))}
+            {entries.length > 8 && (
+                <div className="text-xs text-muted-foreground">
+                    +{entries.length - 8} more fields
+                </div>
+            )}
+        </div>
+    );
+};
+
+export const AuditEventList = ({
+    events,
+    isLoading,
+    isError,
+    emptyMessage = 'No audit events found.',
+    onRevertCustomerEvent,
+    revertingEventId,
+}: AuditEventListProps) => {
+    if (isLoading) {
+        return (
+            <div className="space-y-2">
+                {skeletonKeys.map((key) => (
+                    <div
+                        key={key}
+                        className="h-24 animate-pulse rounded-md border bg-muted/30"
+                    />
+                ))}
+            </div>
+        );
+    }
+
+    if (isError) {
+        return (
+            <div className="rounded-md border border-destructive/30 p-4 text-sm text-destructive">
+                Failed to load audit history.
+            </div>
+        );
+    }
+
+    if (!events || events.length === 0) {
+        return (
+            <div className="rounded-md border p-4 text-sm text-muted-foreground">
+                {emptyMessage}
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-2">
+            {events.map((event) => {
+                const source = getSource(event);
+                const changedFields = getChangedFields(event);
+                const customerId = getAuditEventCustomerId(event);
+                const canRevert =
+                    !!onRevertCustomerEvent &&
+                    !!customerId &&
+                    (event.resourceType === 'customer' ||
+                        event.resourceType === 'customer_iban') &&
+                    !event.revertedFromEventId;
+
+                return (
+                    <div key={event.id} className="rounded-md border p-3">
+                        <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0 space-y-1">
+                                <div className="flex flex-wrap items-center gap-2">
+                                    <Badge variant="secondary">
+                                        {event.action}
+                                    </Badge>
+                                    <span className="text-sm font-medium">
+                                        {event.resourceLabel ||
+                                            event.resourceId}
+                                    </span>
+                                    <span className="text-xs text-muted-foreground">
+                                        {event.resourceType}
+                                    </span>
+                                </div>
+                                <div className="text-xs text-muted-foreground">
+                                    {formatDateTime(event.createdAt)}
+                                    {event.actorUserId
+                                        ? ` by ${event.actorUserId}`
+                                        : ` by ${event.actorType}`}
+                                    {source ? ` - ${source}` : ''}
+                                </div>
+                                {changedFields.length > 0 && (
+                                    <div className="flex flex-wrap gap-1 pt-1">
+                                        {changedFields
+                                            .slice(0, 8)
+                                            .map((field) => (
+                                                <Badge
+                                                    key={field}
+                                                    variant="outline"
+                                                >
+                                                    {field}
+                                                </Badge>
+                                            ))}
+                                        {changedFields.length > 8 && (
+                                            <Badge variant="outline">
+                                                +{changedFields.length - 8}
+                                            </Badge>
+                                        )}
+                                    </div>
+                                )}
+                            </div>
+                            {canRevert && (
+                                <Button
+                                    type="button"
+                                    size="sm"
+                                    variant="outlined"
+                                    disabled={revertingEventId === event.id}
+                                    onClick={() =>
+                                        onRevertCustomerEvent(event, customerId)
+                                    }
+                                >
+                                    <RotateCcw className="mr-2 size-4" />
+                                    Revert
+                                </Button>
+                            )}
+                        </div>
+                        <FieldDelta event={event} />
+                    </div>
+                );
+            })}
+        </div>
+    );
+};

--- a/features/audit/components/audit-history-panel.tsx
+++ b/features/audit/components/audit-history-panel.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import type { AuditEvent } from '@/features/audit/api/use-get-audit-events';
+import { useGetAuditEvents } from '@/features/audit/api/use-get-audit-events';
+import { AuditEventList } from '@/features/audit/components/audit-event-list';
+
+type AuditHistoryPanelProps = {
+    resourceType: string;
+    resourceId?: string | null;
+    limit?: number;
+    onRevertCustomerEvent?: (event: AuditEvent, customerId: string) => void;
+    revertingEventId?: string | null;
+};
+
+export const AuditHistoryPanel = ({
+    resourceType,
+    resourceId,
+    limit = 50,
+    onRevertCustomerEvent,
+    revertingEventId,
+}: AuditHistoryPanelProps) => {
+    const auditEventsQuery = useGetAuditEvents({
+        resourceType,
+        resourceId: resourceId ?? undefined,
+        limit,
+    });
+
+    if (!resourceId) {
+        return (
+            <div className="rounded-md border p-4 text-sm text-muted-foreground">
+                Save this record before viewing audit history.
+            </div>
+        );
+    }
+
+    return (
+        <AuditEventList
+            events={auditEventsQuery.data}
+            isLoading={auditEventsQuery.isLoading}
+            isError={auditEventsQuery.isError}
+            emptyMessage="No audit history recorded for this record."
+            onRevertCustomerEvent={onRevertCustomerEvent}
+            revertingEventId={revertingEventId}
+        />
+    );
+};

--- a/features/customers/components/edit-customer-sheet.tsx
+++ b/features/customers/components/edit-customer-sheet.tsx
@@ -5,6 +5,7 @@ import {
     TabsTrigger,
 } from '@signalco/ui-primitives/Tabs';
 import { Loader2 } from 'lucide-react';
+import { useState } from 'react';
 import type { z } from 'zod';
 import {
     Sheet,
@@ -14,6 +15,12 @@ import {
     SheetTitle,
 } from '@/components/ui/sheet';
 import { insertCustomerSchema } from '@/db/schema';
+import {
+    type CustomerHistoryEvent,
+    useGetCustomerHistory,
+} from '@/features/audit/api/use-get-customer-history';
+import { useRevertCustomerAuditEvent } from '@/features/audit/api/use-revert-customer-audit-event';
+import { AuditEventList } from '@/features/audit/components/audit-event-list';
 import { useDeleteCustomer } from '@/features/customers/api/use-delete-customer';
 import { useEditCustomer } from '@/features/customers/api/use-edit-customer';
 import { useGetCustomer } from '@/features/customers/api/use-get-customer';
@@ -26,23 +33,38 @@ const formSchema = insertCustomerSchema.omit({
     userId: true,
     id: true,
     isComplete: true,
+    isDeleted: true,
+    deletedAt: true,
+    deletedBy: true,
+    deleteReason: true,
+    restoredAt: true,
+    restoredBy: true,
+    restoreReason: true,
 });
 
 type FormValues = z.input<typeof formSchema>;
 
 export const EditCustomerSheet = () => {
     const { isOpen, onClose, id } = useOpenCustomer();
+    const [revertingEventId, setRevertingEventId] = useState<string | null>(
+        null,
+    );
 
     const [ConfirmDialog, confirm] = useConfirm(
         'Are you sure?',
-        'You are about to delete this customer. This action cannot be undone.',
+        'You are about to move this customer to trash.',
     );
 
     const customerQuery = useGetCustomer(id);
+    const customerHistoryQuery = useGetCustomerHistory(id);
     const editMutation = useEditCustomer(id);
     const deleteMutation = useDeleteCustomer(id);
+    const revertCustomerAuditEvent = useRevertCustomerAuditEvent();
 
-    const isPending = editMutation.isPending || deleteMutation.isPending;
+    const isPending =
+        editMutation.isPending ||
+        deleteMutation.isPending ||
+        revertCustomerAuditEvent.isPending;
 
     const isLoading = customerQuery.isLoading;
 
@@ -63,6 +85,26 @@ export const EditCustomerSheet = () => {
                     onClose();
                 },
             });
+        }
+    };
+
+    const onRevertCustomerEvent = async (
+        event: CustomerHistoryEvent,
+        customerId: string,
+    ) => {
+        if (!window.confirm('Revert this customer change?')) {
+            return;
+        }
+
+        setRevertingEventId(event.id);
+        try {
+            await revertCustomerAuditEvent.mutateAsync({
+                customerId,
+                auditEventId: event.id,
+                reason: 'Reverted from customer history',
+            });
+        } finally {
+            setRevertingEventId(null);
         }
     };
 
@@ -122,6 +164,12 @@ export const EditCustomerSheet = () => {
                                     >
                                         Bank Accounts
                                     </TabsTrigger>
+                                    <TabsTrigger
+                                        value="history"
+                                        className="flex-1"
+                                    >
+                                        History
+                                    </TabsTrigger>
                                 </TabsList>
                             </div>
                             <TabsContent
@@ -153,6 +201,21 @@ export const EditCustomerSheet = () => {
                                         </p>
                                     </div>
                                 )}
+                            </TabsContent>
+                            <TabsContent
+                                value="history"
+                                className="flex-1 overflow-y-auto px-6 mt-0"
+                            >
+                                <AuditEventList
+                                    events={customerHistoryQuery.data}
+                                    isLoading={customerHistoryQuery.isLoading}
+                                    isError={customerHistoryQuery.isError}
+                                    emptyMessage="No customer history recorded."
+                                    onRevertCustomerEvent={
+                                        onRevertCustomerEvent
+                                    }
+                                    revertingEventId={revertingEventId}
+                                />
                             </TabsContent>
                         </Tabs>
                     )}

--- a/features/transactions/components/edit-transaction-sheet.tsx
+++ b/features/transactions/components/edit-transaction-sheet.tsx
@@ -23,6 +23,7 @@ import {
 import { UserAvatar } from '@/components/user-avatar';
 import { insertTransactionSchema } from '@/db/schema';
 import { useCreateAccount } from '@/features/accounts/api/use-create-account';
+import { AuditHistoryPanel } from '@/features/audit/components/audit-history-panel';
 import { useCreateCustomer } from '@/features/customers/api/use-create-customer';
 import { useGetSettings } from '@/features/settings/api/use-get-settings';
 import { useCreateTag } from '@/features/tags/api/use-create-tag';
@@ -1147,26 +1148,48 @@ export const TransactionSheet = () => {
                                                         );
                                                     },
                                                 )}
+                                                <div className="space-y-2">
+                                                    <div className="text-sm font-semibold">
+                                                        Audit history
+                                                    </div>
+                                                    <AuditHistoryPanel
+                                                        resourceType="transaction"
+                                                        resourceId={id}
+                                                    />
+                                                </div>
                                             </div>
                                         ) : (
-                                            <div className="space-y-2 rounded-md border p-3">
-                                                <div className="text-sm font-semibold">
-                                                    Status history
-                                                </div>
-                                                <div className="text-xs text-muted-foreground">
-                                                    Created:{' '}
-                                                    {formatDateTime(
-                                                        statusHistoryQuery
-                                                            .data?.[
+                                            <div className="space-y-4">
+                                                <div className="space-y-2 rounded-md border p-3">
+                                                    <div className="text-sm font-semibold">
+                                                        Status history
+                                                    </div>
+                                                    <div className="text-xs text-muted-foreground">
+                                                        Created:{' '}
+                                                        {formatDateTime(
                                                             statusHistoryQuery
-                                                                .data.length - 1
-                                                        ]?.changedAt ?? null,
+                                                                .data?.[
+                                                                statusHistoryQuery
+                                                                    .data
+                                                                    .length - 1
+                                                            ]?.changedAt ??
+                                                                null,
+                                                        )}
+                                                    </div>
+                                                    {renderStatusHistory(
+                                                        statusHistoryQuery.data ??
+                                                            [],
                                                     )}
                                                 </div>
-                                                {renderStatusHistory(
-                                                    statusHistoryQuery.data ??
-                                                        [],
-                                                )}
+                                                <div className="space-y-2">
+                                                    <div className="text-sm font-semibold">
+                                                        Audit history
+                                                    </div>
+                                                    <AuditHistoryPanel
+                                                        resourceType="transaction"
+                                                        resourceId={id}
+                                                    />
+                                                </div>
                                             </div>
                                         )}
                                     </TabsContent>

--- a/lib/audit-query.ts
+++ b/lib/audit-query.ts
@@ -1,0 +1,24 @@
+export const DEFAULT_AUDIT_EVENT_LIMIT = 100;
+export const MAX_AUDIT_EVENT_LIMIT = 200;
+
+export const normalizeAuditEventLimit = (value?: number | null) => {
+    if (!Number.isFinite(value) || !value || value < 1) {
+        return DEFAULT_AUDIT_EVENT_LIMIT;
+    }
+
+    return Math.min(Math.floor(value), MAX_AUDIT_EVENT_LIMIT);
+};
+
+export const normalizeAuditEventSource = (value?: string | null) => {
+    const source = value?.trim();
+    return source ? source : undefined;
+};
+
+export const normalizeAuditEventDate = (value?: string | null) => {
+    if (!value) {
+        return undefined;
+    }
+
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? undefined : date;
+};

--- a/tests/audit-query.test.mjs
+++ b/tests/audit-query.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+    DEFAULT_AUDIT_EVENT_LIMIT,
+    MAX_AUDIT_EVENT_LIMIT,
+    normalizeAuditEventDate,
+    normalizeAuditEventLimit,
+    normalizeAuditEventSource,
+} from '../lib/audit-query.ts';
+
+test('normalizeAuditEventLimit defaults invalid limits', () => {
+    assert.equal(normalizeAuditEventLimit(), DEFAULT_AUDIT_EVENT_LIMIT);
+    assert.equal(normalizeAuditEventLimit(0), DEFAULT_AUDIT_EVENT_LIMIT);
+    assert.equal(
+        normalizeAuditEventLimit(Number.NaN),
+        DEFAULT_AUDIT_EVENT_LIMIT,
+    );
+});
+
+test('normalizeAuditEventLimit clamps and floors valid limits', () => {
+    assert.equal(normalizeAuditEventLimit(25.9), 25);
+    assert.equal(
+        normalizeAuditEventLimit(MAX_AUDIT_EVENT_LIMIT + 50),
+        MAX_AUDIT_EVENT_LIMIT,
+    );
+});
+
+test('normalizeAuditEventSource trims empty source filters', () => {
+    assert.equal(
+        normalizeAuditEventSource('  customers_update  '),
+        'customers_update',
+    );
+    assert.equal(normalizeAuditEventSource('   '), undefined);
+});
+
+test('normalizeAuditEventDate returns undefined for invalid dates', () => {
+    assert.equal(normalizeAuditEventDate('not-a-date'), undefined);
+    assert.equal(
+        normalizeAuditEventDate('2026-06-29T12:00:00.000Z')?.toISOString(),
+        '2026-06-29T12:00:00.000Z',
+    );
+});


### PR DESCRIPTION
## Summary

- Adds a user-scoped `/api/audit-events` query endpoint with resource, actor, action, date, source, and limit filters.
- Adds an Audit dashboard with filtered audit log, field-delta rendering, customer revert actions, and trash recovery for deleted transactions/documents.
- Adds resource-level audit history panels to transaction, customer, and document surfaces.
- Adds restore/revert hooks and query helpers for deleted resources and customer audit history.

## Verification

- `./node_modules/.bin/biome check 'app/api/[[...route]]/auditEventsRoutes.ts' 'app/api/[[...route]]/route.ts' 'app/(dashboard)/audit/page.tsx' 'app/(dashboard)/documents/page.tsx' 'app/(dashboard)/documents/actions.tsx' 'app/(dashboard)/documents/columns.tsx' components/navigation.tsx features/audit/api/use-get-audit-events.ts features/audit/api/use-get-customer-history.ts features/audit/api/use-get-deleted-documents.ts features/audit/api/use-get-deleted-transactions.ts features/audit/api/use-restore-document.ts features/audit/api/use-restore-transaction.ts features/audit/api/use-revert-customer-audit-event.ts features/audit/components/audit-event-list.tsx features/audit/components/audit-history-panel.tsx features/customers/components/edit-customer-sheet.tsx features/transactions/components/edit-transaction-sheet.tsx lib/audit-query.ts tests/audit-query.test.mjs`
- `node --experimental-strip-types --test tests/audit.test.mjs tests/audit-query.test.mjs tests/transaction-lifecycle.test.mjs tests/document-lifecycle.test.mjs tests/customer-lifecycle.test.mjs`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --check`

## Risk

- UI tests are limited to local TypeScript and helper coverage because the repo does not have a browser/UI test harness in place.
- Restore/revert actions rely on the existing audited lifecycle APIs and surface API conflict messages directly.

Closes #130