### PR TITLE
Add MCP mutation tools

### DIFF
--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -1,5 +1,8 @@
 import { authenticateMcpRequest } from '@/lib/mcp/auth';
-import { defaultMcpReadServices } from '@/lib/mcp/default-services';
+import {
+    defaultMcpMutationServices,
+    defaultMcpReadServices,
+} from '@/lib/mcp/default-services';
 import { handleMcpRequest } from '@/lib/mcp/http';
 import { createNumeraMcpServer } from '@/lib/mcp/server';
 
@@ -12,6 +15,7 @@ const handleAuthenticatedMcpRequest = (request: Request) =>
         createServer: (context) =>
             createNumeraMcpServer(context, {
                 readServices: defaultMcpReadServices,
+                mutationServices: defaultMcpMutationServices,
             }),
     });
 

--- a/lib/mcp/context.ts
+++ b/lib/mcp/context.ts
@@ -26,3 +26,8 @@ export const createJsonToolResult = (data: JsonToolResultData) => {
         structuredContent: jsonSafeData,
     };
 };
+
+export const createJsonErrorToolResult = (data: JsonToolResultData) => ({
+    ...createJsonToolResult(data),
+    isError: true,
+});

--- a/lib/mcp/default-services.ts
+++ b/lib/mcp/default-services.ts
@@ -12,7 +12,18 @@ import {
     listTags,
     listTransactions,
 } from '@/lib/services/finance-entities';
+import {
+    deleteCustomerForUser,
+    deleteDocumentForUser,
+    deleteTransactionForUser,
+    purgeDocumentForUser,
+    purgeTransactionForUser,
+    restoreCustomerForUser,
+    restoreDocumentForUser,
+    restoreTransactionForUser,
+} from '@/lib/services/finance-mutations';
 
