### PR TITLE
Add MCP read tools

### DIFF
--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -1,5 +1,7 @@
 import { authenticateMcpRequest } from '@/lib/mcp/auth';
+import { defaultMcpReadServices } from '@/lib/mcp/default-services';
 import { handleMcpRequest } from '@/lib/mcp/http';
+import { createNumeraMcpServer } from '@/lib/mcp/server';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -7,6 +9,10 @@ export const dynamic = 'force-dynamic';
 const handleAuthenticatedMcpRequest = (request: Request) =>
     handleMcpRequest(request, {
         authenticate: authenticateMcpRequest,
+        createServer: (context) =>
+            createNumeraMcpServer(context, {
+                readServices: defaultMcpReadServices,
+            }),
     });
 
 export const GET = handleAuthenticatedMcpRequest;

--- a/lib/mcp/context.ts
+++ b/lib/mcp/context.ts
@@ -10,12 +10,19 @@ export type NumeraMcpContext = {
 
 export type JsonToolResultData = Record<string, unknown>;
 
-export const createJsonToolResult = (data: JsonToolResultData) => ({
-    content: [
-        {
-            type: 'text' as const,
-            text: JSON.stringify(data),
-        },
-    ],
-    structuredContent: data,
-});
+const toJsonSafeData = (data: JsonToolResultData): JsonToolResultData =>
+    JSON.parse(JSON.stringify(data)) as JsonToolResultData;
+
+export const createJsonToolResult = (data: JsonToolResultData) => {
+    const jsonSafeData = toJsonSafeData(data);
+
+    return {
+        content: [
+            {
+                type: 'text' as const,
+                text: JSON.stringify(jsonSafeData),
+            },
+        ],
+        structuredContent: jsonSafeData,
+    };
+};

--- a/lib/mcp/default-services.ts
+++ b/lib/mcp/default-services.ts
@@ -1,0 +1,41 @@
+import {
+    getAccount,
+    getCustomer,
+    getDocument,
+    getTag,
+    getTransaction,
+    listAccounts,
+    listAuditEvents,
+    listCustomerIbans,
+    listCustomers,
+    listDocuments,
+    listTags,
+    listTransactions,
+} from '@/lib/services/finance-entities';
+
+import type { McpReadServices } from './read-tools.ts';
+
+export const defaultMcpReadServices: McpReadServices = {
+    listTransactions: (input) =>
+        listTransactions(input as Parameters<typeof listTransactions>[0]),
+    getTransaction: (input) =>
+        getTransaction(input as Parameters<typeof getTransaction>[0]),
+    listCustomers: (input) =>
+        listCustomers(input as Parameters<typeof listCustomers>[0]),
+    getCustomer: (input) =>
+        getCustomer(input as Parameters<typeof getCustomer>[0]),
+    listCustomerIbans: (input) =>
+        listCustomerIbans(input as Parameters<typeof listCustomerIbans>[0]),
+    listAccounts: (input) =>
+        listAccounts(input as Parameters<typeof listAccounts>[0]),
+    getAccount: (input) =>
+        getAccount(input as Parameters<typeof getAccount>[0]),
+    listTags: (input) => listTags(input as Parameters<typeof listTags>[0]),
+    getTag: (input) => getTag(input as Parameters<typeof getTag>[0]),
+    listDocuments: (input) =>
+        listDocuments(input as Parameters<typeof listDocuments>[0]),
+    getDocument: (input) =>
+        getDocument(input as Parameters<typeof getDocument>[0]),
+    listAuditEvents: (input) =>
+        listAuditEvents(input as Parameters<typeof listAuditEvents>[0]),
+};

--- a/lib/mcp/http.ts
+++ b/lib/mcp/http.ts
@@ -1,5 +1,5 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
-
 import type { NumeraMcpContext } from './context.ts';
 import { createNumeraMcpServer } from './server.ts';
 
@@ -9,7 +9,7 @@ export type McpAuthenticator = (
 
 export type HandleMcpRequestOptions = {
     authenticate: McpAuthenticator;
-    createServer?: typeof createNumeraMcpServer;
+    createServer?: (context: NumeraMcpContext) => McpServer;
 };
 
 export const createUnauthorizedMcpResponse = () =>

--- a/lib/mcp/read-tools.ts
+++ b/lib/mcp/read-tools.ts
@@ -1,0 +1,368 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import { createJsonToolResult, type NumeraMcpContext } from './context.ts';
+
+const deletedModeSchema = z.enum(['include', 'only']).optional();
+const limitSchema = z.number().int().min(1).max(100).optional();
+const offsetSchema = z.number().int().min(0).optional();
+
+const pageSchema = {
+    limit: limitSchema,
+    offset: offsetSchema,
+};
+
+type ServiceResult = unknown[] | Record<string, unknown> | null;
+type ServiceFn<
+    Input extends Record<string, unknown> = Record<string, unknown>,
+> = (input: Input) => Promise<ServiceResult>;
+
+export type McpReadServices = {
+    listTransactions: ServiceFn;
+    getTransaction: ServiceFn;
+    listCustomers: ServiceFn;
+    getCustomer: ServiceFn;
+    listCustomerIbans: ServiceFn;
+    listAccounts: ServiceFn;
+    getAccount: ServiceFn;
+    listTags: ServiceFn;
+    getTag: ServiceFn;
+    listDocuments: ServiceFn;
+    getDocument: ServiceFn;
+    listAuditEvents: ServiceFn;
+};
+
+const createListResult = (entity: string, data: ServiceResult) =>
+    createJsonToolResult({
+        entity,
+        data: data ?? [],
+    });
+
+const createItemResult = (entity: string, data: ServiceResult) =>
+    createJsonToolResult({
+        entity,
+        data,
+        found: Boolean(data),
+    });
+
+export const registerReadMcpTools = (
+    server: McpServer,
+    context: NumeraMcpContext,
+    services: McpReadServices,
+) => {
+    server.registerTool(
+        'numera_list_transactions',
+        {
+            title: 'List Transactions',
+            description:
+                'List transactions scoped to the authenticated Numera user.',
+            inputSchema: z.object({
+                from: z.string().optional(),
+                to: z.string().optional(),
+                accountId: z.string().optional(),
+                payeeCustomerId: z.string().optional(),
+                deleted: deletedModeSchema,
+                ...pageSchema,
+            }),
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+            },
+        },
+        async (input) =>
+            createListResult(
+                'transactions',
+                await services.listTransactions({
+                    userId: context.userId,
+                    ...input,
+                }),
+            ),
+    );
+
+    server.registerTool(
+        'numera_get_transaction',
+        {
+            title: 'Get Transaction',
+            description:
+                'Get one transaction by id when it belongs to the authenticated Numera user.',
+            inputSchema: z.object({
+                id: z.string().min(1),
+                deleted: deletedModeSchema,
+            }),
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+            },
+        },
+        async (input) =>
+            createItemResult(
+                'transaction',
+                await services.getTransaction({
+                    userId: context.userId,
+                    ...input,
+                }),
+            ),
+    );
+
+    server.registerTool(
+        'numera_list_customers',
+        {
+            title: 'List Customers',
+            description:
+                'List customers scoped to the authenticated Numera user.',
+            inputSchema: z.object({
+                search: z.string().optional(),
+                deleted: deletedModeSchema,
+                ...pageSchema,
+            }),
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+            },
+        },
+        async (input) =>
+            createListResult(
+                'customers',
+                await services.listCustomers({
+                    userId: context.userId,
+                    ...input,
+                }),
+            ),
+    );
+
+    server.registerTool(
+        'numera_get_customer',
+        {
+            title: 'Get Customer',
+            description:
+                'Get one customer by id when it belongs to the authenticated Numera user.',
+            inputSchema: z.object({
+                id: z.string().min(1),
+                deleted: deletedModeSchema,
+            }),
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+            },
+        },
+        async (input) =>
+            createItemResult(
+                'customer',
+                await services.getCustomer({
+                    userId: context.userId,
+                    ...input,
+                }),
+            ),
+    );
+
+    server.registerTool(
+        'numera_list_customer_ibans',
+        {
+            title: 'List Customer IBANs',
+            description:
+                'List IBANs for a customer scoped to the authenticated Numera user.',
+            inputSchema: z.object({
+                customerId: z.string().min(1),
+                deleted: deletedModeSchema,
+                customerDeleted: deletedModeSchema,
+                ...pageSchema,
+            }),
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+            },
+        },
+        async (input) =>
+            createListResult(
+                'customer_ibans',
+                await services.listCustomerIbans({
+                    userId: context.userId,
+                    ...input,
+                }),
+            ),
+    );
+
+    server.registerTool(
+        'numera_list_accounts',
+        {
+            title: 'List Accounts',
+            description:
+                'List accounts scoped to the authenticated Numera user.',
+            inputSchema: z.object({
+                search: z.string().optional(),
+                accountId: z.string().optional(),
+                showClosed: z.boolean().optional(),
+                ...pageSchema,
+            }),
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+            },
+        },
+        async (input) =>
+            createListResult(
+                'accounts',
+                await services.listAccounts({
+                    userId: context.userId,
+                    ...input,
+                }),
+            ),
+    );
+
+    server.registerTool(
+        'numera_get_account',
+        {
+            title: 'Get Account',
+            description:
+                'Get one account by id when it belongs to the authenticated Numera user.',
+            inputSchema: z.object({
+                id: z.string().min(1),
+            }),
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+            },
+        },
+        async (input) =>
+            createItemResult(
+                'account',
+                await services.getAccount({
+                    userId: context.userId,
+                    ...input,
+                }),
+            ),
+    );
+
+    server.registerTool(
+        'numera_list_tags',
+        {
+            title: 'List Tags',
+            description: 'List tags scoped to the authenticated Numera user.',
+            inputSchema: z.object(pageSchema),
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+            },
+        },
+        async (input) =>
+            createListResult(
+                'tags',
+                await services.listTags({
+                    userId: context.userId,
+                    ...input,
+                }),
+            ),
+    );
+
+    server.registerTool(
+        'numera_get_tag',
+        {
+            title: 'Get Tag',
+            description:
+                'Get one tag by id when it belongs to the authenticated Numera user.',
+            inputSchema: z.object({
+                id: z.string().min(1),
+            }),
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+            },
+        },
+        async (input) =>
+            createItemResult(
+                'tag',
+                await services.getTag({
+                    userId: context.userId,
+                    ...input,
+                }),
+            ),
+    );
+
+    server.registerTool(
+        'numera_list_documents',
+        {
+            title: 'List Documents',
+            description:
+                'List documents scoped to the authenticated Numera user.',
+            inputSchema: z.object({
+                documentTypeId: z.string().optional(),
+                from: z.string().optional(),
+                to: z.string().optional(),
+                unattached: z.boolean().optional(),
+                deleted: deletedModeSchema,
+                ...pageSchema,
+            }),
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+            },
+        },
+        async (input) =>
+            createListResult(
+                'documents',
+                await services.listDocuments({
+                    userId: context.userId,
+                    includeDownloadUrl: false,
+                    ...input,
+                }),
+            ),
+    );
+
+    server.registerTool(
+        'numera_get_document',
+        {
+            title: 'Get Document',
+            description:
+                'Get one document by id when it belongs to the authenticated Numera user.',
+            inputSchema: z.object({
+                id: z.string().min(1),
+                deleted: deletedModeSchema,
+            }),
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+            },
+        },
+        async (input) =>
+            createItemResult(
+                'document',
+                await services.getDocument({
+                    userId: context.userId,
+                    ...input,
+                }),
+            ),
+    );
+
+    server.registerTool(
+        'numera_list_audit_events',
+        {
+            title: 'List Audit Events',
+            description:
+                'List audit events scoped to the authenticated Numera user.',
+            inputSchema: z.object({
+                resourceType: z.string().optional(),
+                resourceId: z.string().optional(),
+                actorUserId: z.string().optional(),
+                actorType: z.enum(['user', 'system', 'integration']).optional(),
+                action: z.string().optional(),
+                from: z.string().optional(),
+                to: z.string().optional(),
+                source: z.string().optional(),
+                limit: limitSchema,
+                offset: offsetSchema,
+            }),
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+            },
+        },
+        async (input) =>
+            createListResult(
+                'audit_events',
+                await services.listAuditEvents({
+                    userId: context.userId,
+                    ...input,
+                }),
+            ),
+    );
+};

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -6,9 +6,14 @@ import {
     MCP_SOURCE,
     type NumeraMcpContext,
 } from './context.ts';
