### PR TITLE
Document auditability rollout verification

### DIFF
--- a/docs/auditability-rollout.md
+++ b/docs/auditability-rollout.md
@@ -1,0 +1,56 @@
+# Auditability Rollout
+
+## Migration Order
+
+Production deployments must apply the auditability migrations in this order:
+
+1. `0043_same_the_initiative` creates `audit_events`.
+2. `0044_quick_spiral` adds transaction lifecycle columns.
+3. `0045_misty_sauron` adds document lifecycle columns.
+4. `0046_colorful_rumiko_fujikawa` adds customer and customer IBAN lifecycle columns.
+
+The route/UI changes depend on those columns existing first. Existing rows stay visible because lifecycle columns default to active state (`is_deleted = false` or `deleted_at is null`).
+
+## Backfill
+
+- Do not synthesize historical audit events for changes made before `audit_events` existed.
+- Existing transactions, documents, customers, and customer IBANs remain active after migration.
+- Records hard-deleted before the soft-delete migrations cannot be recovered by backfill.
+- Existing document blobs are retained as-is. Blob deletion happens only through explicit document purge.
+
+## Retention
+
+- Keep `audit_events` for at least seven years for finance traceability.
+- Keep soft-deleted transactions, documents, customers, and customer IBANs until an explicit purge path removes them.
+- Keep blobs while documents are soft-deleted. Delete blobs only on explicit purge and retain the purge audit event.
+- Future archival jobs may move old audit events to cold storage only if events remain queryable by user, resource, action, and date.
+
+## Verification Matrix
+
+| Area | Required evidence |
+| --- | --- |
+| Reports | Income statement, balance sheet, summary, open finances, and account balances include only `transactions.deleted_at is null`. |
+| Reconciliation | Reconciliation ignores soft-deleted transactions and documents. |
+| Imports and sync | Banking and Stripe sync dedupe against active and soft-deleted provider IDs. |
+| Recovery | Transaction, document, customer, and IBAN restore routes write explicit restore audit events. |
+| Customer revert | Customer profile and IBAN revert reject conflicts when current state no longer matches the audit event after snapshot. |
+| Authorization | Audit log queries scope to `audit_events.user_id`; restore/revert routes reuse resource ownership checks. |
+
+## Manual End-to-End Checks
+
+Run these checks in preview before promoting:
+
+1. Delete a transaction, confirm it leaves normal transaction lists and reports, restore it from Audit > Trash, then confirm it returns.
+2. Delete a document, confirm it leaves normal document lists and reconciliation checks, restore it from Audit > Trash, then confirm the blob download still works.
+3. Edit a customer profile, open the customer History tab, revert the update, then confirm a revert audit event is written.
+4. Edit the same customer after an audited update, attempt to revert the older event, and confirm the UI shows the conflict response.
+5. Add and delete a customer IBAN, open customer History, restore/revert the IBAN event, and confirm lookup by IBAN only uses active rows.
+6. Trigger Stripe or banking sync against a provider transaction that has a soft-deleted local row and confirm it is not recreated.
+7. Filter Audit by resource type, resource id, action, and source, and confirm only the signed-in user's events appear.
+
+## Operational Notes
+
+- `audit_events` has indexes for user, actor, action, resource, request id, revert source, and created time.
+- Soft-delete metadata indexes exist on transactions, documents, customers, and customer IBANs for trash views and recovery queries.
+- Audit payloads are redacted by key pattern before storage. Do not add secrets to `sourceMetadata` under non-sensitive names.
+- Purge operations are destructive and must stay explicit. Do not run automated purge jobs until archival, export, and customer support requirements are defined.

