### PR TITLE
Add shared finance entity services

### DIFF
--- a/app/api/[[...route]]/accountsRoutes.ts
+++ b/app/api/[[...route]]/accountsRoutes.ts
@@ -23,6 +23,7 @@ import {
     insertAccountSchema,
     transactions,
 } from '@/db/schema';
+import { getAccount, listAccounts } from '@/lib/services/finance-entities';
 
 const app = new Hono()
     .get(
@@ -56,64 +57,13 @@ const app = new Hono()
                 return ctx.json({ error: 'Unauthorized.' }, 401);
             }
 
-            // Split keywords by space, group when in quotes
-            const keywords = search?.match(/(?:[^\s"]+|"[^"]*")+/g) || [];
-            const searchAccountNameSql = keywords.map((keyword) =>
-                or(
-                    ilike(accounts.name, `%${keyword.replace(/"/g, '')}%`),
-                    ilike(accounts.code, `%${keyword.replace(/"/g, '')}%`),
-                ),
-            );
-
-            const data = await db
-                .select({
-                    id: accounts.id,
-                    name: accounts.name,
-                    code: accounts.code,
-                    isOpen: accounts.isOpen,
-                    isReadOnly: accounts.isReadOnly,
-                    accountType: accounts.accountType,
-                    accountClass: accounts.accountClass,
-                    openingBalance: accounts.openingBalance,
-                })
-                .from(accounts)
-                .where(
-                    and(
-                        and(...searchAccountNameSql),
-                        eq(accounts.userId, auth.userId),
-                        accountId ? eq(accounts.id, accountId) : undefined,
-                        // If showClosed is not explicitly true, only show open accounts
-                        showClosed ? undefined : eq(accounts.isOpen, true),
-                    ),
-                )
-                .offset(page ? Number(page) * Number(pageSize) : 0)
-                .limit(pageSize ? Number(pageSize) : 10);
-
-            // Add validation warnings for accounts with invalid configurations
-            const dataWithValidation = data.map((account) => {
-                let hasInvalidConfig = false;
-
-                // Check if account is open but any parent is closed
-                if (account.isOpen && account.code && account.code.length > 1) {
-                    const parentCodes: string[] = [];
-                    for (let i = 1; i < account.code.length; i++) {
-                        parentCodes.push(account.code.substring(0, i));
-                    }
-
-                    // Check if any parent is closed (this would be invalid)
-                    const closedParents = data.filter(
-                        (a) =>
-                            a.code && parentCodes.includes(a.code) && !a.isOpen,
-                    );
-
-                    hasInvalidConfig = closedParents.length > 0;
-                }
-
-                return {
-                    ...account,
-                    accountType: account.accountType,
-                    hasInvalidConfig,
-                };
+            const dataWithValidation = await listAccounts({
+                userId: auth.userId,
+                accountId,
+                search,
+                showClosed,
+                offset: page ? Number(page) * Number(pageSize) : 0,
+                limit: pageSize ? Number(pageSize) : 10,
             });
 
             return ctx.json({ data: dataWithValidation });
@@ -140,21 +90,7 @@ const app = new Hono()
                 return ctx.json({ error: 'Unauthorized.' }, 401);
             }
 
-            const [data] = await db
-                .select({
-                    id: accounts.id,
-                    name: accounts.name,
-                    code: accounts.code,
-                    isOpen: accounts.isOpen,
-                    isReadOnly: accounts.isReadOnly,
-                    accountType: accounts.accountType,
-                    accountClass: accounts.accountClass,
-                    openingBalance: accounts.openingBalance,
-                })
-                .from(accounts)
-                .where(
-                    and(eq(accounts.userId, auth.userId), eq(accounts.id, id)),
-                );
+            const data = await getAccount({ userId: auth.userId, id });
 
             if (!data) {
                 return ctx.json({ error: 'Not found.' }, 404);

--- a/app/api/[[...route]]/auditEventsRoutes.ts
+++ b/app/api/[[...route]]/auditEventsRoutes.ts
@@ -1,16 +1,9 @@
 import { clerkMiddleware, getAuth } from '@hono/clerk-auth';
 import { zValidator } from '@hono/zod-validator';
-import { and, desc, eq, gte, lte, sql } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { z } from 'zod';
 
-import { db } from '@/db/drizzle';
-import { auditEvents } from '@/db/schema';
-import {
-    normalizeAuditEventDate,
-    normalizeAuditEventLimit,
-    normalizeAuditEventSource,
-} from '@/lib/audit-query';
+import { listAuditEvents } from '@/lib/services/finance-entities';
 
 const auditEventQuerySchema = z.object({
     resourceType: z.string().optional(),
@@ -36,52 +29,10 @@ const app = new Hono().get(
             return ctx.json({ error: 'Unauthorized.' }, 401);
         }
 
-        const source = normalizeAuditEventSource(query.source);
-        const from = normalizeAuditEventDate(query.from);
-        const to = normalizeAuditEventDate(query.to);
-
-        const conditions = [eq(auditEvents.userId, auth.userId)];
-
-        if (query.resourceType) {
-            conditions.push(eq(auditEvents.resourceType, query.resourceType));
-        }
-
-        if (query.resourceId) {
-            conditions.push(eq(auditEvents.resourceId, query.resourceId));
-        }
-
-        if (query.actorUserId) {
-            conditions.push(eq(auditEvents.actorUserId, query.actorUserId));
-        }
-
-        if (query.actorType) {
-            conditions.push(eq(auditEvents.actorType, query.actorType));
-        }
-
-        if (query.action) {
-            conditions.push(eq(auditEvents.action, query.action));
-        }
-
-        if (from) {
-            conditions.push(gte(auditEvents.createdAt, from));
-        }
-
-        if (to) {
-            conditions.push(lte(auditEvents.createdAt, to));
-        }
-
-        if (source) {
-            conditions.push(
-                sql`${auditEvents.sourceMetadata}->>'source' = ${source}`,
-            );
-        }
-
-        const data = await db
-            .select()
-            .from(auditEvents)
-            .where(and(...conditions))
-            .orderBy(desc(auditEvents.createdAt))
-            .limit(normalizeAuditEventLimit(query.limit));
+        const data = await listAuditEvents({
+            userId: auth.userId,
+            ...query,
+        });
 
         return ctx.json({ data });
     },

--- a/app/api/[[...route]]/customersRoutes.ts
+++ b/app/api/[[...route]]/customersRoutes.ts
@@ -1,18 +1,7 @@
 import { clerkMiddleware, getAuth } from '@hono/clerk-auth';
 import { zValidator } from '@hono/zod-validator';
 import { createId } from '@paralleldrive/cuid2';
-import {
-    and,
-    asc,
-    desc,
-    eq,
-    ilike,
-    inArray,
-    isNull,
-    ne,
-    or,
-    sql,
-} from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, ne, or, sql } from 'drizzle-orm';
 import { type Context, Hono } from 'hono';
 import { z } from 'zod';
 
@@ -22,7 +11,6 @@ import {
     customerIbans,
     customers,
     insertCustomerSchema,
-    transactions,
 } from '@/db/schema';
 import { type AuditAction, writeAuditEvent } from '@/lib/audit';
 import {
@@ -36,6 +24,7 @@ import {
     getCustomerProfileRevertConflicts,
     type SnapshotRecord,
 } from '@/lib/customer-lifecycle';
+import { listCustomers } from '@/lib/services/finance-entities';
 
 type DeletedMode = 'include' | 'only';
 type CustomerRow = typeof customers.$inferSelect;
@@ -82,9 +71,6 @@ const isCustomerComplete = (customer: CustomerData): boolean => {
         customer.country
     );
 };
-
-const escapeLikePattern = (value: string): string =>
-    value.replace(/[\\%_]/g, '\\\\$&');
 
 const normalizeIban = (iban: string) => iban.toUpperCase().replace(/\s/g, '');
 
@@ -651,59 +637,11 @@ const app = new Hono()
                 return ctx.json({ error: 'Unauthorized.' }, 401);
             }
 
-            const escapedSearch = search ? escapeLikePattern(search) : '';
-            const data = await db
-                .select({
-                    id: customers.id,
-                    name: customers.name,
-                    friendlyName: customers.friendlyName,
-                    vatNumber: customers.vatNumber,
-                    address: customers.address,
-                    contactEmail: customers.contactEmail,
-                    contactTelephone: customers.contactTelephone,
-                    country: customers.country,
-                    isComplete: customers.isComplete,
-                    isOwnFirm: customers.isOwnFirm,
-                    isDeleted: customers.isDeleted,
-                    deletedAt: customers.deletedAt,
-                    deletedBy: customers.deletedBy,
-                    deleteReason: customers.deleteReason,
-                    restoredAt: customers.restoredAt,
-                    restoredBy: customers.restoredBy,
-                    restoreReason: customers.restoreReason,
-                    transactionCount: sql<number>`count(${transactions.id})`.as(
-                        'transaction_count',
-                    ),
-                })
-                .from(customers)
-                .leftJoin(
-                    transactions,
-                    and(
-                        eq(customers.id, transactions.payeeCustomerId),
-                        isNull(transactions.deletedAt),
-                    ),
-                )
-                .where(
-                    and(
-                        eq(customers.userId, auth.userId),
-                        customerDeletedFilter(deleted),
-                        search
-                            ? or(
-                                  ilike(customers.name, `%${escapedSearch}%`),
-                                  ilike(
-                                      customers.friendlyName,
-                                      `%${escapedSearch}%`,
-                                  ),
-                                  ilike(
-                                      customers.vatNumber,
-                                      `%${escapedSearch}%`,
-                                  ),
-                              )
-                            : undefined,
-                    ),
-                )
-                .groupBy(customers.id)
-                .orderBy(desc(customers.name));
+            const data = await listCustomers({
+                userId: auth.userId,
+                search,
+                deleted,
+            });
 
             return ctx.json({ data });
         },

--- a/app/api/[[...route]]/documentsRoutes.ts
+++ b/app/api/[[...route]]/documentsRoutes.ts
@@ -1,7 +1,7 @@
 import { clerkMiddleware, getAuth } from '@hono/clerk-auth';
 import { zValidator } from '@hono/zod-validator';
 import { createId } from '@paralleldrive/cuid2';
-import { aliasedTable, and, desc, eq, gte, isNull, lte, or } from 'drizzle-orm';
+import { aliasedTable, and, eq, isNull, or } from 'drizzle-orm';
 import { type Context, Hono } from 'hono';
 import { z } from 'zod';
 
@@ -21,6 +21,7 @@ import {
     createDocumentSoftDeletePatch,
     DOCUMENT_SOFT_DELETE_BLOB_POLICY,
 } from '@/lib/document-lifecycle';
+import { listDocuments } from '@/lib/services/finance-entities';
 
 const getAuthorizedTransaction = async (
     transactionId: string,
@@ -263,76 +264,14 @@ const app = new Hono()
                 return ctx.json({ error: 'Unauthorized.' }, 401);
             }
 
-            const conditions = [eq(documents.uploadedBy, auth.userId)];
-            const deletedFilter = documentDeletedFilter(deleted);
-            if (deletedFilter) conditions.push(deletedFilter);
-
-            if (!deleted) {
-                const activeTransactionFilter = or(
-                    isNull(documents.transactionId),
-                    isNull(transactions.deletedAt),
-                );
-                if (activeTransactionFilter) {
-                    conditions.push(activeTransactionFilter);
-                }
-            }
-
-            if (documentTypeId) {
-                conditions.push(eq(documents.documentTypeId, documentTypeId));
-            }
-
-            if (from) {
-                conditions.push(gte(documents.uploadedAt, new Date(from)));
-            }
-
-            if (to) {
-                conditions.push(lte(documents.uploadedAt, new Date(to)));
-            }
-
-            if (unattached === 'true') {
-                conditions.push(isNull(documents.transactionId));
-            }
-
-            // Use LEFT JOIN to fetch transaction data alongside documents (avoids N+1 query)
-            const data = await db
-                .select({
-                    id: documents.id,
-                    fileName: documents.fileName,
-                    fileSize: documents.fileSize,
-                    mimeType: documents.mimeType,
-                    documentTypeId: documents.documentTypeId,
-                    documentTypeName: documentTypes.name,
-                    transactionId: documents.transactionId,
-                    uploadedBy: documents.uploadedBy,
-                    uploadedAt: documents.uploadedAt,
-                    storagePath: documents.storagePath,
-                    isDeleted: documents.isDeleted,
-                    deletedAt: documents.deletedAt,
-                    deletedBy: documents.deletedBy,
-                    deleteReason: documents.deleteReason,
-                    restoredAt: documents.restoredAt,
-                    restoredBy: documents.restoredBy,
-                    restoreReason: documents.restoreReason,
-                    transactionDate: transactions.date,
-                    transactionPayee: transactions.payee,
-                })
-                .from(documents)
-                .leftJoin(
-                    documentTypes,
-                    eq(documents.documentTypeId, documentTypes.id),
-                )
-                .leftJoin(
-                    transactions,
-                    eq(documents.transactionId, transactions.id),
-                )
-                .where(and(...conditions))
-                .orderBy(desc(documents.uploadedAt));
-
-            // Generate download URLs
-            const documentsWithUrls = data.map((doc) => ({
-                ...doc,
-                downloadUrl: generateDownloadUrl(doc.storagePath),
-            }));
+            const documentsWithUrls = await listDocuments({
+                userId: auth.userId,
+                documentTypeId,
+                from,
+                to,
+                unattached: unattached === 'true',
+                deleted,
+            });
 
             return ctx.json({ data: documentsWithUrls });
         },

--- a/app/api/[[...route]]/tagsRoutes.ts
+++ b/app/api/[[...route]]/tagsRoutes.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 
 import { db } from '@/db/drizzle';
 import { insertTagSchema, tags } from '@/db/schema';
+import { getTag, listTags } from '@/lib/services/finance-entities';
 
 const app = new Hono()
     .get('/', clerkMiddleware(), async (ctx) => {
@@ -16,15 +17,7 @@ const app = new Hono()
             return ctx.json({ error: 'Unauthorized.' }, 401);
         }
 
-        const data = await db
-            .select({
-                id: tags.id,
-                name: tags.name,
-                color: tags.color,
-                tagType: tags.tagType,
-            })
-            .from(tags)
-            .where(eq(tags.userId, auth.userId));
+        const data = await listTags({ userId: auth.userId });
 
         return ctx.json({ data });
     })