+import type { McpMutationServices } from './mutation-tools.ts';
 import type { McpReadServices } from './read-tools.ts';
 
 export const defaultMcpReadServices: McpReadServices = {
@@ -38,4 +49,15 @@ export const defaultMcpReadServices: McpReadServices = {
         getDocument(input as Parameters<typeof getDocument>[0]),
     listAuditEvents: (input) =>
         listAuditEvents(input as Parameters<typeof listAuditEvents>[0]),
+};
+
+export const defaultMcpMutationServices: McpMutationServices = {
+    deleteTransaction: deleteTransactionForUser,
+    restoreTransaction: restoreTransactionForUser,
+    purgeTransaction: purgeTransactionForUser,
+    deleteCustomer: deleteCustomerForUser,
+    restoreCustomer: restoreCustomerForUser,
+    deleteDocument: deleteDocumentForUser,
+    restoreDocument: restoreDocumentForUser,
+    purgeDocument: purgeDocumentForUser,
 };

--- a/lib/mcp/mutation-tools.ts
+++ b/lib/mcp/mutation-tools.ts
@@ -1,0 +1,228 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import {
+    createJsonErrorToolResult,
+    createJsonToolResult,
+    type NumeraMcpContext,
+} from './context.ts';
+
+type MutationResult =
+    | {
+          ok: true;
+          data: unknown;
+      }
+    | {
+          ok: false;
+          status: number;
+          error: string;
+      };
+
+type MutationService = (input: {
+    userId: string;
+    id: string;
+    reason?: string | null;
+    confirm?: boolean;
+}) => Promise<MutationResult>;
+
+export type McpMutationServices = {
+    deleteTransaction: MutationService;
+    restoreTransaction: MutationService;
+    purgeTransaction: MutationService;
+    deleteCustomer: MutationService;
+    restoreCustomer: MutationService;
+    deleteDocument: MutationService;
+    restoreDocument: MutationService;
+    purgeDocument: MutationService;
+};
+
+const lifecycleInputSchema = z.object({
+    id: z.string().min(1),
+    reason: z.string().max(500).optional(),
+});
+
+const purgeInputSchema = lifecycleInputSchema.extend({
+    confirm: z.literal(true),
+});
+
+const createMutationToolResult = (entity: string, result: MutationResult) => {
+    if (!result.ok) {
+        return createJsonErrorToolResult({
+            entity,
+            ok: false,
+            status: result.status,
+            error: result.error,
+        });
+    }
+
+    return createJsonToolResult({
+        entity,
+        ok: true,
+        data: result.data,
+    });
+};
+
+const registerLifecycleTool = ({
+    server,
+    context,
+    name,
+    title,
+    description,
+    entity,
+    service,
+}: {
+    server: McpServer;
+    context: NumeraMcpContext;
+    name: string;
+    title: string;
+    description: string;
+    entity: string;
+    service: MutationService;
+}) => {
+    server.registerTool(
+        name,
+        {
+            title,
+            description,
+            inputSchema: lifecycleInputSchema,
+            annotations: {
+                readOnlyHint: false,
+                destructiveHint: true,
+            },
+        },
+        async (input) =>
+            createMutationToolResult(
+                entity,
+                await service({
+                    userId: context.userId,
+                    ...input,
+                }),
+            ),
+    );
+};
+
+const registerPurgeTool = ({
+    server,
+    context,
+    name,
+    title,
+    description,
+    entity,
+    service,
+}: {
+    server: McpServer;
+    context: NumeraMcpContext;
+    name: string;
+    title: string;
+    description: string;
+    entity: string;
+    service: MutationService;
+}) => {
+    server.registerTool(
+        name,
+        {
+            title,
+            description,
+            inputSchema: purgeInputSchema,
+            annotations: {
+                readOnlyHint: false,
+                destructiveHint: true,
+            },
+        },
+        async (input) =>
+            createMutationToolResult(
+                entity,
+                await service({
+                    userId: context.userId,
+                    ...input,
+                }),
+            ),
+    );
+};
+
+export const registerMutationMcpTools = (
+    server: McpServer,
+    context: NumeraMcpContext,
+    services: McpMutationServices,
+) => {
+    registerLifecycleTool({
+        server,
+        context,
+        name: 'numera_delete_transaction',
+        title: 'Delete Transaction',
+        description:
+            'Soft-delete a transaction for the authenticated Numera user. Split transaction groups are handled by the app lifecycle policy.',
+        entity: 'transaction',
+        service: services.deleteTransaction,
+    });
+    registerLifecycleTool({
+        server,
+        context,
+        name: 'numera_restore_transaction',
+        title: 'Restore Transaction',
+        description:
+            'Restore a previously soft-deleted transaction for the authenticated Numera user.',
+        entity: 'transaction',
+        service: services.restoreTransaction,
+    });
+    registerPurgeTool({
+        server,
+        context,
+        name: 'numera_purge_transaction',
+        title: 'Purge Transaction',
+        description:
+            'Permanently purge a previously soft-deleted transaction. Requires confirm: true.',
+        entity: 'transaction',
+        service: services.purgeTransaction,
+    });
+    registerLifecycleTool({
+        server,
+        context,
+        name: 'numera_delete_customer',
+        title: 'Delete Customer',
+        description:
+            'Soft-delete a customer for the authenticated Numera user.',
+        entity: 'customer',
+        service: services.deleteCustomer,
+    });
+    registerLifecycleTool({
+        server,
+        context,
+        name: 'numera_restore_customer',
+        title: 'Restore Customer',
+        description:
+            'Restore a previously soft-deleted customer for the authenticated Numera user.',
+        entity: 'customer',
+        service: services.restoreCustomer,
+    });
+    registerLifecycleTool({
+        server,
+        context,
+        name: 'numera_delete_document',
+        title: 'Delete Document',
+        description:
+            'Soft-delete a document for the authenticated Numera user while retaining the backing blob.',
+        entity: 'document',
+        service: services.deleteDocument,
+    });
+    registerLifecycleTool({
+        server,
+        context,
+        name: 'numera_restore_document',
+        title: 'Restore Document',
+        description:
+            'Restore a previously soft-deleted document for the authenticated Numera user.',
+        entity: 'document',
+        service: services.restoreDocument,
+    });
+    registerPurgeTool({
+        server,
+        context,
+        name: 'numera_purge_document',
+        title: 'Purge Document',
+        description:
+            'Permanently purge a previously soft-deleted document and its backing blob. Requires confirm: true.',
+        entity: 'document',
+        service: services.purgeDocument,
+    });
+};

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -6,6 +6,10 @@ import {
     MCP_SOURCE,
     type NumeraMcpContext,
 } from './context.ts';
+import {
+    type McpMutationServices,
+    registerMutationMcpTools,
+} from './mutation-tools.ts';
 import { type McpReadServices, registerReadMcpTools } from './read-tools.ts';
 
 export const NUMERA_MCP_SERVER_NAME = 'numera-now';
@@ -13,6 +17,7 @@ export const NUMERA_MCP_SERVER_VERSION = '0.1.0';
 
 export type NumeraMcpServerOptions = {
     readServices?: McpReadServices;
+    mutationServices?: McpMutationServices;
 };
 
 export const registerBaseMcpTools = (
@@ -55,6 +60,9 @@ export const createNumeraMcpServer = (
     registerBaseMcpTools(server, context);
     if (options.readServices) {
         registerReadMcpTools(server, context, options.readServices);
+    }
+    if (options.mutationServices) {
+        registerMutationMcpTools(server, context, options.mutationServices);
     }
 
     return server;

--- a/lib/services/finance-mutations.ts
+++ b/lib/services/finance-mutations.ts
@@ -1,0 +1,738 @@
+import { UTCDate } from '@date-fns/utc';
+import {
+    aliasedTable,
+    and,
+    eq,
+    inArray,
+    isNotNull,
+    isNull,
+    ne,
+    or,
+} from 'drizzle-orm';
+import { db } from '@/db/drizzle';
+import { accounts, customers, documents, transactions } from '@/db/schema';
+import { validateDateNotInClosedPeriod } from '@/lib/accounting-periods';
+import { type AuditAction, writeAuditEvent } from '@/lib/audit';
+import { deleteDocument as deleteDocumentBlob } from '@/lib/azure-storage';
+import {
+    createCustomerRestorePatch,
+    createCustomerSoftDeletePatch,
+} from '@/lib/customer-lifecycle';
+import {
+    createDocumentRestorePatch,
+    createDocumentSoftDeletePatch,
+} from '@/lib/document-lifecycle';
+import {
+    createTransactionRestorePatch,
+    createTransactionSoftDeletePatch,
+    expandTransactionLifecycleTargetIds,
+    TRANSACTION_SPLIT_LIFECYCLE_POLICY,
+} from '@/lib/transaction-lifecycle';
+
+type MutationSource =
+    | 'mcp_transactions_delete'
+    | 'mcp_transactions_restore'
+    | 'mcp_transactions_purge'
+    | 'mcp_customers_delete'
+    | 'mcp_customers_restore'
+    | 'mcp_documents_delete'
+    | 'mcp_documents_restore'
+    | 'mcp_documents_purge';
+
+type MutationResult<T> =
+    | {
+          ok: true;
+          data: T;
+      }
+    | {
+          ok: false;
+          status: 400 | 403 | 404 | 500;
+          error: string;
+      };
+
+type DeletedMode = 'include' | 'only';
+
+const transactionDeletedFilter = (deleted?: DeletedMode) => {
+    if (deleted === 'include') {
+        return undefined;
+    }
+
+    if (deleted === 'only') {
+        return isNotNull(transactions.deletedAt);
+    }
+
+    return isNull(transactions.deletedAt);
+};
+
+const transactionAccessFilter = (
+    userId: string,
+    creditAccounts: ReturnType<typeof aliasedTable<typeof accounts>>,
+    debitAccounts: ReturnType<typeof aliasedTable<typeof accounts>>,
+) =>
+    or(
+        eq(accounts.userId, userId),
+        eq(creditAccounts.userId, userId),
+        eq(debitAccounts.userId, userId),
+        and(
+            isNull(transactions.accountId),
+            isNull(transactions.creditAccountId),
+            isNull(transactions.debitAccountId),
+            eq(transactions.statusChangedBy, userId),
+        ),
+        eq(transactions.deletedBy, userId),
+    );
+
+const getAuthorizedTransactionLifecycleRows = async ({
+    ids,
+    userId,
+    deleted,
+}: {
+    ids: string[];
+    userId: string;
+    deleted?: DeletedMode;
+}) => {
+    if (ids.length === 0) {
+        return [];
+    }
+
+    const uniqueIds = [...new Set(ids)];
+    const creditAccounts = aliasedTable(accounts, 'creditAccounts');
+    const debitAccounts = aliasedTable(accounts, 'debitAccounts');
+    const selectedRows = await db
+        .select({ transaction: transactions })
+        .from(transactions)
+        .leftJoin(accounts, eq(transactions.accountId, accounts.id))
+        .leftJoin(
+            creditAccounts,
+            eq(transactions.creditAccountId, creditAccounts.id),
+        )
+        .leftJoin(
+            debitAccounts,
+            eq(transactions.debitAccountId, debitAccounts.id),
+        )
+        .where(
+            and(
+                inArray(transactions.id, uniqueIds),
+                transactionAccessFilter(userId, creditAccounts, debitAccounts),
+                transactionDeletedFilter(deleted),
+            ),
+        );
+
+    const splitGroupIds = [
+        ...new Set(
+            selectedRows
+                .map(({ transaction }) => transaction.splitGroupId)
+                .filter(Boolean) as string[],
+        ),
+    ];
+
+    if (splitGroupIds.length === 0) {
+        return selectedRows.map(({ transaction }) => transaction);
+    }
+
+    const expandedRows = await db
+        .select({ transaction: transactions })
+        .from(transactions)
+        .leftJoin(accounts, eq(transactions.accountId, accounts.id))
+        .leftJoin(
+            creditAccounts,
+            eq(transactions.creditAccountId, creditAccounts.id),
+        )
+        .leftJoin(
+            debitAccounts,
+            eq(transactions.debitAccountId, debitAccounts.id),
+        )
+        .where(
+            and(
+                or(
+                    inArray(transactions.id, uniqueIds),
+                    inArray(transactions.splitGroupId, splitGroupIds),
+                ),
+                transactionAccessFilter(userId, creditAccounts, debitAccounts),
+                transactionDeletedFilter(deleted),
+            ),
+        );
+
+    const targetIds = new Set(
+        expandTransactionLifecycleTargetIds(
+            uniqueIds,
+            expandedRows.map(({ transaction }) => transaction),
+        ),
+    );
+
+    return expandedRows
+        .map(({ transaction }) => transaction)
+        .filter((transaction) => targetIds.has(transaction.id));
+};
+
+const writeTransactionLifecycleAuditEvents = async ({
+    action,
+    userId,
+    beforeRows,
+    afterRows,
+    reason,
+    source,
+}: {
+    action: 'delete' | 'restore' | 'purge';
+    userId: string;
+    beforeRows: (typeof transactions.$inferSelect)[];
+    afterRows?: (typeof transactions.$inferSelect)[];
+    reason?: string | null;
+    source: MutationSource;
+}) => {
+    const afterById = new Map(afterRows?.map((row) => [row.id, row]) ?? []);
+
+    for (const before of beforeRows) {
+        await writeAuditEvent(db, {
+            userId,
+            actorUserId: userId,
+            actorType: 'user',
+            action,
+            resourceType: 'transaction',
+            resourceId: before.id,
+            resourceLabel: before.payee,
+            before,
+            after: afterById.get(before.id) ?? null,
+            sourceMetadata: {
+                source,
+                reason: reason ?? null,
+                splitPolicy: TRANSACTION_SPLIT_LIFECYCLE_POLICY,
+            },
+        });
+    }
+};
+
+const rejectClosedPeriodTransactions = async (
+    rows: (typeof transactions.$inferSelect)[],
+    userId: string,
+    verb: string,
+): Promise<MutationResult<never> | null> => {
+    for (const transaction of rows) {
+        const periodError = await validateDateNotInClosedPeriod(
+            transaction.date,
+            userId,
+        );
+        if (periodError) {
+            return {
+                ok: false,
+                status: 400,
+                error: `Cannot ${verb} transaction ${transaction.id}: ${periodError}`,
+            };
+        }
+    }
+
+    return null;
+};
+
+export const deleteTransactionForUser = async ({
+    userId,
+    id,
+    reason,
+}: {
+    userId: string;
+    id: string;
+    reason?: string | null;
+}): Promise<MutationResult<(typeof transactions.$inferSelect)[]>> => {
+    const rows = await getAuthorizedTransactionLifecycleRows({
+        ids: [id],
+        userId,
+    });
+
+    if (rows.length === 0) {
+        return { ok: false, status: 404, error: 'Transaction not found.' };
+    }
+
+    const periodRejection = await rejectClosedPeriodTransactions(
+        rows,
+        userId,
+        'delete',
+    );
+    if (periodRejection) return periodRejection;
+
+    const data = await db
+        .update(transactions)
+        .set(
+            createTransactionSoftDeletePatch({
+                userId,
+                reason: reason ?? null,
+                now: new UTCDate(),
+            }),
+        )
+        .where(
+            inArray(
+                transactions.id,
+                rows.map((row) => row.id),
+            ),
+        )
+        .returning();
+
+    await writeTransactionLifecycleAuditEvents({
+        action: 'delete',
+        userId,
+        beforeRows: rows,
+        afterRows: data,
+        reason,
+        source: 'mcp_transactions_delete',
+    });
+
+    return { ok: true, data };
+};
+
+export const restoreTransactionForUser = async ({
+    userId,
+    id,
+    reason,
+}: {
+    userId: string;
+    id: string;
+    reason?: string | null;
+}): Promise<MutationResult<(typeof transactions.$inferSelect)[]>> => {
+    const rows = await getAuthorizedTransactionLifecycleRows({
+        ids: [id],
+        userId,
+        deleted: 'only',
+    });
+
+    if (rows.length === 0) {
+        return { ok: false, status: 404, error: 'Transaction not found.' };
+    }
+
+    const periodRejection = await rejectClosedPeriodTransactions(
+        rows,
+        userId,
+        'restore',
+    );
+    if (periodRejection) return periodRejection;
+
+    const data = await db
+        .update(transactions)
+        .set(
+            createTransactionRestorePatch({
+                userId,
+                reason: reason ?? null,
+                now: new UTCDate(),
+            }),
+        )
+        .where(
+            inArray(
+                transactions.id,
+                rows.map((row) => row.id),
+            ),
+        )
+        .returning();
+
+    await writeTransactionLifecycleAuditEvents({
+        action: 'restore',
+        userId,
+        beforeRows: rows,
+        afterRows: data,
+        reason,
+        source: 'mcp_transactions_restore',
+    });
+
+    return { ok: true, data };
+};
+
+export const purgeTransactionForUser = async ({
+    userId,
+    id,
+    reason,
+    confirm,
+}: {
+    userId: string;
+    id: string;
+    reason?: string | null;
+    confirm?: boolean;
+}): Promise<MutationResult<(typeof transactions.$inferSelect)[]>> => {
+    if (confirm !== true) {
+        return {
+            ok: false,
+            status: 400,
+            error: 'Permanent purge requires confirm: true.',
+        };
+    }
+
+    const rows = await getAuthorizedTransactionLifecycleRows({
+        ids: [id],
+        userId,
+        deleted: 'only',
+    });
+
+    if (rows.length === 0) {
+        return { ok: false, status: 404, error: 'Transaction not found.' };
+    }
+
+    const data = await db
+        .delete(transactions)
+        .where(
+            inArray(
+                transactions.id,
+                rows.map((row) => row.id),
+            ),
+        )
+        .returning();
+
+    await writeTransactionLifecycleAuditEvents({
+        action: 'purge',
+        userId,
+        beforeRows: rows,
+        afterRows: [],
+        reason,
+        source: 'mcp_transactions_purge',
+    });
+
+    return { ok: true, data };
+};
+
+const getAuthorizedDocument = async ({
+    id,
+    userId,
+    deleted,
+}: {
+    id: string;
+    userId: string;
+    deleted?: DeletedMode;
+}) => {
+    const [document] = await db
+        .select()
+        .from(documents)
+        .where(
+            and(
+                eq(documents.id, id),
+                eq(documents.uploadedBy, userId),
+                deleted === 'only'
+                    ? eq(documents.isDeleted, true)
+                    : eq(documents.isDeleted, false),
+            ),
+        );
+
+    return document ?? null;
+};
+
+const writeDocumentAuditEvent = async ({
+    action,
+    userId,
+    before,
+    after,
+    reason,
+    source,
+}: {
+    action: AuditAction;
+    userId: string;
+    before?: typeof documents.$inferSelect | null;
+    after?: typeof documents.$inferSelect | null;
+    reason?: string | null;
+    source: MutationSource;
+}) => {
+    const resource = after ?? before;
+    if (!resource) return;
+
+    await writeAuditEvent(db, {
+        userId,
+        actorUserId: userId,
+        actorType: 'user',
+        action,
+        resourceType: 'document',
+        resourceId: resource.id,
+        resourceLabel: resource.fileName,
+        before: before ?? null,
+        after: after ?? null,
+        sourceMetadata: {
+            source,
+            reason: reason ?? null,
+        },
+    });
+};
+
+export const deleteDocumentForUser = async ({
+    userId,
+    id,
+    reason,
+}: {
+    userId: string;
+    id: string;
+    reason?: string | null;
+}): Promise<MutationResult<typeof documents.$inferSelect>> => {
+    const document = await getAuthorizedDocument({ id, userId });
+    if (!document) {
+        return { ok: false, status: 404, error: 'Document not found.' };
+    }
+
+    const [updatedDocument] = await db
+        .update(documents)
+        .set(createDocumentSoftDeletePatch({ userId, reason: reason ?? null }))
+        .where(eq(documents.id, id))
+        .returning();
+
+    await writeDocumentAuditEvent({
+        action: 'delete',
+        userId,
+        before: document,
+        after: updatedDocument,
+        reason,
+        source: 'mcp_documents_delete',
+    });
+
+    return { ok: true, data: updatedDocument };
+};
+
+export const restoreDocumentForUser = async ({
+    userId,
+    id,
+    reason,
+}: {
+    userId: string;
+    id: string;
+    reason?: string | null;
+}): Promise<MutationResult<typeof documents.$inferSelect>> => {
+    const document = await getAuthorizedDocument({
+        id,
+        userId,
+        deleted: 'only',
+    });
+    if (!document) {
+        return { ok: false, status: 404, error: 'Document not found.' };
+    }
+
+    const [updatedDocument] = await db
+        .update(documents)
+        .set(createDocumentRestorePatch({ userId, reason: reason ?? null }))
+        .where(eq(documents.id, id))
+        .returning();
+
+    await writeDocumentAuditEvent({
+        action: 'restore',
+        userId,
+        before: document,
+        after: updatedDocument,
+        reason,
+        source: 'mcp_documents_restore',
+    });
+
+    return { ok: true, data: updatedDocument };
+};
+
+export const purgeDocumentForUser = async ({
+    userId,
+    id,
+    reason,
+    confirm,
+}: {
+    userId: string;
+    id: string;
+    reason?: string | null;
+    confirm?: boolean;
+}): Promise<MutationResult<typeof documents.$inferSelect>> => {
+    if (confirm !== true) {
+        return {
+            ok: false,
+            status: 400,
+            error: 'Permanent purge requires confirm: true.',
+        };
+    }
+
+    const document = await getAuthorizedDocument({
+        id,
+        userId,
+        deleted: 'only',
+    });
+    if (!document) {
+        return { ok: false, status: 404, error: 'Document not found.' };
+    }
+
+    await deleteDocumentBlob(document.storagePath);
+
+    const [purgedDocument] = await db
+        .delete(documents)
+        .where(eq(documents.id, id))
+        .returning();
+
+    await writeDocumentAuditEvent({
+        action: 'purge',
+        userId,
+        before: document,
+        after: null,
+        reason,
+        source: 'mcp_documents_purge',
+    });
+
+    return { ok: true, data: purgedDocument };
+};
+
+const getAuthorizedCustomer = async ({
+    id,
+    userId,
+    deleted,
+}: {
+    id: string;
+    userId: string;
+    deleted?: DeletedMode;
+}) => {
+    const [customer] = await db
+        .select()
+        .from(customers)
+        .where(
+            and(
+                eq(customers.id, id),
+                eq(customers.userId, userId),
+                deleted === 'only'
+                    ? eq(customers.isDeleted, true)
+                    : eq(customers.isDeleted, false),
+            ),
+        );
+
+    return customer ?? null;
+};
+
+const writeCustomerAuditEvent = async ({
+    action,
+    userId,
+    before,
+    after,
+    reason,
+    source,
+}: {
+    action: AuditAction;
+    userId: string;
+    before?: typeof customers.$inferSelect | null;
+    after?: typeof customers.$inferSelect | null;
+    reason?: string | null;
+    source: MutationSource;
+}) => {
+    const resource = after ?? before;
+    if (!resource) return;
+
+    await writeAuditEvent(db, {
+        userId,
+        actorUserId: userId,
+        actorType: 'user',
+        action,
+        resourceType: 'customer',
+        resourceId: resource.id,
+        resourceLabel: resource.friendlyName ?? resource.name,
+        before: before ?? null,
+        after: after ?? null,
+        sourceMetadata: {
+            source,
+            reason: reason ?? null,
+        },
+    });
+};
+
+const unmarkOtherOwnFirmCustomers = async ({
+    userId,
+    exceptId,
+}: {
+    userId: string;
+    exceptId?: string;
+}) => {
+    const beforeRows = await db
+        .select()
+        .from(customers)
+        .where(
+            and(
+                eq(customers.userId, userId),
+                eq(customers.isOwnFirm, true),
+                eq(customers.isDeleted, false),
+                exceptId ? ne(customers.id, exceptId) : undefined,
+            ),
+        );
+
+    if (beforeRows.length === 0) {
+        return;
+    }
+
+    const updatedRows = await db
+        .update(customers)
+        .set({ isOwnFirm: false })
+        .where(
+            inArray(
+                customers.id,
+                beforeRows.map((customer) => customer.id),
+            ),
+        )
+        .returning();
+    const beforeById = new Map(beforeRows.map((row) => [row.id, row]));
+
+    for (const updatedRow of updatedRows) {
+        await writeCustomerAuditEvent({
+            action: 'update',
+            userId,
+            before: beforeById.get(updatedRow.id) ?? null,
+            after: updatedRow,
+            source: 'mcp_customers_restore',
+        });
+    }
+};
+
+export const deleteCustomerForUser = async ({
+    userId,
+    id,
+    reason,
+}: {
+    userId: string;
+    id: string;
+    reason?: string | null;
+}): Promise<MutationResult<typeof customers.$inferSelect>> => {
+    const customer = await getAuthorizedCustomer({ id, userId });
+    if (!customer) {
+        return { ok: false, status: 404, error: 'Customer not found.' };
+    }
+
+    const [updatedCustomer] = await db
+        .update(customers)
+        .set(createCustomerSoftDeletePatch({ userId, reason: reason ?? null }))
+        .where(eq(customers.id, id))
+        .returning();
+
+    await writeCustomerAuditEvent({
+        action: 'delete',
+        userId,
+        before: customer,
+        after: updatedCustomer,
+        reason,
+        source: 'mcp_customers_delete',
+    });
+
+    return { ok: true, data: updatedCustomer };
+};
+
+export const restoreCustomerForUser = async ({
+    userId,
+    id,
+    reason,
+}: {
+    userId: string;
+    id: string;
+    reason?: string | null;
+}): Promise<MutationResult<typeof customers.$inferSelect>> => {
+    const customer = await getAuthorizedCustomer({
+        id,
+        userId,
+        deleted: 'only',
+    });
+    if (!customer) {
+        return { ok: false, status: 404, error: 'Customer not found.' };
+    }
+
+    if (customer.isOwnFirm) {
+        await unmarkOtherOwnFirmCustomers({ userId, exceptId: id });
+    }
+
+    const [updatedCustomer] = await db
+        .update(customers)
+        .set(createCustomerRestorePatch({ userId, reason: reason ?? null }))
+        .where(eq(customers.id, id))
+        .returning();
+
+    await writeCustomerAuditEvent({
+        action: 'restore',
+        userId,
+        before: customer,
+        after: updatedCustomer,
+        reason,
+        source: 'mcp_customers_restore',
+    });
+
+    return { ok: true, data: updatedCustomer };
+};

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -52,6 +52,53 @@ const createMockReadServices = () => {
     };
 };
 
+const createMockMutationServices = () => {
+    const calls = [];
+    const createService = (name, result) => async (input) => {
+        calls.push({ name, input });
+        return result;
+    };
+
+    return {
+        calls,
+        services: {
+            deleteTransaction: createService('deleteTransaction', {
+                ok: true,
+                data: [{ id: 'transaction_1', deletedAt: '2026-06-30' }],
+            }),
+            restoreTransaction: createService('restoreTransaction', {
+                ok: true,
+                data: [{ id: 'transaction_1', deletedAt: null }],
+            }),
+            purgeTransaction: createService('purgeTransaction', {
+                ok: false,
+                status: 400,
+                error: 'Permanent purge requires confirm: true.',
+            }),
+            deleteCustomer: createService('deleteCustomer', {
+                ok: true,
+                data: { id: 'customer_1', isDeleted: true },
+            }),
+            restoreCustomer: createService('restoreCustomer', {
+                ok: true,
+                data: { id: 'customer_1', isDeleted: false },
+            }),
+            deleteDocument: createService('deleteDocument', {
+                ok: true,
+                data: { id: 'document_1', isDeleted: true },
+            }),
+            restoreDocument: createService('restoreDocument', {
+                ok: true,
+                data: { id: 'document_1', isDeleted: false },
+            }),
+            purgeDocument: createService('purgeDocument', {
+                ok: true,
+                data: { id: 'document_1' },
+            }),
+        },
+    };
+};
+
 test('unauthorized MCP response is a JSON-RPC error response', async () => {
     const response = createUnauthorizedMcpResponse();
 
@@ -78,9 +125,11 @@ test('MCP request handler rejects unauthenticated requests before transport hand
 });
 
 test('base MCP server registers authenticated whoami tool', async () => {
-    const { calls, services } = createMockReadServices();
+    const read = createMockReadServices();
+    const mutations = createMockMutationServices();
     const server = createNumeraMcpServer(createTestContext(), {
-        readServices: services,
+        readServices: read.services,
+        mutationServices: mutations.services,
     });
     const client = new Client({
         name: 'numera-test-client',
@@ -101,6 +150,12 @@ test('base MCP server registers authenticated whoami tool', async () => {
         assert.ok(
             tools.tools.some((tool) => tool.name === 'numera_list_customers'),
             'expected numera_list_customers to be listed',
+        );
+        assert.ok(
+            tools.tools.some(
+                (tool) => tool.name === 'numera_delete_transaction',
+            ),
+            'expected numera_delete_transaction to be listed',
         );
 
         const result = await client.callTool({
@@ -125,7 +180,7 @@ test('base MCP server registers authenticated whoami tool', async () => {
             entity: 'customers',
             data: [{ id: 'customer_1', name: 'ACME' }],
         });
-        assert.deepEqual(calls, [
+        assert.deepEqual(read.calls, [
             {
                 name: 'listCustomers',
                 input: {
@@ -135,6 +190,44 @@ test('base MCP server registers authenticated whoami tool', async () => {
                 },
             },
         ]);
+
+        const deleteResult = await client.callTool({
+            name: 'numera_delete_transaction',
+            arguments: {
+                id: 'transaction_1',
+                reason: 'Duplicate imported transaction',
+            },
+        });
+
+        assert.deepEqual(deleteResult.structuredContent, {
+            entity: 'transaction',
+            ok: true,
+            data: [{ id: 'transaction_1', deletedAt: '2026-06-30' }],
+        });
+        assert.deepEqual(mutations.calls[0], {
+            name: 'deleteTransaction',
+            input: {
+                userId: 'user_test_123',
+                id: 'transaction_1',
+                reason: 'Duplicate imported transaction',
+            },
+        });
+
+        const purgeResult = await client.callTool({
+            name: 'numera_purge_transaction',
+            arguments: {
+                id: 'transaction_1',
+                confirm: true,
+            },
+        });
+
+        assert.equal(purgeResult.isError, true);
+        assert.deepEqual(purgeResult.structuredContent, {
+            entity: 'transaction',
+            ok: false,
+            status: 400,
+            error: 'Permanent purge requires confirm: true.',
+        });
     } finally {
         await client.close();
         await server.close();


### PR DESCRIPTION
## Summary

- Adds shared mutation services for recoverable transaction, customer, and document lifecycle operations with MCP source audit metadata.
- Registers MCP mutation tools for transaction/customer/document delete and restore, plus guarded transaction/document purge tools requiring `confirm: true`.
- Extends MCP tests to verify mutation tool listing, authenticated user-scope delegation, and structured error results.

## Verification

- `PATH=/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/biome check --write app/api/mcp/route.ts lib/mcp/context.ts lib/mcp/default-services.ts lib/mcp/mutation-tools.ts lib/mcp/server.ts lib/services/finance-mutations.ts tests/mcp-server.test.mjs`
- `PATH=/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node --experimental-strip-types --test tests/mcp-server.test.mjs tests/transaction-lifecycle.test.mjs tests/document-lifecycle.test.mjs tests/customer-lifecycle.test.mjs`
- `PATH=/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --cached --check`

## Risk

- Mutation tools can alter user data for authenticated MCP clients. Destructive permanent purge tools require explicit `confirm: true`; soft deletes and restores write audit events with MCP source metadata.

Closes #144
Refs #140