--- a/lib/audit-rollout.ts
+++ b/lib/audit-rollout.ts
@@ -1,0 +1,68 @@
+export const AUDITABILITY_MIGRATION_SEQUENCE = [
+    {
+        tag: '0043_same_the_initiative',
+        purpose: 'Create audit_events before any route writes audit records.',
+    },
+    {
+        tag: '0044_quick_spiral',
+        purpose:
+            'Add transaction soft-delete columns before transaction delete routes switch to recovery.',
+    },
+    {
+        tag: '0045_misty_sauron',
+        purpose:
+            'Add document soft-delete columns before document delete routes retain blobs.',
+    },
+    {
+        tag: '0046_colorful_rumiko_fujikawa',
+        purpose:
+            'Add customer and customer IBAN lifecycle columns before customer revert/trash UI ships.',
+    },
+] as const;
+
+export const AUDITABILITY_RETENTION_POLICY = {
+    auditEvents:
+        'Retain audit_events for at least seven years for finance traceability; archival can move older events to cold storage only after exports remain queryable by user, resource, action, and date.',
+    softDeletedRecords:
+        'Retain soft-deleted transactions, documents, customers, and customer IBANs until an explicit user or operator purge path removes them.',
+    documentBlobs:
+        'Retain blobs while documents are soft-deleted; delete blobs only on explicit document purge and keep the purge audit event.',
+    preMigrationHistory:
+        'Do not synthesize historical audit events for changes made before audit_events existed; existing rows remain active through default false/null lifecycle columns.',
+} as const;
+
+export const AUDITABILITY_VERIFICATION_MATRIX = [
+    {
+        area: 'Reports',
+        evidence:
+            'Income statement, balance sheet, summary, open finances, and account balances filter transactions.deleted_at is null.',
+    },
+    {
+        area: 'Reconciliation',
+        evidence:
+            'Reconciliation checks ignore soft-deleted transactions and documents.is_deleted rows.',
+    },
+    {
+        area: 'Imports and sync',
+        evidence:
+            'Banking and Stripe dedupe across active and soft-deleted provider IDs to avoid recreating deleted transactions.',
+    },
+    {
+        area: 'Recovery',
+        evidence:
+            'Transaction/document/customer/IBAN restore routes write explicit restore audit events.',
+    },
+    {
+        area: 'Customer revert',
+        evidence:
+            'Customer profile and IBAN revert compare current state to the audit event after snapshot before writing.',
+    },
+    {
+        area: 'Authorization',
+        evidence:
+            'Audit log queries scope to audit_events.user_id and recovery routes reuse resource ownership checks.',
+    },
+] as const;
+
+export const auditabilityMigrationTags = () =>
+    AUDITABILITY_MIGRATION_SEQUENCE.map((entry) => entry.tag);

--- a/tests/audit-rollout.test.mjs
+++ b/tests/audit-rollout.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+    AUDITABILITY_RETENTION_POLICY,
+    AUDITABILITY_VERIFICATION_MATRIX,
+    auditabilityMigrationTags,
+} from '../lib/audit-rollout.ts';
+
+test('auditability migrations stay in dependency order', () => {
+    assert.deepEqual(auditabilityMigrationTags(), [
+        '0043_same_the_initiative',
+        '0044_quick_spiral',
+        '0045_misty_sauron',
+        '0046_colorful_rumiko_fujikawa',
+    ]);
+});
+
+test('retention policy covers audit events, soft-deleted rows, and blobs', () => {
+    assert.match(AUDITABILITY_RETENTION_POLICY.auditEvents, /seven years/);
+    assert.match(AUDITABILITY_RETENTION_POLICY.softDeletedRecords, /purge/);
+    assert.match(AUDITABILITY_RETENTION_POLICY.documentBlobs, /blobs/);
+    assert.match(AUDITABILITY_RETENTION_POLICY.preMigrationHistory, /default/);
+});
+
+test('verification matrix covers finance-critical rollout areas', () => {
+    const areas = AUDITABILITY_VERIFICATION_MATRIX.map((entry) => entry.area);
+
+    assert.deepEqual(areas, [
+        'Reports',
+        'Reconciliation',
+        'Imports and sync',
+        'Recovery',
+        'Customer revert',
+        'Authorization',
+    ]);
+});


### PR DESCRIPTION
## Summary

- Documents production migration order, backfill limits, retention/purge policy, operational notes, and manual end-to-end checks for auditability rollout.
- Adds code-level rollout constants for migration order, retention policy, and the finance-critical verification matrix.
- Adds unit tests that pin the rollout contract and coverage areas.

## Verification

- `./node_modules/.bin/biome check --write docs/auditability-rollout.md lib/audit-rollout.ts tests/audit-rollout.test.mjs`
- `node --experimental-strip-types --test tests/audit.test.mjs tests/audit-query.test.mjs tests/audit-rollout.test.mjs tests/transaction-lifecycle.test.mjs tests/document-lifecycle.test.mjs tests/customer-lifecycle.test.mjs`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --check`

## Risk

- This PR documents and pins rollout policy; it intentionally does not add purge/archive automation until archival requirements are defined.

Closes #131