### PR TITLE
Fix split transaction document counts

### DIFF
--- a/app/api/[[...route]]/documentsRoutes.ts
+++ b/app/api/[[...route]]/documentsRoutes.ts
@@ -1,7 +1,7 @@
 import { clerkMiddleware, getAuth } from '@hono/clerk-auth';
 import { zValidator } from '@hono/zod-validator';
 import { createId } from '@paralleldrive/cuid2';
-import { aliasedTable, and, eq, isNull, or } from 'drizzle-orm';
+import { aliasedTable, and, eq, inArray, isNull, or } from 'drizzle-orm';
 import { type Context, Hono } from 'hono';
 import { z } from 'zod';
 
@@ -31,7 +31,10 @@ const getAuthorizedTransaction = async (
     const debitAccounts = aliasedTable(accounts, 'debitAccounts');
 
     const [transaction] = await db
-        .select({ id: transactions.id })
+        .select({
+            id: transactions.id,
+            splitGroupId: transactions.splitGroupId,
+        })
         .from(transactions)
         .leftJoin(accounts, eq(transactions.accountId, accounts.id))
         .leftJoin(
@@ -61,6 +64,54 @@ const getAuthorizedTransaction = async (
         );
 
     return transaction;
+};
+
+const getDocumentTransactionIds = async (
+    transaction: NonNullable<
+        Awaited<ReturnType<typeof getAuthorizedTransaction>>
+    >,
+    userId: string,
+) => {
+    if (!transaction.splitGroupId) {
+        return [transaction.id];
+    }
+
+    const creditAccounts = aliasedTable(accounts, 'documentCreditAccounts');
+    const debitAccounts = aliasedTable(accounts, 'documentDebitAccounts');
+
+    const splitGroupMembers = await db
+        .select({ id: transactions.id })
+        .from(transactions)
+        .leftJoin(accounts, eq(transactions.accountId, accounts.id))
+        .leftJoin(
+            creditAccounts,
+            eq(transactions.creditAccountId, creditAccounts.id),
+        )
+        .leftJoin(
+            debitAccounts,
+            eq(transactions.debitAccountId, debitAccounts.id),
+        )
+        .where(
+            and(
+                eq(transactions.splitGroupId, transaction.splitGroupId),
+                or(
+                    eq(accounts.userId, userId),
+                    eq(creditAccounts.userId, userId),
+                    eq(debitAccounts.userId, userId),
+                    and(
+                        isNull(transactions.accountId),
+                        isNull(transactions.creditAccountId),
+                        isNull(transactions.debitAccountId),
+                        eq(transactions.statusChangedBy, userId),
+                    ),
+                ),
+                isNull(transactions.deletedAt),
+            ),
+        );
+
+    return splitGroupMembers.length > 0
+        ? splitGroupMembers.map((member) => member.id)
+        : [transaction.id];
 };
 
 const documentLifecycleSchema = z.object({
@@ -296,6 +347,10 @@ const app = new Hono()
             return ctx.json({ error: 'Transaction not found.' }, 404);
         }
 
+        const documentTransactionIds = await getDocumentTransactionIds(
+            transaction,
+            auth.userId,
+        );
         const data = await db
             .select({
                 id: documents.id,
@@ -322,7 +377,7 @@ const app = new Hono()
             )
             .where(
                 and(
-                    eq(documents.transactionId, transactionId),
+                    inArray(documents.transactionId, documentTransactionIds),
                     documentDeletedFilter(deleted),
                 ),
             );

--- a/components/documents-tab.tsx
+++ b/components/documents-tab.tsx
@@ -107,9 +107,7 @@ export function DocumentUpload({
 
             if (successCount > 0) {
                 // Invalidate documents query to refresh the list
-                queryClient.invalidateQueries({
-                    queryKey: ['documents', transactionId],
-                });
+                queryClient.invalidateQueries({ queryKey: ['documents'] });
                 // Invalidate transaction queries to refresh validation status in transaction table
                 queryClient.invalidateQueries({
                     queryKey: ['transaction', { id: transactionId }],
@@ -233,9 +231,7 @@ export function DocumentList({
 
         try {
             await deleteDocument.mutateAsync(documentId);
-            queryClient.invalidateQueries({
-                queryKey: ['documents', transactionId],
-            });
+            queryClient.invalidateQueries({ queryKey: ['documents'] });
             // Invalidate transaction queries to refresh validation status in transaction table
             queryClient.invalidateQueries({
                 queryKey: ['transaction', { id: transactionId }],
@@ -254,9 +250,7 @@ export function DocumentList({
                 id: documentId,
                 documentTypeId: newTypeId,
             });
-            queryClient.invalidateQueries({
-                queryKey: ['documents', transactionId],
-            });
+            queryClient.invalidateQueries({ queryKey: ['documents'] });
             // Invalidate transaction queries to refresh validation status in transaction table
             queryClient.invalidateQueries({
                 queryKey: ['transaction', { id: transactionId }],
@@ -400,9 +394,7 @@ function UnattachedDocuments({ transactionId }: UnattachedDocumentsProps) {
                 documentId,
                 transactionId,
             });
-            queryClient.invalidateQueries({
-                queryKey: ['documents', transactionId],
-            });
+            queryClient.invalidateQueries({ queryKey: ['documents'] });
         } catch (error) {
             console.error('Link error:', error);
         }

--- a/features/transactions/api/use-get-transactions.ts
+++ b/features/transactions/api/use-get-transactions.ts
@@ -94,7 +94,7 @@ export const useGetTransactions = () => {
              * @returns A summary object containing:
              *   - status: The lowest status among all children (draft < pending < completed < reconciled)
              *   - tags: Unique tags collected from all children
-             *   - documentCount: Total count of documents across all children
+             *   - documentCount: Effective document count for the split group
              *   - hasAllRequiredDocuments: True only if all children have required documents
              *   - creditAccounts/debitAccounts/singleAccounts: Unique accounts aggregated from children
              *   - customers: Unique customer names from all children
@@ -150,7 +150,10 @@ export const useGetTransactions = () => {
                         }
                     }
 
-                    documentCount += child.documentCount ?? 0;
+                    documentCount = Math.max(
+                        documentCount,
+                        child.documentCount ?? 0,
+                    );
                     hasAllRequiredDocuments =
                         hasAllRequiredDocuments &&
                         (child.hasAllRequiredDocuments ?? true);

--- a/features/transactions/components/edit-transaction-sheet.tsx
+++ b/features/transactions/components/edit-transaction-sheet.tsx
@@ -377,10 +377,13 @@ export const TransactionSheet = () => {
             : [],
     });
 
-    const totalSplitDocuments = childDocumentQueries.reduce(
-        (sum, query) => sum + (query.data?.length ?? 0),
-        0,
-    );
+    const splitDocumentIds = new Set<string>();
+    for (const query of childDocumentQueries) {
+        for (const document of query.data ?? []) {
+            splitDocumentIds.add(document.id);
+        }
+    }
+    const totalSplitDocuments = splitDocumentIds.size;
 
     const statusColors: Record<typeof currentStatus, string> = {
         draft: 'text-muted-foreground',
@@ -990,9 +993,9 @@ export const TransactionSheet = () => {
                                                     Documents
                                                 </div>
                                                 <div className="text-xs text-muted-foreground">
-                                                    Documents are stored on
-                                                    split parts. Open a part to
-                                                    manage its documents.
+                                                    Documents attached anywhere
+                                                    in this split group are
+                                                    visible on each part.
                                                 </div>
                                                 <div className="text-sm">
                                                     {totalSplitDocuments}{' '}

--- a/lib/reconciliation.ts
+++ b/lib/reconciliation.ts
@@ -1,4 +1,4 @@
-import { aliasedTable, and, count, eq, isNull, or } from 'drizzle-orm';
+import { aliasedTable, and, count, eq, inArray, isNull, or } from 'drizzle-orm';
 import { db } from '@/db/drizzle';
 import { accounts, documents, settings, transactions } from '@/db/schema';
 
@@ -46,6 +46,83 @@ const hasTransactionAccess = async (
     return Boolean(transaction);
 };
 
+const getTransactionDocumentTargetIds = async (
+    transactionId: string,
+    userId: string,
+) => {
+    const [transaction] = await db
+        .select({
+            id: transactions.id,
+            splitGroupId: transactions.splitGroupId,
+        })
+        .from(transactions)
+        .where(
+            and(
+                eq(transactions.id, transactionId),
+                isNull(transactions.deletedAt),
+            ),
+        );
+
+    if (!transaction?.splitGroupId) {
+        return [transactionId];
+    }
+
+    const creditAccounts = aliasedTable(accounts, 'documentCreditAccounts');
+    const debitAccounts = aliasedTable(accounts, 'documentDebitAccounts');
+
+    const splitGroupMembers = await db
+        .select({ id: transactions.id })
+        .from(transactions)
+        .leftJoin(accounts, eq(transactions.accountId, accounts.id))
+        .leftJoin(
+            creditAccounts,
+            eq(transactions.creditAccountId, creditAccounts.id),
+        )
+        .leftJoin(
+            debitAccounts,
+            eq(transactions.debitAccountId, debitAccounts.id),
+        )
+        .where(
+            and(
+                eq(transactions.splitGroupId, transaction.splitGroupId),
+                or(
+                    eq(accounts.userId, userId),
+                    eq(creditAccounts.userId, userId),
+                    eq(debitAccounts.userId, userId),
+                    and(
+                        isNull(transactions.accountId),
+                        isNull(transactions.creditAccountId),
+                        isNull(transactions.debitAccountId),
+                        eq(transactions.statusChangedBy, userId),
+                    ),
+                ),
+                isNull(transactions.deletedAt),
+            ),
+        );
+
+    return splitGroupMembers.length > 0
+        ? splitGroupMembers.map((member) => member.id)
+        : [transaction.id];
+};
+
+const hasReceipt = async (transactionId: string, userId: string) => {
+    const documentTargetIds = await getTransactionDocumentTargetIds(
+        transactionId,
+        userId,
+    );
+    const [docCount] = await db
+        .select({ count: count() })
+        .from(documents)
+        .where(
+            and(
+                inArray(documents.transactionId, documentTargetIds),
+                eq(documents.isDeleted, false),
+            ),
+        );
+
+    return docCount.count > 0;
+};
+
 /**
  * Check if a transaction meets the reconciliation conditions
  */
@@ -75,17 +152,7 @@ export async function isTransactionReconciled(
     for (const condition of conditions) {
         switch (condition) {
             case 'hasReceipt': {
-                const [docCount] = await db
-                    .select({ count: count() })
-                    .from(documents)
-                    .where(
-                        and(
-                            eq(documents.transactionId, transactionId),
-                            eq(documents.isDeleted, false),
-                        ),
-                    );
-
-                if (docCount.count === 0) return false;
+                if (!(await hasReceipt(transactionId, userId))) return false;
                 break;
             }
 
@@ -186,17 +253,7 @@ export async function getReconciliationStatus(
 
             switch (condition) {
                 case 'hasReceipt': {
-                    const [docCount] = await db
-                        .select({ count: count() })
-                        .from(documents)
-                        .where(
-                            and(
-                                eq(documents.transactionId, transactionId),
-                                eq(documents.isDeleted, false),
-                            ),
-                        );
-
-                    met = docCount.count > 0;
+                    met = await hasReceipt(transactionId, userId);
                     break;
                 }
 

--- a/lib/services/finance-entities.ts
+++ b/lib/services/finance-entities.ts
@@ -31,6 +31,7 @@ import {
 import { normalizeAuditEventSource } from '@/lib/audit-query';
 import { generateDownloadUrl } from '@/lib/azure-storage';
 import {
+    buildTransactionDocumentCounts,
     type DeletedMode,
     escapeLikePattern,
     normalizeEntityDate,
@@ -669,12 +670,69 @@ export const listTransactions = async (
 
     const data = await applyLimitOffset(query, input);
     const transactionIds = data.map((transaction) => transaction.id);
-    const documentCounts: Map<
-        string,
-        { total: number; requiredTypes: string[] }
-    > = new Map();
+    const splitGroupIds = [
+        ...new Set(
+            data
+                .map((transaction) => transaction.splitGroupId)
+                .filter((id): id is string => Boolean(id)),
+        ),
+    ];
+    let documentCountTargets = data.map((transaction) => ({
+        id: transaction.id,
+        splitGroupId: transaction.splitGroupId,
+    }));
+    let documentCounts = buildTransactionDocumentCounts(
+        documentCountTargets,
+        [],
+        requiredDocTypeIds,
+    );
 
     if (transactionIds.length > 0) {
+        if (splitGroupIds.length > 0) {
+            const memberCreditAccounts = aliasedTable(
+                accounts,
+                'memberCreditAccounts',
+            );
+            const memberDebitAccounts = aliasedTable(
+                accounts,
+                'memberDebitAccounts',
+            );
+            const splitGroupMembers = await database
+                .select({
+                    id: transactions.id,
+                    splitGroupId: transactions.splitGroupId,
+                })
+                .from(transactions)
+                .leftJoin(accounts, eq(transactions.accountId, accounts.id))
+                .leftJoin(
+                    memberCreditAccounts,
+                    eq(transactions.creditAccountId, memberCreditAccounts.id),
+                )
+                .leftJoin(
+                    memberDebitAccounts,
+                    eq(transactions.debitAccountId, memberDebitAccounts.id),
+                )
+                .where(
+                    and(
+                        inArray(transactions.splitGroupId, splitGroupIds),
+                        createTransactionAccessFilter(
+                            input.userId,
+                            memberCreditAccounts,
+                            memberDebitAccounts,
+                        ),
+                        transactionDeletedFilter(input.deleted),
+                    ),
+                );
+
+            documentCountTargets = [
+                ...documentCountTargets,
+                ...splitGroupMembers,
+            ];
+        }
+
+        const documentTransactionIds = [
+            ...new Set(documentCountTargets.map((target) => target.id)),
+        ];
         const docsData = await database
             .select({
                 transactionId: documents.transactionId,
@@ -683,27 +741,16 @@ export const listTransactions = async (
             .from(documents)
             .where(
                 and(
-                    inArray(documents.transactionId, transactionIds),
+                    inArray(documents.transactionId, documentTransactionIds),
                     eq(documents.isDeleted, false),
                 ),
             );
 
-        for (const document of docsData) {
-            if (!document.transactionId) continue;
-
-            const existing = documentCounts.get(document.transactionId) ?? {
-                total: 0,
-                requiredTypes: [],
-            };
-            existing.total++;
-            if (
-                requiredDocTypeIds.includes(document.documentTypeId) &&
-                !existing.requiredTypes.includes(document.documentTypeId)
-            ) {
-                existing.requiredTypes.push(document.documentTypeId);
-            }
-            documentCounts.set(document.transactionId, existing);
-        }
+        documentCounts = buildTransactionDocumentCounts(
+            documentCountTargets,
+            docsData,
+            requiredDocTypeIds,
+        );
     }
 
     const transactionTagsMap: Map<

--- a/lib/services/finance-entity-core.ts
+++ b/lib/services/finance-entity-core.ts
@@ -43,6 +43,78 @@ export const splitSearchKeywords = (search?: string | null) =>
         .map((keyword) => keyword.replace(/"/g, '').trim())
         .filter(Boolean);
 
+export type TransactionDocumentCountTarget = {
+    id: string;
+    splitGroupId?: string | null;
+};
+
+export type TransactionDocumentReference = {
+    transactionId?: string | null;
+    documentTypeId: string;
+};
+
+export type TransactionDocumentCount = {
+    total: number;
+    requiredTypes: string[];
+};
+
+export const buildTransactionDocumentCounts = (
+    transactions: TransactionDocumentCountTarget[],
+    documents: TransactionDocumentReference[],
+    requiredDocumentTypeIds: string[],
+) => {
+    const transactionById = new Map<string, TransactionDocumentCountTarget>();
+    const groupMembers = new Map<string, string[]>();
+    const requiredTypes = new Set(requiredDocumentTypeIds);
+
+    for (const transaction of transactions) {
+        if (transactionById.has(transaction.id)) continue;
+
+        transactionById.set(transaction.id, transaction);
+
+        if (transaction.splitGroupId) {
+            const members = groupMembers.get(transaction.splitGroupId) ?? [];
+            members.push(transaction.id);
+            groupMembers.set(transaction.splitGroupId, members);
+        }
+    }
+
+    const documentCounts = new Map<string, TransactionDocumentCount>();
+
+    for (const document of documents) {
+        if (!document.transactionId) continue;
+
+        const attachedTransaction = transactionById.get(document.transactionId);
+        if (!attachedTransaction) continue;
+
+        const targetIds = attachedTransaction.splitGroupId
+            ? (groupMembers.get(attachedTransaction.splitGroupId) ?? [
+                  attachedTransaction.id,
+              ])
+            : [attachedTransaction.id];
+
+        for (const targetId of targetIds) {
+            const existing = documentCounts.get(targetId) ?? {
+                total: 0,
+                requiredTypes: [],
+            };
+
+            existing.total++;
+
+            if (
+                requiredTypes.has(document.documentTypeId) &&
+                !existing.requiredTypes.includes(document.documentTypeId)
+            ) {
+                existing.requiredTypes.push(document.documentTypeId);
+            }
+
+            documentCounts.set(targetId, existing);
+        }
+    }
+
+    return documentCounts;
+};
+
 export const normalizeIban = (iban: string) =>
     iban.toUpperCase().replace(/\s/g, '');
 

--- a/tests/finance-entity-core.test.mjs
+++ b/tests/finance-entity-core.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import {
+    buildTransactionDocumentCounts,
     DEFAULT_ENTITY_LIMIT,
     escapeLikePattern,
     MAX_ENTITY_LIMIT,
@@ -55,4 +56,38 @@ test('entity normalization helpers handle dates and IBANs', () => {
         '2026-06-30T12:00:00.000Z',
     );
     assert.equal(normalizeIban('hr12 3456'), 'HR123456');
+});
+
+test('document counts apply split group documents to every group member', () => {
+    const counts = buildTransactionDocumentCounts(
+        [
+            { id: 'parent_1', splitGroupId: 'split_1' },
+            { id: 'child_1', splitGroupId: 'split_1' },
+            { id: 'child_2', splitGroupId: 'split_1' },
+            { id: 'solo_1', splitGroupId: null },
+        ],
+        [
+            { transactionId: 'parent_1', documentTypeId: 'invoice' },
+            { transactionId: 'child_1', documentTypeId: 'receipt' },
+            { transactionId: 'solo_1', documentTypeId: 'receipt' },
+        ],
+        ['invoice', 'receipt'],
+    );
+
+    assert.deepEqual(counts.get('parent_1'), {
+        total: 2,
+        requiredTypes: ['invoice', 'receipt'],
+    });
+    assert.deepEqual(counts.get('child_1'), {
+        total: 2,
+        requiredTypes: ['invoice', 'receipt'],
+    });
+    assert.deepEqual(counts.get('child_2'), {
+        total: 2,
+        requiredTypes: ['invoice', 'receipt'],
+    });
+    assert.deepEqual(counts.get('solo_1'), {
+        total: 1,
+        requiredTypes: ['receipt'],
+    });
 });


### PR DESCRIPTION
## Summary

- Count documents attached to any member of a split group for every transaction in that group.
- Show group-visible documents in transaction document lists and avoid duplicate totals in split parent UI.
- Use the same split-group document scope for reconciliation receipt checks.

## Verification

- `PATH="/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" node --test tests/*.test.mjs`
- `PATH="/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" ./node_modules/.bin/tsc --noEmit`
- `PATH="/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" ./node_modules/.bin/biome check lib/services/finance-entity-core.ts lib/services/finance-entities.ts lib/reconciliation.ts 'app/api/[[...route]]/documentsRoutes.ts' features/transactions/api/use-get-transactions.ts features/transactions/components/edit-transaction-sheet.tsx components/documents-tab.tsx tests/finance-entity-core.test.mjs`
- `git diff --check`

## Risk

- Keeps the existing single-document-transaction schema intact; true many-to-many document attachments remain separate follow-up work for #107.

Closes #106