@@ -49,15 +42,7 @@ const app = new Hono()
                 return ctx.json({ error: 'Unauthorized.' }, 401);
             }
 
-            const [data] = await db
-                .select({
-                    id: tags.id,
-                    name: tags.name,
-                    color: tags.color,
-                    tagType: tags.tagType,
-                })
-                .from(tags)
-                .where(and(eq(tags.userId, auth.userId), eq(tags.id, id)));
+            const data = await getTag({ userId: auth.userId, id });
 
             if (!data) {
                 return ctx.json({ error: 'Not found.' }, 404);

--- a/app/api/[[...route]]/transactionsRoutes.ts
+++ b/app/api/[[...route]]/transactionsRoutes.ts
@@ -2,19 +2,16 @@ import { UTCDate } from '@date-fns/utc';
 import { clerkMiddleware, getAuth } from '@hono/clerk-auth';
 import { zValidator } from '@hono/zod-validator';
 import { createId } from '@paralleldrive/cuid2';
-import { endOfDay, parse, startOfYear } from 'date-fns';
 import {
     aliasedTable,
     and,
     asc,
     desc,
     eq,
-    gte,
     ilike,
     inArray,
     isNotNull,
     isNull,
-    lte,
     or,
     sql,
 } from 'drizzle-orm';
@@ -25,7 +22,6 @@ import {
     accounts,
     createTransactionSchema,
     customers,
-    documents,
     settings,
     tags,
     transactionStatusHistory,
@@ -33,6 +29,7 @@ import {
     transactionTags,
 } from '@/db/schema';
 import { writeAuditEvent } from '@/lib/audit';
+import { listTransactions } from '@/lib/services/finance-entities';
 import {
     createTransactionRestorePatch,
     createTransactionSoftDeletePatch,
@@ -410,223 +407,13 @@ const app = new Hono()
                 return ctx.json({ error: 'Unauthorized.' }, 401);
             }
 
-            const startDate = from
-                ? parse(from, 'yyyy-MM-dd', new UTCDate())
-                : startOfYear(new UTCDate());
-            const endDate = to
-                ? endOfDay(parse(to, 'yyyy-MM-dd', new UTCDate()))
-                : new UTCDate();
-
-            const creditAccounts = aliasedTable(accounts, 'creditAccounts');
-            const debitAccounts = aliasedTable(accounts, 'debitAccounts');
-
-            // Get user settings for required document types
-            const [userSettings] = await db
-                .select({
-                    minRequiredDocuments: settings.minRequiredDocuments,
-                    requiredDocumentTypeIds: settings.requiredDocumentTypeIds,
-                })
-                .from(settings)
-                .where(eq(settings.userId, auth.userId));
-
-            const minRequiredDocs = userSettings?.minRequiredDocuments ?? 0;
-            const requiredDocTypeIds = userSettings?.requiredDocumentTypeIds
-                ? JSON.parse(userSettings.requiredDocumentTypeIds)
-                : [];
-
-            const data = await db
-                .select({
-                    id: transactions.id,
-                    date: transactions.date,
-                    payee: transactions.payee,
-                    payeeCustomerId: transactions.payeeCustomerId,
-                    payeeCustomerName:
-                        sql<string>`coalesce(${customers.friendlyName}, ${customers.name})`.as(
-                            'payee_customer_name',
-                        ),
-                    amount: transactions.amount,
-                    notes: transactions.notes,
-                    account: accounts.name,
-                    accountCode: accounts.code,
-                    accountId: transactions.accountId,
-                    accountIsOpen: accounts.isOpen,
-                    accountClass: accounts.accountClass,
-                    creditAccount: creditAccounts.name,
-                    creditAccountCode: creditAccounts.code,
-                    creditAccountId: transactions.creditAccountId,
-                    creditAccountIsOpen: creditAccounts.isOpen,
-                    creditAccountType: creditAccounts.accountType,
-                    creditAccountClass: creditAccounts.accountClass,
-                    debitAccount: debitAccounts.name,
-                    debitAccountCode: debitAccounts.code,
-                    debitAccountId: transactions.debitAccountId,
-                    debitAccountIsOpen: debitAccounts.isOpen,
-                    debitAccountType: debitAccounts.accountType,
-                    debitAccountClass: debitAccounts.accountClass,
-                    status: transactions.status,
-                    statusChangedAt: transactions.statusChangedAt,
-                    statusChangedBy: transactions.statusChangedBy,
-                    splitGroupId: transactions.splitGroupId,
-                    splitType: transactions.splitType,
-                    stripePaymentId: transactions.stripePaymentId,
-                    deletedAt: transactions.deletedAt,
-                    deletedBy: transactions.deletedBy,
-                    deleteReason: transactions.deleteReason,
-                    restoredAt: transactions.restoredAt,
-                    restoredBy: transactions.restoredBy,
-                    restoreReason: transactions.restoreReason,
-                })
-                .from(transactions)
-                .leftJoin(accounts, eq(transactions.accountId, accounts.id))
-                .leftJoin(
-                    creditAccounts,
-                    eq(transactions.creditAccountId, creditAccounts.id),
-                )
-                .leftJoin(
-                    debitAccounts,
-                    eq(transactions.debitAccountId, debitAccounts.id),
-                )
-                .leftJoin(
-                    customers,
-                    eq(transactions.payeeCustomerId, customers.id),
-                )
-                .where(
-                    and(
-                        accountId
-                            ? or(
-                                  eq(transactions.accountId, accountId),
-                                  eq(transactions.creditAccountId, accountId),
-                                  eq(transactions.debitAccountId, accountId),
-                              )
-                            : undefined,
-                        payeeCustomerId
-                            ? eq(transactions.payeeCustomerId, payeeCustomerId)
-                            : undefined,
-                        or(
-                            eq(accounts.userId, auth.userId),
-                            eq(creditAccounts.userId, auth.userId),
-                            eq(debitAccounts.userId, auth.userId),
-                            and(
-                                isNull(transactions.accountId),
-                                isNull(transactions.creditAccountId),
-                                isNull(transactions.debitAccountId),
-                                eq(transactions.statusChangedBy, auth.userId),
-                            ),
-                        ),
-                        gte(transactions.date, startDate),
-                        lte(transactions.date, endDate),
-                        transactionDeletedFilter(deleted),
-                    ),
-                )
-                .orderBy(desc(transactions.date));
-
-            // Get document counts and required documents status for each transaction
-            const transactionIds = data.map((t) => t.id);
-            const documentCounts: Map<
-                string,
-                { total: number; requiredTypes: string[] }
-            > = new Map();
-
-            if (transactionIds.length > 0) {
-                const docsData = await db
-                    .select({
-                        transactionId: documents.transactionId,
-                        documentTypeId: documents.documentTypeId,
-                    })
-                    .from(documents)
-                    .where(
-                        and(
-                            inArray(documents.transactionId, transactionIds),
-                            eq(documents.isDeleted, false),
-                        ),
-                    );
-
-                // Group by transaction and count
-                docsData.forEach((doc) => {
-                    if (!doc.transactionId) return;
-                    const existing = documentCounts.get(doc.transactionId) || {
-                        total: 0,
-                        requiredTypes: [],
-                    };
-                    existing.total++;
-                    if (requiredDocTypeIds.includes(doc.documentTypeId)) {
-                        if (
-                            !existing.requiredTypes.includes(doc.documentTypeId)
-                        ) {
-                            existing.requiredTypes.push(doc.documentTypeId);
-                        }
-                    }
-                    documentCounts.set(doc.transactionId, existing);
-                });
-            }
-
-            // Get tags for each transaction
-            const transactionTagsMap: Map<
-                string,
-                Array<{ id: string; name: string; color: string | null }>
-            > = new Map();
-
-            if (transactionIds.length > 0) {
-                const tagsData = await db
-                    .select({
-                        transactionId: transactionTags.transactionId,
-                        tagId: tags.id,
-                        tagName: tags.name,
-                        tagColor: tags.color,
-                    })
-                    .from(transactionTags)
-                    .innerJoin(tags, eq(transactionTags.tagId, tags.id))
-                    .where(
-                        inArray(transactionTags.transactionId, transactionIds),
-                    );
-
-                // Group by transaction
-                tagsData.forEach((tagData) => {
-                    const existing =
-                        transactionTagsMap.get(tagData.transactionId) || [];
-                    existing.push({
-                        id: tagData.tagId,
-                        name: tagData.tagName,
-                        color: tagData.tagColor,
-                    });
-                    transactionTagsMap.set(tagData.transactionId, existing);
-                });
-            }
-
-            // Combine data with document info and tags
-            // If minRequiredDocs is 0, all required types must be attached
-            // If minRequiredDocs > 0, at least that many required types must be attached
-            const dataWithDocs = data.map((transaction) => {
-                const attachedRequiredCount =
-                    documentCounts.get(transaction.id)?.requiredTypes.length ??
-                    0;
-                const totalRequiredTypes = requiredDocTypeIds.length;
-
-                // Determine if documents requirement is met
-                let hasAllRequiredDocuments = true;
-                if (totalRequiredTypes > 0) {
-                    if (minRequiredDocs === 0) {
-                        // All required document types must be attached
-                        hasAllRequiredDocuments =
-                            attachedRequiredCount >= totalRequiredTypes;
-                    } else {
-                        // At least minRequiredDocs of the required types must be attached
-                        hasAllRequiredDocuments =
-                            attachedRequiredCount >=
-                            Math.min(minRequiredDocs, totalRequiredTypes);
-                    }
-                }
-
-                return {
-                    ...transaction,
-                    tags: transactionTagsMap.get(transaction.id) ?? [],
-                    documentCount:
-                        documentCounts.get(transaction.id)?.total ?? 0,
-                    hasAllRequiredDocuments,
-                    requiredDocumentTypes: totalRequiredTypes,
-                    attachedRequiredTypes: attachedRequiredCount,
-                    minRequiredDocuments: minRequiredDocs,
-                };
+            const dataWithDocs = await listTransactions({
+                userId: auth.userId,
+                from,
+                to,
+                accountId,
+                payeeCustomerId,
+                deleted,
             });
 
             return ctx.json({ data: dataWithDocs });

--- a/lib/services/finance-entities.ts
+++ b/lib/services/finance-entities.ts
@@ -1,0 +1,779 @@
+import { UTCDate } from '@date-fns/utc';
+import { endOfDay, parse, startOfYear } from 'date-fns';
+import {
+    aliasedTable,
+    and,
+    desc,
+    eq,
+    gte,
+    ilike,
+    inArray,
+    isNotNull,
+    isNull,
+    lte,
+    or,
+    sql,
+} from 'drizzle-orm';
+
+import { db } from '@/db/drizzle';
+import {
+    accounts,
+    auditEvents,
+    customerIbans,
+    customers,
+    documents,
+    documentTypes,
+    settings,
+    tags,
+    transactions,
+    transactionTags,
+} from '@/db/schema';
+import { normalizeAuditEventSource } from '@/lib/audit-query';
+import { generateDownloadUrl } from '@/lib/azure-storage';
+import {
+    type DeletedMode,
+    escapeLikePattern,
+    normalizeEntityDate,
+    normalizeEntityLimit,
+    normalizeEntityOffset,
+    splitSearchKeywords,
+} from '@/lib/services/finance-entity-core';
+
+type Database = typeof db;
+
+export type ServicePageOptions = {
+    limit?: number | null;
+    offset?: number | null;
+};
+
+export type ListAccountsInput = ServicePageOptions & {
+    userId: string;
+    search?: string | null;
+    accountId?: string | null;
+    showClosed?: boolean | null;
+};
+
+export type ListAuditEventsInput = ServicePageOptions & {
+    userId: string;
+    resourceType?: string | null;
+    resourceId?: string | null;
+    actorUserId?: string | null;
+    actorType?: 'user' | 'system' | 'integration' | null;
+    action?: string | null;
+    from?: string | Date | null;
+    to?: string | Date | null;
+    source?: string | null;
+};
+
+export type ListCustomersInput = ServicePageOptions & {
+    userId: string;
+    search?: string | null;
+    deleted?: DeletedMode;
+};
+
+export type ListCustomerIbansInput = ServicePageOptions & {
+    userId: string;
+    customerId: string;
+    deleted?: DeletedMode;
+    customerDeleted?: DeletedMode;
+};
+
+export type ListDocumentsInput = ServicePageOptions & {
+    userId: string;
+    documentTypeId?: string | null;
+    from?: string | Date | null;
+    to?: string | Date | null;
+    unattached?: boolean | null;
+    deleted?: DeletedMode;
+    includeDownloadUrl?: boolean;
+};
+
+export type ListTagsInput = ServicePageOptions & {
+    userId: string;
+};
+
+export type ListTransactionsInput = ServicePageOptions & {
+    userId: string;
+    id?: string | null;
+    from?: string | null;
+    to?: string | null;
+    accountId?: string | null;
+    payeeCustomerId?: string | null;
+    deleted?: DeletedMode;
+};
+
+const applyLimitOffset = <
+    T extends { limit: (limit: number) => T; offset: (offset: number) => T },
+>(
+    query: T,
+    options: ServicePageOptions,
+) => {
+    let current = query;
+    if (typeof options.limit === 'number') {
+        current = current.limit(normalizeEntityLimit(options.limit));
+    }
+    if (typeof options.offset === 'number') {
+        current = current.offset(normalizeEntityOffset(options.offset));
+    }
+    return current;
+};
+
+const customerDeletedFilter = (deleted?: DeletedMode) => {
+    if (deleted === 'include') {
+        return undefined;
+    }
+
+    if (deleted === 'only') {
+        return eq(customers.isDeleted, true);
+    }
+
+    return eq(customers.isDeleted, false);
+};
+
+const customerIbanDeletedFilter = (deleted?: DeletedMode) => {
+    if (deleted === 'include') {
+        return undefined;
+    }
+
+    if (deleted === 'only') {
+        return eq(customerIbans.isDeleted, true);
+    }
+
+    return eq(customerIbans.isDeleted, false);
+};
+
+const documentDeletedFilter = (deleted?: DeletedMode) => {
+    if (deleted === 'include') {
+        return undefined;
+    }
+
+    if (deleted === 'only') {
+        return eq(documents.isDeleted, true);
+    }
+
+    return eq(documents.isDeleted, false);
+};
+
+const transactionDeletedFilter = (deleted?: DeletedMode) => {
+    if (deleted === 'include') {
+        return undefined;
+    }
+
+    if (deleted === 'only') {
+        return isNotNull(transactions.deletedAt);
+    }
+
+    return isNull(transactions.deletedAt);
+};
+
+const createTransactionAccessFilter = (
+    userId: string,
+    creditAccounts: ReturnType<typeof aliasedTable<typeof accounts>>,
+    debitAccounts: ReturnType<typeof aliasedTable<typeof accounts>>,
+) =>
+    or(
+        eq(accounts.userId, userId),
+        eq(creditAccounts.userId, userId),
+        eq(debitAccounts.userId, userId),
+        and(
+            isNull(transactions.accountId),
+            isNull(transactions.creditAccountId),
+            isNull(transactions.debitAccountId),
+            eq(transactions.statusChangedBy, userId),
+        ),
+    );
+
+export const listAccounts = async (
+    input: ListAccountsInput,
+    database: Database = db,
+) => {
+    const keywords = splitSearchKeywords(input.search);
+    const searchConditions = keywords.map((keyword) =>
+        or(
+            ilike(accounts.name, `%${keyword}%`),
+            ilike(accounts.code, `%${keyword}%`),
+        ),
+    );
+
+    const query = database
+        .select({
+            id: accounts.id,
+            name: accounts.name,
+            code: accounts.code,
+            isOpen: accounts.isOpen,
+            isReadOnly: accounts.isReadOnly,
+            accountType: accounts.accountType,
+            accountClass: accounts.accountClass,
+            openingBalance: accounts.openingBalance,
+        })
+        .from(accounts)
+        .where(
+            and(
+                searchConditions.length > 0
+                    ? and(...searchConditions)
+                    : undefined,
+                eq(accounts.userId, input.userId),
+                input.accountId ? eq(accounts.id, input.accountId) : undefined,
+                input.showClosed ? undefined : eq(accounts.isOpen, true),
+            ),
+        )
+        .$dynamic();
+
+    const data = await applyLimitOffset(query, input);
+
+    return data.map((account) => {
+        let hasInvalidConfig = false;
+
+        if (account.isOpen && account.code && account.code.length > 1) {
+            const parentCodes: string[] = [];
+            for (let i = 1; i < account.code.length; i++) {
+                parentCodes.push(account.code.substring(0, i));
+            }
+
+            const closedParents = data.filter(
+                (candidate) =>
+                    candidate.code &&
+                    parentCodes.includes(candidate.code) &&
+                    !candidate.isOpen,
+            );
+
+            hasInvalidConfig = closedParents.length > 0;
+        }
+
+        return {
+            ...account,
+            hasInvalidConfig,
+        };
+    });
+};
+
+export const getAccount = async (
+    input: { userId: string; id: string },
+    database: Database = db,
+) => {
+    const [account] = await database
+        .select({
+            id: accounts.id,
+            name: accounts.name,
+            code: accounts.code,
+            isOpen: accounts.isOpen,
+            isReadOnly: accounts.isReadOnly,
+            accountType: accounts.accountType,
+            accountClass: accounts.accountClass,
+            openingBalance: accounts.openingBalance,
+        })
+        .from(accounts)
+        .where(
+            and(eq(accounts.userId, input.userId), eq(accounts.id, input.id)),
+        );
+
+    return account ?? null;
+};
+
+export const listTags = async (
+    input: ListTagsInput,
+    database: Database = db,
+) => {
+    const query = database
+        .select({
+            id: tags.id,
+            name: tags.name,
+            color: tags.color,
+            tagType: tags.tagType,
+        })
+        .from(tags)
+        .where(eq(tags.userId, input.userId))
+        .$dynamic();
+
+    return applyLimitOffset(query, input);
+};
+
+export const getTag = async (
+    input: { userId: string; id: string },
+    database: Database = db,
+) => {
+    const [tag] = await database
+        .select({
+            id: tags.id,
+            name: tags.name,
+            color: tags.color,
+            tagType: tags.tagType,
+        })
+        .from(tags)
+        .where(and(eq(tags.userId, input.userId), eq(tags.id, input.id)));
+
+    return tag ?? null;
+};
+
+export const listCustomers = async (
+    input: ListCustomersInput,
+    database: Database = db,
+) => {
+    const escapedSearch = input.search ? escapeLikePattern(input.search) : '';
+    const query = database
+        .select({
+            id: customers.id,
+            name: customers.name,
+            friendlyName: customers.friendlyName,
+            vatNumber: customers.vatNumber,
+            address: customers.address,
+            contactEmail: customers.contactEmail,
+            contactTelephone: customers.contactTelephone,
+            country: customers.country,
+            isComplete: customers.isComplete,
+            isOwnFirm: customers.isOwnFirm,
+            isDeleted: customers.isDeleted,
+            deletedAt: customers.deletedAt,
+            deletedBy: customers.deletedBy,
+            deleteReason: customers.deleteReason,
+            restoredAt: customers.restoredAt,
+            restoredBy: customers.restoredBy,
+            restoreReason: customers.restoreReason,
+            transactionCount: sql<number>`count(${transactions.id})`.as(
+                'transaction_count',
+            ),
+        })
+        .from(customers)
+        .leftJoin(
+            transactions,
+            and(
+                eq(customers.id, transactions.payeeCustomerId),
+                isNull(transactions.deletedAt),
+            ),
+        )
+        .where(
+            and(
+                eq(customers.userId, input.userId),
+                customerDeletedFilter(input.deleted),
+                input.search
+                    ? or(
+                          ilike(customers.name, `%${escapedSearch}%`),
+                          ilike(customers.friendlyName, `%${escapedSearch}%`),
+                          ilike(customers.vatNumber, `%${escapedSearch}%`),
+                      )
+                    : undefined,
+            ),
+        )
+        .groupBy(customers.id)
+        .orderBy(desc(customers.name))
+        .$dynamic();
+
+    return applyLimitOffset(query, input);
+};
+
+export const getCustomer = async (
+    input: { userId: string; id: string; deleted?: DeletedMode },
+    database: Database = db,
+) => {
+    const [customer] = await database
+        .select()
+        .from(customers)
+        .where(
+            and(
+                eq(customers.id, input.id),
+                eq(customers.userId, input.userId),
+                customerDeletedFilter(input.deleted),
+            ),
+        );
+
+    return customer ?? null;
+};
+
+export const listCustomerIbans = async (
+    input: ListCustomerIbansInput,
+    database: Database = db,
+) => {
+    const customer = await getCustomer(
+        {
+            id: input.customerId,
+            userId: input.userId,
+            deleted: input.customerDeleted,
+        },
+        database,
+    );
+
+    if (!customer) {
+        return null;
+    }
+
+    const query = database
+        .select()
+        .from(customerIbans)
+        .where(
+            and(
+                eq(customerIbans.customerId, input.customerId),
+                customerIbanDeletedFilter(input.deleted),
+            ),
+        )
+        .$dynamic();
+
+    return applyLimitOffset(query, input);
+};
+
+export const listAuditEvents = async (
+    input: ListAuditEventsInput,
+    database: Database = db,
+) => {
+    const from = normalizeEntityDate(input.from);
+    const to = normalizeEntityDate(input.to);
+    const source = normalizeAuditEventSource(input.source);
+    const conditions = [eq(auditEvents.userId, input.userId)];
+
+    if (input.resourceType) {
+        conditions.push(eq(auditEvents.resourceType, input.resourceType));
+    }
+
+    if (input.resourceId) {
+        conditions.push(eq(auditEvents.resourceId, input.resourceId));
+    }
+
+    if (input.actorUserId) {
+        conditions.push(eq(auditEvents.actorUserId, input.actorUserId));
+    }
+
+    if (input.actorType) {
+        conditions.push(eq(auditEvents.actorType, input.actorType));
+    }
+
+    if (input.action) {
+        conditions.push(eq(auditEvents.action, input.action));
+    }
+
+    if (from) {
+        conditions.push(gte(auditEvents.createdAt, from));
+    }
+
+    if (to) {
+        conditions.push(lte(auditEvents.createdAt, to));
+    }
+
+    if (source) {
+        conditions.push(
+            sql`${auditEvents.sourceMetadata}->>'source' = ${source}`,
+        );
+    }
+
+    const query = database
+        .select()
+        .from(auditEvents)
+        .where(and(...conditions))
+        .orderBy(desc(auditEvents.createdAt))
+        .$dynamic();
+
+    return applyLimitOffset(query, {
+        ...input,
+        limit: input.limit ?? 100,
+    });
+};
+
+export const listDocuments = async (
+    input: ListDocumentsInput,
+    database: Database = db,
+) => {
+    const conditions = [eq(documents.uploadedBy, input.userId)];
+    const deletedFilter = documentDeletedFilter(input.deleted);
+    const from = normalizeEntityDate(input.from);
+    const to = normalizeEntityDate(input.to);
+
+    if (deletedFilter) conditions.push(deletedFilter);
+
+    if (!input.deleted) {
+        const activeTransactionFilter = or(
+            isNull(documents.transactionId),
+            isNull(transactions.deletedAt),
+        );
+        if (activeTransactionFilter) {
+            conditions.push(activeTransactionFilter);
+        }
+    }
+
+    if (input.documentTypeId) {
+        conditions.push(eq(documents.documentTypeId, input.documentTypeId));
+    }
+
+    if (from) {
+        conditions.push(gte(documents.uploadedAt, from));
+    }
+
+    if (to) {
+        conditions.push(lte(documents.uploadedAt, to));
+    }
+
+    if (input.unattached) {
+        conditions.push(isNull(documents.transactionId));
+    }
+
+    const query = database
+        .select({
+            id: documents.id,
+            fileName: documents.fileName,
+            fileSize: documents.fileSize,
+            mimeType: documents.mimeType,
+            documentTypeId: documents.documentTypeId,
+            documentTypeName: documentTypes.name,
+            transactionId: documents.transactionId,
+            uploadedBy: documents.uploadedBy,
+            uploadedAt: documents.uploadedAt,
+            storagePath: documents.storagePath,
+            isDeleted: documents.isDeleted,
+            deletedAt: documents.deletedAt,
+            deletedBy: documents.deletedBy,
+            deleteReason: documents.deleteReason,
+            restoredAt: documents.restoredAt,
+            restoredBy: documents.restoredBy,
+            restoreReason: documents.restoreReason,
+            transactionDate: transactions.date,
+            transactionPayee: transactions.payee,
+        })
+        .from(documents)
+        .leftJoin(documentTypes, eq(documents.documentTypeId, documentTypes.id))
+        .leftJoin(transactions, eq(documents.transactionId, transactions.id))
+        .where(and(...conditions))
+        .orderBy(desc(documents.uploadedAt))
+        .$dynamic();
+
+    const data = await applyLimitOffset(query, input);
+
+    if (input.includeDownloadUrl === false) {
+        return data;
+    }
+
+    return data.map((document) => ({
+        ...document,
+        downloadUrl: generateDownloadUrl(document.storagePath),
+    }));
+};
+
+export const getDocument = async (
+    input: { userId: string; id: string; deleted?: DeletedMode },
+    database: Database = db,
+) => {
+    const [document] = await database
+        .select()
+        .from(documents)
+        .where(
+            and(
+                eq(documents.id, input.id),
+                eq(documents.uploadedBy, input.userId),
+                documentDeletedFilter(input.deleted),
+            ),
+        );
+
+    return document ?? null;
+};
+
+export const listTransactions = async (
+    input: ListTransactionsInput,
+    database: Database = db,
+) => {
+    const startDate = input.from
+        ? parse(input.from, 'yyyy-MM-dd', new UTCDate())
+        : startOfYear(new UTCDate());
+    const endDate = input.to
+        ? endOfDay(parse(input.to, 'yyyy-MM-dd', new UTCDate()))
+        : new UTCDate();
+    const creditAccounts = aliasedTable(accounts, 'creditAccounts');
+    const debitAccounts = aliasedTable(accounts, 'debitAccounts');
+
+    const [userSettings] = await database
+        .select({
+            minRequiredDocuments: settings.minRequiredDocuments,
+            requiredDocumentTypeIds: settings.requiredDocumentTypeIds,
+        })
+        .from(settings)
+        .where(eq(settings.userId, input.userId));
+
+    const minRequiredDocs = userSettings?.minRequiredDocuments ?? 0;
+    const requiredDocTypeIds = userSettings?.requiredDocumentTypeIds
+        ? JSON.parse(userSettings.requiredDocumentTypeIds)
+        : [];
+
+    const query = database
+        .select({
+            id: transactions.id,
+            date: transactions.date,
+            payee: transactions.payee,
+            payeeCustomerId: transactions.payeeCustomerId,
+            payeeCustomerName:
+                sql<string>`coalesce(${customers.friendlyName}, ${customers.name})`.as(
+                    'payee_customer_name',
+                ),
+            amount: transactions.amount,
+            notes: transactions.notes,
+            account: accounts.name,
+            accountCode: accounts.code,
+            accountId: transactions.accountId,
+            accountIsOpen: accounts.isOpen,
+            accountClass: accounts.accountClass,
+            creditAccount: creditAccounts.name,
+            creditAccountCode: creditAccounts.code,
+            creditAccountId: transactions.creditAccountId,
+            creditAccountIsOpen: creditAccounts.isOpen,
+            creditAccountType: creditAccounts.accountType,
+            creditAccountClass: creditAccounts.accountClass,
+            debitAccount: debitAccounts.name,
+            debitAccountCode: debitAccounts.code,
+            debitAccountId: transactions.debitAccountId,
+            debitAccountIsOpen: debitAccounts.isOpen,
+            debitAccountType: debitAccounts.accountType,
+            debitAccountClass: debitAccounts.accountClass,
+            status: transactions.status,
+            statusChangedAt: transactions.statusChangedAt,
+            statusChangedBy: transactions.statusChangedBy,
+            splitGroupId: transactions.splitGroupId,
+            splitType: transactions.splitType,
+            stripePaymentId: transactions.stripePaymentId,
+            deletedAt: transactions.deletedAt,
+            deletedBy: transactions.deletedBy,
+            deleteReason: transactions.deleteReason,
+            restoredAt: transactions.restoredAt,
+            restoredBy: transactions.restoredBy,
+            restoreReason: transactions.restoreReason,
+        })
+        .from(transactions)
+        .leftJoin(accounts, eq(transactions.accountId, accounts.id))
+        .leftJoin(
+            creditAccounts,
+            eq(transactions.creditAccountId, creditAccounts.id),
+        )
+        .leftJoin(
+            debitAccounts,
+            eq(transactions.debitAccountId, debitAccounts.id),
+        )
+        .leftJoin(customers, eq(transactions.payeeCustomerId, customers.id))
+        .where(
+            and(
+                input.accountId
+                    ? or(
+                          eq(transactions.accountId, input.accountId),
+                          eq(transactions.creditAccountId, input.accountId),
+                          eq(transactions.debitAccountId, input.accountId),
+                      )
+                    : undefined,
+                input.id ? eq(transactions.id, input.id) : undefined,
+                input.payeeCustomerId
+                    ? eq(transactions.payeeCustomerId, input.payeeCustomerId)
+                    : undefined,
+                createTransactionAccessFilter(
+                    input.userId,
+                    creditAccounts,
+                    debitAccounts,
+                ),
+                gte(transactions.date, startDate),
+                lte(transactions.date, endDate),
+                transactionDeletedFilter(input.deleted),
+            ),
+        )
+        .orderBy(desc(transactions.date))
+        .$dynamic();
+
+    const data = await applyLimitOffset(query, input);
+    const transactionIds = data.map((transaction) => transaction.id);
+    const documentCounts: Map<
+        string,
+        { total: number; requiredTypes: string[] }
+    > = new Map();
+
+    if (transactionIds.length > 0) {
+        const docsData = await database
+            .select({
+                transactionId: documents.transactionId,
+                documentTypeId: documents.documentTypeId,
+            })
+            .from(documents)
+            .where(
+                and(
+                    inArray(documents.transactionId, transactionIds),
+                    eq(documents.isDeleted, false),
+                ),
+            );
+
+        for (const document of docsData) {
+            if (!document.transactionId) continue;
+
+            const existing = documentCounts.get(document.transactionId) ?? {
+                total: 0,
+                requiredTypes: [],
+            };
+            existing.total++;
+            if (
+                requiredDocTypeIds.includes(document.documentTypeId) &&
+                !existing.requiredTypes.includes(document.documentTypeId)
+            ) {
+                existing.requiredTypes.push(document.documentTypeId);
+            }
+            documentCounts.set(document.transactionId, existing);
+        }
+    }
+
+    const transactionTagsMap: Map<
+        string,
+        Array<{ id: string; name: string; color: string | null }>
+    > = new Map();
+
+    if (transactionIds.length > 0) {
+        const tagsData = await database
+            .select({
+                transactionId: transactionTags.transactionId,
+                tagId: tags.id,
+                tagName: tags.name,
+                tagColor: tags.color,
+            })
+            .from(transactionTags)
+            .innerJoin(tags, eq(transactionTags.tagId, tags.id))
+            .where(inArray(transactionTags.transactionId, transactionIds));
+
+        for (const tagData of tagsData) {
+            const existing =
+                transactionTagsMap.get(tagData.transactionId) ?? [];
+            existing.push({
+                id: tagData.tagId,
+                name: tagData.tagName,
+                color: tagData.tagColor,
+            });
+            transactionTagsMap.set(tagData.transactionId, existing);
+        }
+    }
+
+    return data.map((transaction) => {
+        const attachedRequiredCount =
+            documentCounts.get(transaction.id)?.requiredTypes.length ?? 0;
+        const totalRequiredTypes = requiredDocTypeIds.length;
+        let hasAllRequiredDocuments = true;
+
+        if (totalRequiredTypes > 0) {
+            hasAllRequiredDocuments =
+                minRequiredDocs === 0
+                    ? attachedRequiredCount >= totalRequiredTypes
+                    : attachedRequiredCount >=
+                      Math.min(minRequiredDocs, totalRequiredTypes);
+        }
+
+        return {
+            ...transaction,
+            tags: transactionTagsMap.get(transaction.id) ?? [],
+            documentCount: documentCounts.get(transaction.id)?.total ?? 0,
+            hasAllRequiredDocuments,
+            requiredDocumentTypes: totalRequiredTypes,
+            attachedRequiredTypes: attachedRequiredCount,
+            minRequiredDocuments: minRequiredDocs,
+        };
+    });
+};
+
+export const getTransaction = async (
+    input: { userId: string; id: string; deleted?: DeletedMode },
+    database: Database = db,
+) => {
+    const [transaction] = await listTransactions(
+        {
+            userId: input.userId,
+            id: input.id,
+            deleted: input.deleted ?? 'include',
+            limit: 1,
+        },
+        database,
+    );
+
+    return transaction ?? null;
+};

--- a/lib/services/finance-entity-core.ts
+++ b/lib/services/finance-entity-core.ts
@@ -1,0 +1,56 @@
+export const DEFAULT_ENTITY_LIMIT = 50;
+export const MAX_ENTITY_LIMIT = 100;
+
+export type DeletedMode = 'include' | 'only';
+
+export const normalizeEntityLimit = (
+    value?: number | null,
+    options?: { defaultLimit?: number; maxLimit?: number },
+) => {
+    const defaultLimit = options?.defaultLimit ?? DEFAULT_ENTITY_LIMIT;
+    const maxLimit = options?.maxLimit ?? MAX_ENTITY_LIMIT;
+
+    if (!Number.isFinite(value) || !value || value < 1) {
+        return defaultLimit;
+    }
+
+    return Math.min(Math.floor(value), maxLimit);
+};
+
+export const normalizeEntityOffset = (value?: number | null) => {
+    if (!Number.isFinite(value) || !value || value < 0) {
+        return 0;
+    }
+
+    return Math.floor(value);
+};
+
+export const normalizeDeletedMode = (
+    value?: string | null,
+): DeletedMode | undefined => {
+    if (value === 'include' || value === 'only') {
+        return value;
+    }
+
+    return undefined;
+};
+
+export const escapeLikePattern = (value: string): string =>
+    value.replace(/[\\%_]/g, '\\$&');
+
+export const splitSearchKeywords = (search?: string | null) =>
+    (search?.match(/(?:[^\s"]+|"[^"]*")+/g) ?? [])
+        .map((keyword) => keyword.replace(/"/g, '').trim())
+        .filter(Boolean);
+
+export const normalizeIban = (iban: string) =>
+    iban.toUpperCase().replace(/\s/g, '');
+
+export const normalizeEntityDate = (value?: string | Date | null) => {
+    if (!value) {
+        return undefined;
+    }
+
+    const date = value instanceof Date ? value : new Date(value);
+    return Number.isNaN(date.getTime()) ? undefined : date;
+};

--- a/tests/finance-entity-core.test.mjs
+++ b/tests/finance-entity-core.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+    DEFAULT_ENTITY_LIMIT,
+    escapeLikePattern,
+    MAX_ENTITY_LIMIT,
+    normalizeDeletedMode,
+    normalizeEntityDate,
+    normalizeEntityLimit,
+    normalizeEntityOffset,
+    normalizeIban,
+    splitSearchKeywords,
+} from '../lib/services/finance-entity-core.ts';
+
+test('normalizeEntityLimit defaults invalid values and clamps valid values', () => {
+    assert.equal(normalizeEntityLimit(), DEFAULT_ENTITY_LIMIT);
+    assert.equal(normalizeEntityLimit(0), DEFAULT_ENTITY_LIMIT);
+    assert.equal(normalizeEntityLimit(Number.NaN), DEFAULT_ENTITY_LIMIT);
+    assert.equal(normalizeEntityLimit(25.9), 25);
+    assert.equal(normalizeEntityLimit(MAX_ENTITY_LIMIT + 1), MAX_ENTITY_LIMIT);
+});
+
+test('normalizeEntityLimit accepts per-call default and max values', () => {
+    assert.equal(normalizeEntityLimit(undefined, { defaultLimit: 10 }), 10);
+    assert.equal(normalizeEntityLimit(500, { maxLimit: 250 }), 250);
+});
+
+test('normalizeEntityOffset floors positive values and defaults invalid values', () => {
+    assert.equal(normalizeEntityOffset(), 0);
+    assert.equal(normalizeEntityOffset(-1), 0);
+    assert.equal(normalizeEntityOffset(Number.NaN), 0);
+    assert.equal(normalizeEntityOffset(12.9), 12);
+});
+
+test('normalizeDeletedMode only accepts explicit deleted modes', () => {
+    assert.equal(normalizeDeletedMode('include'), 'include');
+    assert.equal(normalizeDeletedMode('only'), 'only');
+    assert.equal(normalizeDeletedMode('deleted'), undefined);
+    assert.equal(normalizeDeletedMode(), undefined);
+});
+
+test('search helpers preserve quoted terms and escape LIKE patterns', () => {
+    assert.deepEqual(splitSearchKeywords('alpha "beta gamma"'), [
+        'alpha',
+        'beta gamma',
+    ]);
+    assert.equal(escapeLikePattern('ACME_100%'), 'ACME\\_100\\%');
+});
+
+test('entity normalization helpers handle dates and IBANs', () => {
+    assert.equal(normalizeEntityDate('not-a-date'), undefined);
+    assert.equal(
+        normalizeEntityDate('2026-06-30T12:00:00.000Z')?.toISOString(),
+        '2026-06-30T12:00:00.000Z',
+    );
+    assert.equal(normalizeIban('hr12 3456'), 'HR123456');
+});


### PR DESCRIPTION
## Summary

- Adds shared finance entity service modules for scoped transaction, customer, account, tag, document, and audit-event reads.
- Refactors core read routes to delegate to those services so the upcoming MCP tools can reuse the same query and shaping logic.
- Adds focused service-core tests for limit/offset normalization, deleted-mode handling, search escaping, dates, and IBAN normalization.

## Verification

- `PATH=/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/biome check --write lib/services/finance-entity-core.ts lib/services/finance-entities.ts tests/finance-entity-core.test.mjs 'app/api/[[...route]]/auditEventsRoutes.ts' 'app/api/[[...route]]/accountsRoutes.ts' 'app/api/[[...route]]/tagsRoutes.ts' 'app/api/[[...route]]/customersRoutes.ts' 'app/api/[[...route]]/documentsRoutes.ts' 'app/api/[[...route]]/transactionsRoutes.ts'`
- `PATH=/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node --experimental-strip-types --test tests/finance-entity-core.test.mjs tests/audit-query.test.mjs`
- `PATH=/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --cached --check`

## Risk

- This is a read-service extraction only. Existing route response shapes are intended to stay unchanged, but several list endpoints now depend on the shared service module.

Closes #141
Refs #140