+import { type McpReadServices, registerReadMcpTools } from './read-tools.ts';
 
 export const NUMERA_MCP_SERVER_NAME = 'numera-now';
 export const NUMERA_MCP_SERVER_VERSION = '0.1.0';
+
+export type NumeraMcpServerOptions = {
+    readServices?: McpReadServices;
+};
 
 export const registerBaseMcpTools = (
     server: McpServer,
@@ -38,13 +43,19 @@ export const registerBaseMcpTools = (
     );
 };
 
-export const createNumeraMcpServer = (context: NumeraMcpContext) => {
+export const createNumeraMcpServer = (
+    context: NumeraMcpContext,
+    options: NumeraMcpServerOptions = {},
+) => {
     const server = new McpServer({
         name: NUMERA_MCP_SERVER_NAME,
         version: NUMERA_MCP_SERVER_VERSION,
     });
 
     registerBaseMcpTools(server, context);
+    if (options.readServices) {
+        registerReadMcpTools(server, context, options.readServices);
+    }
 
     return server;
 };

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -24,6 +24,34 @@ const createTestContext = () => ({
     },
 });
 
+const createMockReadServices = () => {
+    const calls = [];
+    const createService = (name, result) => async (input) => {
+        calls.push({ name, input });
+        return result;
+    };
+
+    return {
+        calls,
+        services: {
+            listTransactions: createService('listTransactions', []),
+            getTransaction: createService('getTransaction', null),
+            listCustomers: createService('listCustomers', [
+                { id: 'customer_1', name: 'ACME' },
+            ]),
+            getCustomer: createService('getCustomer', null),
+            listCustomerIbans: createService('listCustomerIbans', []),
+            listAccounts: createService('listAccounts', []),
+            getAccount: createService('getAccount', null),
+            listTags: createService('listTags', []),
+            getTag: createService('getTag', null),
+            listDocuments: createService('listDocuments', []),
+            getDocument: createService('getDocument', null),
+            listAuditEvents: createService('listAuditEvents', []),
+        },
+    };
+};
+
 test('unauthorized MCP response is a JSON-RPC error response', async () => {
     const response = createUnauthorizedMcpResponse();
 
@@ -50,7 +78,10 @@ test('MCP request handler rejects unauthenticated requests before transport hand
 });
 
 test('base MCP server registers authenticated whoami tool', async () => {
-    const server = createNumeraMcpServer(createTestContext());
+    const { calls, services } = createMockReadServices();
+    const server = createNumeraMcpServer(createTestContext(), {
+        readServices: services,
+    });
     const client = new Client({
         name: 'numera-test-client',
         version: '0.1.0',
@@ -67,6 +98,10 @@ test('base MCP server registers authenticated whoami tool', async () => {
             tools.tools.some((tool) => tool.name === 'numera_whoami'),
             'expected numera_whoami to be listed',
         );
+        assert.ok(
+            tools.tools.some((tool) => tool.name === 'numera_list_customers'),
+            'expected numera_list_customers to be listed',
+        );
 
         const result = await client.callTool({
             name: 'numera_whoami',
@@ -77,6 +112,29 @@ test('base MCP server registers authenticated whoami tool', async () => {
             userId: 'user_test_123',
             source: MCP_SOURCE,
         });
+
+        const customersResult = await client.callTool({
+            name: 'numera_list_customers',
+            arguments: {
+                search: 'ACME',
+                limit: 5,
+            },
+        });
+
+        assert.deepEqual(customersResult.structuredContent, {
+            entity: 'customers',
+            data: [{ id: 'customer_1', name: 'ACME' }],
+        });
+        assert.deepEqual(calls, [
+            {
+                name: 'listCustomers',
+                input: {
+                    userId: 'user_test_123',
+                    search: 'ACME',
+                    limit: 5,
+                },
+            },
+        ]);
     } finally {
         await client.close();
         await server.close();


### PR DESCRIPTION
## Summary

- Adds service-injected MCP read tools for transactions, customers, customer IBANs, accounts, tags, documents, and audit events.
- Wires the Next MCP route to the real shared finance services while keeping the MCP server testable with mocks.
- Returns JSON-safe structured tool content and extends MCP tests to verify tool listing and service delegation with authenticated user scope.

## Verification

- `PATH=/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/biome check --write app/api/mcp/route.ts lib/mcp/context.ts lib/mcp/default-services.ts lib/mcp/http.ts lib/mcp/read-tools.ts lib/mcp/server.ts tests/mcp-server.test.mjs`
- `PATH=/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node --experimental-strip-types --test tests/mcp-server.test.mjs tests/finance-entity-core.test.mjs`
- `PATH=/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --cached --check`

## Risk

- Read tools expose structured entity data to authenticated MCP clients. They use shared services and do not include document download URLs by default.

Closes #143
Refs #140