### PR TITLE
Add customer website favicons

### DIFF
--- a/app/(dashboard)/customers/columns.tsx
+++ b/app/(dashboard)/customers/columns.tsx
@@ -7,9 +7,11 @@ import type { InferResponseType } from 'hono';
 import {
     ArrowUpDown,
     Building2,
+    ExternalLink,
     MoreHorizontal,
     TriangleAlert,
 } from 'lucide-react';
+import Image from 'next/image';
 import { Badge } from '@/components/ui/badge';
 import {
     DropdownMenu,
@@ -99,6 +101,39 @@ const ActionsCell = ({ row }: { row: { original: ResponseType } }) => {
     );
 };
 
+const CustomerAvatar = ({ customer }: { customer: ResponseType }) => {
+    const displayName = customer.friendlyName || customer.name;
+    const initial = displayName.trim().charAt(0).toUpperCase() || '?';
+
+    if (customer.avatarImage) {
+        return (
+            <Image
+                src={customer.avatarImage}
+                alt={`${displayName} favicon`}
+                width={24}
+                height={24}
+                className="size-6 shrink-0 rounded-sm border bg-background object-contain"
+                unoptimized
+            />
+        );
+    }
+
+    return (
+        <span className="flex size-6 shrink-0 items-center justify-center rounded-sm border bg-muted text-xs font-medium text-muted-foreground">
+            {initial}
+        </span>
+    );
+};
+
+const formatWebsiteLabel = (website: string) => {
+    try {
+        const url = new URL(website);
+        return `${url.hostname}${url.pathname === '/' ? '' : url.pathname}`;
+    } catch {
+        return website;
+    }
+};
+
 export const columns: ColumnDef<ResponseType>[] = [
     {
         id: 'select',
@@ -137,24 +172,51 @@ export const columns: ColumnDef<ResponseType>[] = [
             );
         },
         cell: ({ row }) => {
+            const displayName = row.original.friendlyName || row.original.name;
+
             return (
-                <div className="flex items-center gap-2">
-                    {!row.original.isComplete && (
-                        <Badge variant="destructive" className="text-xs">
-                            <TriangleAlert className="size-4 mr-2" />
-                            Incomplete
-                        </Badge>
-                    )}
-                    {row.original.isOwnFirm && (
-                        <Badge variant="secondary" className="text-xs">
-                            <Building2 className="size-4 mr-2" />
-                            Own Firm
-                        </Badge>
-                    )}
-                    <span>
-                        {row.original.friendlyName || row.getValue('name')}
-                    </span>
+                <div className="flex min-w-0 items-center gap-3">
+                    <CustomerAvatar customer={row.original} />
+                    <div className="flex min-w-0 flex-wrap items-center gap-2">
+                        {!row.original.isComplete && (
+                            <Badge variant="destructive" className="text-xs">
+                                <TriangleAlert className="size-4 mr-2" />
+                                Incomplete
+                            </Badge>
+                        )}
+                        {row.original.isOwnFirm && (
+                            <Badge variant="secondary" className="text-xs">
+                                <Building2 className="size-4 mr-2" />
+                                Own Firm
+                            </Badge>
+                        )}
+                        <span className="truncate">{displayName}</span>
+                    </div>
                 </div>
+            );
+        },
+    },
+    {
+        accessorKey: 'website',
+        header: 'Website',
+        cell: ({ row }) => {
+            const website = row.getValue('website') as string | null;
+            if (!website) {
+                return <div>-</div>;
+            }
+
+            return (
+                <a
+                    href={website}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex max-w-48 items-center gap-1 truncate text-sm text-blue-600 hover:underline"
+                >
+                    <span className="truncate">
+                        {formatWebsiteLabel(website)}
+                    </span>
+                    <ExternalLink className="size-3 shrink-0" />
+                </a>
             );
         },
     },

--- a/app/api/[[...route]]/customersRoutes.ts
+++ b/app/api/[[...route]]/customersRoutes.ts
@@ -14,6 +14,10 @@ import {
 } from '@/db/schema';
 import { type AuditAction, writeAuditEvent } from '@/lib/audit';
 import {
+    fetchCustomerAvatarImage,
+    normalizeCustomerWebsite,
+} from '@/lib/customer-favicon';
+import {
     createCustomerIbanRestorePatch,
     createCustomerIbanSoftDeletePatch,
     createCustomerProfileRevertPatch,
@@ -33,6 +37,8 @@ type CustomerUpdate = Partial<typeof customers.$inferInsert>;
 
 type CustomerData = {
     name?: string | null;
+    website?: string | null;
+    avatarImage?: string | null;
     vatNumber?: string | null;
     address?: string | null;
     contactEmail?: string | null;
@@ -48,18 +54,30 @@ const customerRevertSchema = customerLifecycleSchema.extend({
     auditEventId: z.string().min(1),
 });
 
-const customerPayloadSchema = insertCustomerSchema.omit({
-    id: true,
-    userId: true,
-    isComplete: true,
-    isDeleted: true,
-    deletedAt: true,
-    deletedBy: true,
-    deleteReason: true,
-    restoredAt: true,
-    restoredBy: true,
-    restoreReason: true,
-});
+const customerPayloadSchema = insertCustomerSchema
+    .omit({
+        id: true,
+        userId: true,
+        isComplete: true,
+        isDeleted: true,
+        deletedAt: true,
+        deletedBy: true,
+        deleteReason: true,
+        restoredAt: true,
+        restoredBy: true,
+        restoreReason: true,
+        avatarImage: true,
+    })
+    .extend({
+        name: z.string().min(1),
+        website: z.string().max(2048).nullable().optional(),
+    });
+
+type CustomerPayload = z.infer<typeof customerPayloadSchema>;
+type CustomerWriteValues = CustomerPayload & {
+    website: string | null;
+    avatarImage: string | null;
+};
 
 const isCustomerComplete = (customer: CustomerData): boolean => {
     return !!(
@@ -70,6 +88,47 @@ const isCustomerComplete = (customer: CustomerData): boolean => {
         customer.contactTelephone &&
         customer.country
     );
+};
+
+const prepareCustomerWriteValues = async (
+    values: CustomerPayload,
+    existingCustomer?: CustomerRow | null,
+): Promise<
+    | {
+          ok: true;
+          values: CustomerWriteValues;
+      }
+    | {
+          ok: false;
+          error: string;
+      }
+> => {
+    const submittedWebsite = values.website?.trim() ?? '';
+    const website = normalizeCustomerWebsite(submittedWebsite);
+
+    if (submittedWebsite && !website) {
+        return {
+            ok: false,
+            error: 'Website must be a public http or https URL.',
+        };
+    }
+
+    const shouldFetchAvatar =
+        !!website &&
+        (website !== existingCustomer?.website ||
+            !existingCustomer.avatarImage);
+    const avatarImage = shouldFetchAvatar
+        ? await fetchCustomerAvatarImage(website)
+        : (existingCustomer?.avatarImage ?? null);
+
+    return {
+        ok: true,
+        values: {
+            ...values,
+            website,
+            avatarImage: website ? avatarImage : null,
+        },
+    };
 };
 
 const normalizeIban = (iban: string) => iban.toUpperCase().replace(/\s/g, '');
@@ -1078,7 +1137,12 @@ const app = new Hono()
                 return ctx.json({ error: 'Unauthorized.' }, 401);
             }
 
-            const isComplete = isCustomerComplete(values);
+            const preparedValues = await prepareCustomerWriteValues(values);
+            if (!preparedValues.ok) {
+                return ctx.json({ error: preparedValues.error }, 400);
+            }
+
+            const isComplete = isCustomerComplete(preparedValues.values);
 
             if (values.isOwnFirm) {
                 await unmarkOtherOwnFirmCustomers({
@@ -1093,7 +1157,7 @@ const app = new Hono()
                     id: createId(),
                     userId: auth.userId,
                     isComplete,
-                    ...values,
+                    ...preparedValues.values,
                 })
                 .returning();
 
@@ -1140,7 +1204,15 @@ const app = new Hono()
                 return ctx.json({ error: 'Not found.' }, 404);
             }
 
-            const isComplete = isCustomerComplete(values);
+            const preparedValues = await prepareCustomerWriteValues(
+                values,
+                existingCustomer,
+            );
+            if (!preparedValues.ok) {
+                return ctx.json({ error: preparedValues.error }, 400);
+            }
+
+            const isComplete = isCustomerComplete(preparedValues.values);
 
             if (values.isOwnFirm) {
                 await unmarkOtherOwnFirmCustomers({
@@ -1154,7 +1226,7 @@ const app = new Hono()
                 .update(customers)
                 .set({
                     isComplete,
-                    ...values,
+                    ...preparedValues.values,
                 })
                 .where(eq(customers.id, id))
                 .returning();

--- a/components/customer-select.tsx
+++ b/components/customer-select.tsx
@@ -36,6 +36,8 @@ const ALL_CUSTOMERS_OPTION = {
     id: 'all',
     name: 'All customers',
     friendlyName: null,
+    website: null,
+    avatarImage: null,
     isComplete: true,
     isOwnFirm: false,
     vatNumber: null,

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -145,6 +145,8 @@ export const customers = pgTable(
         name: text('name').notNull(),
         // Optional short/friendly name displayed in the app instead of the full name
         friendlyName: text('friendly_name'),
+        website: text('website'),
+        avatarImage: text('avatar_image'),
         vatNumber: text('vat_number'),
         address: text('address'),
         contactEmail: text('contact_email'),

--- a/drizzle/0048_customer_website_favicon.sql
+++ b/drizzle/0048_customer_website_favicon.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "customers" ADD COLUMN "website" text;--> statement-breakpoint
+ALTER TABLE "customers" ADD COLUMN "avatar_image" text;

--- a/drizzle/meta/0048_snapshot.json
+++ b/drizzle/meta/0048_snapshot.json
@@ -1,0 +1,2941 @@
+{
+  "id": "a67b91a4-f39f-4189-814f-8b447af6231b",
+  "prevId": "bb5ace58-c6ae-4473-a43f-fa3e6df90fea",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounting_periods": {
+      "name": "accounting_periods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by": {
+          "name": "closed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounting_periods_userid_idx": {
+          "name": "accounting_periods_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounting_periods_status_idx": {
+          "name": "accounting_periods_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounting_periods_startdate_idx": {
+          "name": "accounting_periods_startdate_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounting_periods_enddate_idx": {
+          "name": "accounting_periods_enddate_idx",
+          "columns": [
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plaid_id": {
+          "name": "plaid_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_open": {
+          "name": "is_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_read_only": {
+          "name": "is_read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'neutral'"
+        },
+        "account_class": {
+          "name": "account_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_role": {
+          "name": "system_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_balance": {
+          "name": "opening_balance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "accounts_userid_idx": {
+          "name": "accounts_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_isopen_idx": {
+          "name": "accounts_isopen_idx",
+          "columns": [
+            {
+              "expression": "is_open",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_code_idx": {
+          "name": "accounts_code_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_systemrole_idx": {
+          "name": "accounts_systemrole_idx",
+          "columns": [
+            {
+              "expression": "system_role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_label": {
+          "name": "resource_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "field_delta": {
+          "name": "field_delta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reverted_from_event_id": {
+          "name": "reverted_from_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_events_userid_idx": {
+          "name": "audit_events_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_actoruserid_idx": {
+          "name": "audit_events_actoruserid_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_action_idx": {
+          "name": "audit_events_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_resource_idx": {
+          "name": "audit_events_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_createdat_idx": {
+          "name": "audit_events_createdat_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_requestid_idx": {
+          "name": "audit_events_requestid_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_revertedfromeventid_idx": {
+          "name": "audit_events_revertedfromeventid_idx",
+          "columns": [
+            {
+              "expression": "reverted_from_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_events_actor_type_check": {
+          "name": "audit_events_actor_type_check",
+          "value": "\"audit_events\".\"actor_type\" in ('user', 'system', 'integration')"
+        },
+        "audit_events_action_check": {
+          "name": "audit_events_action_check",
+          "value": "\"audit_events\".\"action\" in ('create', 'update', 'delete', 'restore', 'purge', 'import', 'sync', 'status_change', 'link', 'unlink', 'settings_update', 'integration_event')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bank_accounts": {
+      "name": "bank_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gocardless_account_id": {
+          "name": "gocardless_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iban": {
+          "name": "iban",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_name": {
+          "name": "owner_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'EUR'"
+        },
+        "linked_account_id": {
+          "name": "linked_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_transaction_date": {
+          "name": "last_transaction_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bank_accounts_connectionid_idx": {
+          "name": "bank_accounts_connectionid_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_accounts_userid_idx": {
+          "name": "bank_accounts_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_accounts_gocardlessaccountid_idx": {
+          "name": "bank_accounts_gocardlessaccountid_idx",
+          "columns": [
+            {
+              "expression": "gocardless_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_accounts_linkedaccountid_idx": {
+          "name": "bank_accounts_linkedaccountid_idx",
+          "columns": [
+            {
+              "expression": "linked_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_accounts_isactive_idx": {
+          "name": "bank_accounts_isactive_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bank_accounts_connection_id_bank_connections_id_fk": {
+          "name": "bank_accounts_connection_id_bank_connections_id_fk",
+          "tableFrom": "bank_accounts",
+          "tableTo": "bank_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bank_accounts_linked_account_id_accounts_id_fk": {
+          "name": "bank_accounts_linked_account_id_accounts_id_fk",
+          "tableFrom": "bank_accounts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "linked_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_connections": {
+      "name": "bank_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requisition_id": {
+          "name": "requisition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_name": {
+          "name": "institution_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_logo": {
+          "name": "institution_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreement_id": {
+          "name": "agreement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreement_expires_at": {
+          "name": "agreement_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bank_connections_userid_idx": {
+          "name": "bank_connections_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_connections_requisitionid_idx": {
+          "name": "bank_connections_requisitionid_idx",
+          "columns": [
+            {
+              "expression": "requisition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_connections_institutionid_idx": {
+          "name": "bank_connections_institutionid_idx",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bank_connections_status_idx": {
+          "name": "bank_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_ibans": {
+      "name": "customer_ibans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iban": {
+          "name": "iban",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bank_name": {
+          "name": "bank_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delete_reason": {
+          "name": "delete_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restored_at": {
+          "name": "restored_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restored_by": {
+          "name": "restored_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restore_reason": {
+          "name": "restore_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "customer_ibans_customerid_idx": {
+          "name": "customer_ibans_customerid_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customer_ibans_iban_idx": {
+          "name": "customer_ibans_iban_idx",
+          "columns": [
+            {
+              "expression": "iban",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customer_ibans_isdeleted_idx": {
+          "name": "customer_ibans_isdeleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customer_ibans_deletedat_idx": {
+          "name": "customer_ibans_deletedat_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customer_ibans_deletedby_idx": {
+          "name": "customer_ibans_deletedby_idx",
+          "columns": [
+            {
+              "expression": "deleted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_ibans_customer_id_customers_id_fk": {
+          "name": "customer_ibans_customer_id_customers_id_fk",
+          "tableFrom": "customer_ibans",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friendly_name": {
+          "name": "friendly_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_image": {
+          "name": "avatar_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_telephone": {
+          "name": "contact_telephone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_complete": {
+          "name": "is_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_own_firm": {
+          "name": "is_own_firm",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delete_reason": {
+          "name": "delete_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restored_at": {
+          "name": "restored_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restored_by": {
+          "name": "restored_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restore_reason": {
+          "name": "restore_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "customers_userid_idx": {
+          "name": "customers_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_name_idx": {
+          "name": "customers_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_iscomplete_idx": {
+          "name": "customers_iscomplete_idx",
+          "columns": [
+            {
+              "expression": "is_complete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_isownfirm_idx": {
+          "name": "customers_isownfirm_idx",
+          "columns": [
+            {
+              "expression": "is_own_firm",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_isdeleted_idx": {
+          "name": "customers_isdeleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_deletedat_idx": {
+          "name": "customers_deletedat_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_deletedby_idx": {
+          "name": "customers_deletedby_idx",
+          "columns": [
+            {
+              "expression": "deleted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_layouts": {
+      "name": "dashboard_layouts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "widgets_config": {
+          "name": "widgets_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dashboard_layouts_userid_idx": {
+          "name": "dashboard_layouts_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_transaction_links": {
+      "name": "document_transaction_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_transaction_links_unique_idx": {
+          "name": "document_transaction_links_unique_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_transaction_links_documentid_idx": {
+          "name": "document_transaction_links_documentid_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_transaction_links_transactionid_idx": {
+          "name": "document_transaction_links_transactionid_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_transaction_links_document_id_documents_id_fk": {
+          "name": "document_transaction_links_document_id_documents_id_fk",
+          "tableFrom": "document_transaction_links",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "document_transaction_links_transaction_id_transactions_id_fk": {
+          "name": "document_transaction_links_transaction_id_transactions_id_fk",
+          "tableFrom": "document_transaction_links",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_types": {
+      "name": "document_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_types_userid_idx": {
+          "name": "document_types_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_types_name_idx": {
+          "name": "document_types_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_type_id": {
+          "name": "document_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delete_reason": {
+          "name": "delete_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restored_at": {
+          "name": "restored_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restored_by": {
+          "name": "restored_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restore_reason": {
+          "name": "restore_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "documents_transactionid_idx": {
+          "name": "documents_transactionid_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_documenttypeid_idx": {
+          "name": "documents_documenttypeid_idx",
+          "columns": [
+            {
+              "expression": "document_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_uploadedby_idx": {
+          "name": "documents_uploadedby_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_isdeleted_idx": {
+          "name": "documents_isdeleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_deletedat_idx": {
+          "name": "documents_deletedat_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_deletedby_idx": {
+          "name": "documents_deletedby_idx",
+          "columns": [
+            {
+              "expression": "deleted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "documents_document_type_id_document_types_id_fk": {
+          "name": "documents_document_type_id_document_types_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "document_types",
+          "columnsFrom": [
+            "document_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "documents_transaction_id_transactions_id_fk": {
+          "name": "documents_transaction_id_transactions_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gocardless_settings": {
+      "name": "gocardless_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_key": {
+          "name": "secret_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_credit_account_id": {
+          "name": "default_credit_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_debit_account_id": {
+          "name": "default_debit_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_tag_id": {
+          "name": "default_tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sync_from_date": {
+          "name": "sync_from_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gocardless_settings_userid_idx": {
+          "name": "gocardless_settings_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gocardless_settings_default_credit_account_id_accounts_id_fk": {
+          "name": "gocardless_settings_default_credit_account_id_accounts_id_fk",
+          "tableFrom": "gocardless_settings",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "default_credit_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gocardless_settings_default_debit_account_id_accounts_id_fk": {
+          "name": "gocardless_settings_default_debit_account_id_accounts_id_fk",
+          "tableFrom": "gocardless_settings",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "default_debit_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gocardless_settings_default_tag_id_tags_id_fk": {
+          "name": "gocardless_settings_default_tag_id_tags_id_fk",
+          "tableFrom": "gocardless_settings",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "default_tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.open_finances_settings": {
+      "name": "open_finances_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "exposed_metrics": {
+          "name": "exposed_metrics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_description": {
+          "name": "page_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_embedding": {
+          "name": "allow_embedding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "open_finances_settings_userid_idx": {
+          "name": "open_finances_settings_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "double_entry_mode": {
+          "name": "double_entry_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_draft_to_pending": {
+          "name": "auto_draft_to_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reconciliation_conditions": {
+          "name": "reconciliation_conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"hasReceipt\"]'"
+        },
+        "min_required_documents": {
+          "name": "min_required_documents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "required_document_type_ids": {
+          "name": "required_document_type_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "default_customer_country": {
+          "name": "default_customer_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "settings_userid_idx": {
+          "name": "settings_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_settings": {
+      "name": "stripe_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_secret_key": {
+          "name": "stripe_secret_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_credit_account_id": {
+          "name": "default_credit_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_debit_account_id": {
+          "name": "default_debit_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_tag_id": {
+          "name": "default_tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sync_from_date": {
+          "name": "sync_from_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_settings_userid_idx": {
+          "name": "stripe_settings_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_settings_stripeaccountid_idx": {
+          "name": "stripe_settings_stripeaccountid_idx",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_settings_default_credit_account_id_accounts_id_fk": {
+          "name": "stripe_settings_default_credit_account_id_accounts_id_fk",
+          "tableFrom": "stripe_settings",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "default_credit_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stripe_settings_default_debit_account_id_accounts_id_fk": {
+          "name": "stripe_settings_default_debit_account_id_accounts_id_fk",
+          "tableFrom": "stripe_settings",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "default_debit_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stripe_settings_default_tag_id_tags_id_fk": {
+          "name": "stripe_settings_default_tag_id_tags_id_fk",
+          "tableFrom": "stripe_settings",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "default_tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_type": {
+          "name": "tag_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tags_userid_idx": {
+          "name": "tags_userid_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_tagtype_idx": {
+          "name": "tags_tagtype_idx",
+          "columns": [
+            {
+              "expression": "tag_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction_status_history": {
+      "name": "transaction_status_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "transaction_status_history_transactionid_idx": {
+          "name": "transaction_status_history_transactionid_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transaction_status_history_changedat_idx": {
+          "name": "transaction_status_history_changedat_idx",
+          "columns": [
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_status_history_transaction_id_transactions_id_fk": {
+          "name": "transaction_status_history_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_status_history",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction_tags": {
+      "name": "transaction_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transaction_tags_transactionid_idx": {
+          "name": "transaction_tags_transactionid_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transaction_tags_tagid_idx": {
+          "name": "transaction_tags_tagid_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_tags_transaction_id_transactions_id_fk": {
+          "name": "transaction_tags_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_tags",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_tags_tag_id_tags_id_fk": {
+          "name": "transaction_tags_tag_id_tags_id_fk",
+          "tableFrom": "transaction_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payee": {
+          "name": "payee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payee_customer_id": {
+          "name": "payee_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_account_id": {
+          "name": "credit_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debit_account_id": {
+          "name": "debit_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_changed_at": {
+          "name": "status_changed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status_changed_by": {
+          "name": "status_changed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "split_group_id": {
+          "name": "split_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "split_type": {
+          "name": "split_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_id": {
+          "name": "stripe_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_url": {
+          "name": "stripe_payment_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gocardless_transaction_id": {
+          "name": "gocardless_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closing_period_id": {
+          "name": "closing_period_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delete_reason": {
+          "name": "delete_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restored_at": {
+          "name": "restored_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restored_by": {
+          "name": "restored_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restore_reason": {
+          "name": "restore_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "transactions_accountid_idx": {
+          "name": "transactions_accountid_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_creditaccountid_idx": {
+          "name": "transactions_creditaccountid_idx",
+          "columns": [
+            {
+              "expression": "credit_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_debutaccountid_idx": {
+          "name": "transactions_debutaccountid_idx",
+          "columns": [
+            {
+              "expression": "debit_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_payeecustomerid_idx": {
+          "name": "transactions_payeecustomerid_idx",
+          "columns": [
+            {
+              "expression": "payee_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_date_idx": {
+          "name": "transactions_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_status_idx": {
+          "name": "transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_splitgroupid_idx": {
+          "name": "transactions_splitgroupid_idx",
+          "columns": [
+            {
+              "expression": "split_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_splittype_idx": {
+          "name": "transactions_splittype_idx",
+          "columns": [
+            {
+              "expression": "split_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_stripepaymentid_idx": {
+          "name": "transactions_stripepaymentid_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_gocardlesstransactionid_idx": {
+          "name": "transactions_gocardlesstransactionid_idx",
+          "columns": [
+            {
+              "expression": "gocardless_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_closingperiodid_idx": {
+          "name": "transactions_closingperiodid_idx",
+          "columns": [
+            {
+              "expression": "closing_period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_deletedat_idx": {
+          "name": "transactions_deletedat_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_deletedby_idx": {
+          "name": "transactions_deletedby_idx",
+          "columns": [
+            {
+              "expression": "deleted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_payee_customer_id_customers_id_fk": {
+          "name": "transactions_payee_customer_id_customers_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "payee_customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_credit_account_id_accounts_id_fk": {
+          "name": "transactions_credit_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "credit_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_debit_account_id_accounts_id_fk": {
+          "name": "transactions_debit_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "debit_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -337,6 +337,13 @@
       "when": 1782861641970,
       "tag": "0047_multi_attach_documents",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1782862223324,
+      "tag": "0048_customer_website_favicon",
+      "breakpoints": true
     }
   ]
 }

--- a/features/customers/components/customer-form.tsx
+++ b/features/customers/components/customer-form.tsx
@@ -21,6 +21,7 @@ const formSchema = insertCustomerSchema.omit({
     userId: true,
     id: true,
     isComplete: true,
+    avatarImage: true,
 });
 
 type FormValues = z.input<typeof formSchema>;
@@ -93,6 +94,23 @@ export const CustomerForm = ({
                                 Optional short name displayed in the app instead
                                 of the full name.
                             </FormDescription>
+                        </FormItem>
+                    )}
+                />
+                <FormField
+                    name="website"
+                    control={form.control}
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormLabel>Website</FormLabel>
+                            <FormControl>
+                                <Input
+                                    disabled={disabled}
+                                    placeholder="example.com"
+                                    {...field}
+                                    value={field.value ?? ''}
+                                />
+                            </FormControl>
                         </FormItem>
                     )}
                 />

--- a/features/customers/components/edit-customer-sheet.tsx
+++ b/features/customers/components/edit-customer-sheet.tsx
@@ -40,6 +40,7 @@ const formSchema = insertCustomerSchema.omit({
     restoredAt: true,
     restoredBy: true,
     restoreReason: true,
+    avatarImage: true,
 });
 
 type FormValues = z.input<typeof formSchema>;
@@ -112,6 +113,7 @@ export const EditCustomerSheet = () => {
         ? {
               name: customerQuery.data.name,
               friendlyName: customerQuery.data.friendlyName,
+              website: customerQuery.data.website,
               vatNumber: customerQuery.data.vatNumber,
               address: customerQuery.data.address,
               contactEmail: customerQuery.data.contactEmail,
@@ -121,6 +123,7 @@ export const EditCustomerSheet = () => {
         : {
               name: '',
               friendlyName: '',
+              website: '',
               vatNumber: '',
               address: '',
               contactEmail: '',

--- a/features/customers/components/new-customer-sheet.tsx
+++ b/features/customers/components/new-customer-sheet.tsx
@@ -17,6 +17,7 @@ const formSchema = insertCustomerSchema.omit({
     userId: true,
     id: true,
     isComplete: true,
+    avatarImage: true,
 });
 
 type FormValues = z.input<typeof formSchema>;
@@ -56,6 +57,7 @@ export const NewCustomerSheet = () => {
                         defaultValues={{
                             name: '',
                             friendlyName: '',
+                            website: '',
                             vatNumber: '',
                             address: '',
                             contactEmail: '',

--- a/lib/customer-favicon.ts
+++ b/lib/customer-favicon.ts
@@ -1,0 +1,434 @@
+import { isIP } from 'node:net';
+
+const MAX_HTML_BYTES = 512 * 1024;
+const MAX_ICON_BYTES = 256 * 1024;
+const FETCH_TIMEOUT_MS = 5000;
+const MAX_REDIRECTS = 3;
+
+const IMAGE_MIME_BY_EXTENSION = new Map([
+    ['.ico', 'image/x-icon'],
+    ['.png', 'image/png'],
+    ['.svg', 'image/svg+xml'],
+    ['.jpg', 'image/jpeg'],
+    ['.jpeg', 'image/jpeg'],
+    ['.webp', 'image/webp'],
+    ['.gif', 'image/gif'],
+]);
+
+const ACCEPTED_IMAGE_MIME_TYPES = new Set([
+    'image/gif',
+    'image/jpeg',
+    'image/png',
+    'image/svg+xml',
+    'image/vnd.microsoft.icon',
+    'image/webp',
+    'image/x-icon',
+]);
+
+type FetchInit = Omit<RequestInit, 'redirect' | 'signal'>;
+
+type FaviconCandidate = {
+    url: string;
+    rel: string;
+    sizes: string | null;
+    type: string | null;
+};
+
+export const normalizeCustomerWebsite = (
+    website?: string | null,
+): string | null => {
+    const trimmed = website?.trim();
+    if (!trimmed) {
+        return null;
+    }
+
+    const withProtocol = /^[a-z][a-z\d+\-.]*:\/\//i.test(trimmed)
+        ? trimmed
+        : `https://${trimmed}`;
+
+    try {
+        const url = new URL(withProtocol);
+        if (!['http:', 'https:'].includes(url.protocol)) {
+            return null;
+        }
+
+        url.username = '';
+        url.password = '';
+        url.hash = '';
+
+        if (!isPublicFetchUrl(url)) {
+            return null;
+        }
+
+        return url.toString();
+    } catch {
+        return null;
+    }
+};
+
+const isPublicFetchUrl = (url: URL) => {
+    const hostname = url.hostname.toLowerCase();
+    const ipHostname = hostname.replace(/^\[|\]$/g, '');
+
+    if (
+        hostname === 'localhost' ||
+        hostname.endsWith('.localhost') ||
+        hostname.endsWith('.local')
+    ) {
+        return false;
+    }
+
+    const ipVersion = isIP(ipHostname);
+    if (ipVersion === 4) {
+        return isPublicIpv4(ipHostname);
+    }
+
+    if (ipVersion === 6) {
+        return isPublicIpv6(ipHostname);
+    }
+
+    return true;
+};
+
+const isPublicIpv4 = (hostname: string) => {
+    const octets = hostname.split('.').map((part) => Number(part));
+    if (
+        octets.length !== 4 ||
+        octets.some((octet) => !Number.isInteger(octet) || octet < 0)
+    ) {
+        return false;
+    }
+
+    const [first, second] = octets;
+    if (first === undefined || second === undefined) {
+        return false;
+    }
+
+    return !(
+        first === 0 ||
+        first === 10 ||
+        first === 127 ||
+        first >= 224 ||
+        (first === 100 && second >= 64 && second <= 127) ||
+        (first === 169 && second === 254) ||
+        (first === 172 && second >= 16 && second <= 31) ||
+        (first === 192 && second === 168) ||
+        (first === 198 && (second === 18 || second === 19))
+    );
+};
+
+const isPublicIpv6 = (hostname: string) => {
+    const normalized = hostname.replace(/^\[|\]$/g, '').toLowerCase();
+    return !(
+        normalized === '::1' ||
+        normalized === '::' ||
+        normalized.startsWith('fc') ||
+        normalized.startsWith('fd') ||
+        normalized.startsWith('fe80:')
+    );
+};
+
+const fetchWithRedirects = async (
+    initialUrl: string,
+    init: FetchInit,
+    redirectsRemaining = MAX_REDIRECTS,
+): Promise<Response | null> => {
+    const url = new URL(initialUrl);
+    if (!isPublicFetchUrl(url)) {
+        return null;
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    try {
+        const response = await fetch(url, {
+            ...init,
+            redirect: 'manual',
+            signal: controller.signal,
+            headers: {
+                'user-agent': 'Numera favicon fetcher',
+                ...init.headers,
+            },
+        });
+
+        if (
+            response.status >= 300 &&
+            response.status < 400 &&
+            response.headers.has('location')
+        ) {
+            if (redirectsRemaining <= 0) {
+                return null;
+            }
+
+            const nextUrl = new URL(
+                response.headers.get('location') ?? '',
+                url,
+            );
+            if (
+                !['http:', 'https:'].includes(nextUrl.protocol) ||
+                !isPublicFetchUrl(nextUrl)
+            ) {
+                return null;
+            }
+
+            return fetchWithRedirects(
+                nextUrl.toString(),
+                init,
+                redirectsRemaining - 1,
+            );
+        }
+
+        return response;
+    } catch {
+        return null;
+    } finally {
+        clearTimeout(timeout);
+    }
+};
+
+const readResponseBytes = async (
+    response: Response,
+    maxBytes: number,
+): Promise<Buffer | null> => {
+    const contentLength = response.headers.get('content-length');
+    if (contentLength && Number(contentLength) > maxBytes) {
+        return null;
+    }
+
+    if (!response.body) {
+        const buffer = Buffer.from(await response.arrayBuffer());
+        return buffer.byteLength <= maxBytes ? buffer : null;
+    }
+
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+            break;
+        }
+
+        totalBytes += value.byteLength;
+        if (totalBytes > maxBytes) {
+            return null;
+        }
+
+        chunks.push(value);
+    }
+
+    return Buffer.concat(chunks);
+};
+
+const getMimeType = (url: string, contentTypeHeader: string | null) => {
+    const contentType = contentTypeHeader?.split(';')[0]?.trim().toLowerCase();
+    if (contentType && ACCEPTED_IMAGE_MIME_TYPES.has(contentType)) {
+        return contentType;
+    }
+
+    const pathname = new URL(url).pathname.toLowerCase();
+    for (const [extension, mimeType] of IMAGE_MIME_BY_EXTENSION) {
+        if (pathname.endsWith(extension)) {
+            return mimeType;
+        }
+    }
+
+    return null;
+};
+
+const parseAttributes = (tag: string) => {
+    const attributes = new Map<string, string>();
+    const attributePattern =
+        /\s([a-zA-Z_:][\w:.-]*)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/g;
+
+    for (const match of tag.matchAll(attributePattern)) {
+        const [, name, doubleQuoted, singleQuoted, bare] = match;
+        if (!name) continue;
+        attributes.set(
+            name.toLowerCase(),
+            doubleQuoted ?? singleQuoted ?? bare ?? '',
+        );
+    }
+
+    return attributes;
+};
+
+const extractFaviconCandidates = (html: string, pageUrl: string) => {
+    const candidates: FaviconCandidate[] = [];
+    const seenUrls = new Set<string>();
+    const linkPattern = /<link\b[^>]*>/gi;
+
+    for (const match of html.matchAll(linkPattern)) {
+        const attributes = parseAttributes(match[0]);
+        const rel = attributes.get('rel')?.toLowerCase() ?? '';
+        const relTokens = rel.split(/\s+/).filter(Boolean);
+        const href = attributes.get('href');
+
+        if (
+            !href ||
+            (!relTokens.includes('icon') &&
+                !relTokens.includes('apple-touch-icon') &&
+                !relTokens.includes('apple-touch-icon-precomposed'))
+        ) {
+            continue;
+        }
+
+        try {
+            const candidateUrl = new URL(href, pageUrl);
+            if (
+                !['http:', 'https:'].includes(candidateUrl.protocol) ||
+                !isPublicFetchUrl(candidateUrl) ||
+                seenUrls.has(candidateUrl.toString())
+            ) {
+                continue;
+            }
+
+            seenUrls.add(candidateUrl.toString());
+            candidates.push({
+                url: candidateUrl.toString(),
+                rel,
+                sizes: attributes.get('sizes') ?? null,
+                type: attributes.get('type')?.toLowerCase() ?? null,
+            });
+        } catch {}
+    }
+
+    return candidates.sort((left, right) => {
+        return scoreFaviconCandidate(right) - scoreFaviconCandidate(left);
+    });
+};
+
+const scoreFaviconCandidate = (candidate: FaviconCandidate) => {
+    let score = 0;
+
+    if (candidate.type === 'image/svg+xml') {
+        score += 120;
+    }
+
+    if (candidate.rel.includes('apple-touch-icon')) {
+        score += 25;
+    }
+
+    if (candidate.sizes === 'any') {
+        score += 80;
+    } else if (candidate.sizes) {
+        const bestSize = candidate.sizes
+            .split(/\s+/)
+            .map((size) => size.match(/^(\d+)x(\d+)$/i))
+            .filter((match): match is RegExpMatchArray => !!match)
+            .map((match) => Math.min(Number(match[1]), Number(match[2])))
+            .filter((size) => Number.isFinite(size) && size > 0)
+            .sort((left, right) => Math.abs(left - 64) - Math.abs(right - 64))
+            .at(0);
+
+        if (bestSize) {
+            score += Math.max(0, 80 - Math.abs(bestSize - 64));
+        }
+    }
+
+    return score;
+};
+
+const fetchHtml = async (websiteUrl: string) => {
+    try {
+        const response = await fetchWithRedirects(websiteUrl, {
+            headers: {
+                accept: 'text/html,application/xhtml+xml',
+            },
+        });
+
+        if (!response?.ok) {
+            return null;
+        }
+
+        const contentType = response.headers
+            .get('content-type')
+            ?.split(';')[0]
+            ?.trim()
+            .toLowerCase();
+
+        if (
+            contentType &&
+            !['text/html', 'application/xhtml+xml'].includes(contentType)
+        ) {
+            return null;
+        }
+
+        const bytes = await readResponseBytes(response, MAX_HTML_BYTES);
+        return bytes ? new TextDecoder().decode(bytes) : null;
+    } catch {
+        return null;
+    }
+};
+
+const fetchIconDataUrl = async (iconUrl: string) => {
+    try {
+        const response = await fetchWithRedirects(iconUrl, {
+            headers: {
+                accept: 'image/avif,image/webp,image/svg+xml,image/png,image/*,*/*;q=0.8',
+            },
+        });
+
+        if (!response?.ok) {
+            return null;
+        }
+
+        const mimeType = getMimeType(
+            iconUrl,
+            response.headers.get('content-type'),
+        );
+        if (!mimeType) {
+            return null;
+        }
+
+        const bytes = await readResponseBytes(response, MAX_ICON_BYTES);
+        if (!bytes || bytes.byteLength === 0) {
+            return null;
+        }
+
+        return `data:${mimeType};base64,${bytes.toString('base64')}`;
+    } catch {
+        return null;
+    }
+};
+
+export const fetchCustomerAvatarImage = async (
+    website?: string | null,
+): Promise<string | null> => {
+    const normalizedWebsite = normalizeCustomerWebsite(website);
+    if (!normalizedWebsite) {
+        return null;
+    }
+
+    const html = await fetchHtml(normalizedWebsite);
+    const candidates = html
+        ? extractFaviconCandidates(html, normalizedWebsite)
+        : [];
+
+    const origin = new URL(normalizedWebsite).origin;
+    for (const fallback of ['/favicon.svg', '/favicon.png', '/favicon.ico']) {
+        candidates.push({
+            url: new URL(fallback, origin).toString(),
+            rel: 'icon',
+            sizes: null,
+            type: null,
+        });
+    }
+
+    const seenUrls = new Set<string>();
+    for (const candidate of candidates) {
+        if (seenUrls.has(candidate.url)) {
+            continue;
+        }
+
+        seenUrls.add(candidate.url);
+        const dataUrl = await fetchIconDataUrl(candidate.url);
+        if (dataUrl) {
+            return dataUrl;
+        }
+    }
+
+    return null;
+};

--- a/lib/customer-lifecycle.ts
+++ b/lib/customer-lifecycle.ts
@@ -1,6 +1,8 @@
 export const CUSTOMER_PROFILE_REVERT_FIELDS = [
     'name',
     'friendlyName',
+    'website',
+    'avatarImage',
     'vatNumber',
     'address',
     'contactEmail',

--- a/lib/services/finance-entities.ts
+++ b/lib/services/finance-entities.ts
@@ -317,6 +317,8 @@ export const listCustomers = async (
             id: customers.id,
             name: customers.name,
             friendlyName: customers.friendlyName,
+            website: customers.website,
+            avatarImage: customers.avatarImage,
             vatNumber: customers.vatNumber,
             address: customers.address,
             contactEmail: customers.contactEmail,
@@ -351,6 +353,7 @@ export const listCustomers = async (
                     ? or(
                           ilike(customers.name, `%${escapedSearch}%`),
                           ilike(customers.friendlyName, `%${escapedSearch}%`),
+                          ilike(customers.website, `%${escapedSearch}%`),
                           ilike(customers.vatNumber, `%${escapedSearch}%`),
                       )
                     : undefined,

--- a/tests/customer-favicon.test.mjs
+++ b/tests/customer-favicon.test.mjs
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+    fetchCustomerAvatarImage,
+    normalizeCustomerWebsite,
+} from '../lib/customer-favicon.ts';
+
+test('normalizes public customer websites', () => {
+    assert.equal(
+        normalizeCustomerWebsite('example.com/company#team'),
+        'https://example.com/company',
+    );
+    assert.equal(
+        normalizeCustomerWebsite('http://example.com'),
+        'http://example.com/',
+    );
+});
+
+test('rejects private customer websites before fetching', async () => {
+    const originalFetch = globalThis.fetch;
+    let didFetch = false;
+
+    globalThis.fetch = async () => {
+        didFetch = true;
+        return new Response(null, { status: 404 });
+    };
+
+    try {
+        assert.equal(normalizeCustomerWebsite('localhost:3000'), null);
+        assert.equal(await fetchCustomerAvatarImage('http://127.0.0.1'), null);
+        assert.equal(didFetch, false);
+    } finally {
+        globalThis.fetch = originalFetch;
+    }
+});
+
+test('downloads favicon as a stored data url', async () => {
+    const originalFetch = globalThis.fetch;
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg" />';
+    const calls = [];
+
+    globalThis.fetch = async (input) => {
+        const url = String(input);
+        calls.push(url);
+
+        if (url === 'https://example.com/') {
+            return new Response(
+                '<html><head><link rel="icon" type="image/svg+xml" href="/brand.svg"></head></html>',
+                {
+                    headers: {
+                        'content-type': 'text/html',
+                    },
+                },
+            );
+        }
+
+        if (url === 'https://example.com/brand.svg') {
+            return new Response(svg, {
+                headers: {
+                    'content-type': 'image/svg+xml',
+                },
+            });
+        }
+
+        return new Response(null, { status: 404 });
+    };
+
+    try {
+        assert.equal(
+            await fetchCustomerAvatarImage('example.com'),
+            `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`,
+        );
+        assert.deepEqual(calls, [
+            'https://example.com/',
+            'https://example.com/brand.svg',
+        ]);
+    } finally {
+        globalThis.fetch = originalFetch;
+    }
+});

--- a/tests/customer-lifecycle.test.mjs
+++ b/tests/customer-lifecycle.test.mjs
@@ -55,6 +55,8 @@ test('customer profile revert patch is limited to editable customer fields', () 
         id: 'cus_1',
         name: 'Before',
         friendlyName: null,
+        website: 'https://example.com/',
+        avatarImage: 'data:image/svg+xml;base64,PHN2Zy8+',
         vatNumber: 'HR123',
         address: 'Old address',
         contactEmail: 'old@example.com',
@@ -69,6 +71,8 @@ test('customer profile revert patch is limited to editable customer fields', () 
     assert.deepEqual(patch, {
         name: 'Before',
         friendlyName: null,
+        website: 'https://example.com/',
+        avatarImage: 'data:image/svg+xml;base64,PHN2Zy8+',
         vatNumber: 'HR123',
         address: 'Old address',
         contactEmail: 'old@example.com',


### PR DESCRIPTION
## Summary

- Add nullable `website` and `avatar_image` fields to customers with migration `0048_customer_website_favicon`.
- Let customer create/edit forms accept a website, normalize it server-side, download a favicon, and store it as a base64 data URL instead of hotlinking.
- Render stored customer favicons in the customer table with a fallback initial, and show website links in customer lists/search.
- Include website/avatar image in customer audit profile reverts and list responses.

## Verification

- `PATH="/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" ./node_modules/.bin/biome check db/schema.ts lib/customer-favicon.ts lib/customer-lifecycle.ts lib/services/finance-entities.ts 'app/api/[[...route]]/customersRoutes.ts' 'app/(dashboard)/customers/columns.tsx' components/customer-select.tsx features/customers/components/customer-form.tsx features/customers/components/edit-customer-sheet.tsx features/customers/components/new-customer-sheet.tsx tests/customer-favicon.test.mjs tests/customer-lifecycle.test.mjs`
- `PATH="/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" ./node_modules/.bin/tsc --noEmit`
- `PATH="/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" node --test tests/*.test.mjs`
- `git diff --check`

## Risk

- Adds two nullable customer columns.
- Customer create/update now performs a bounded server-side favicon fetch for public HTTP(S) URLs; failed favicon fetches do not block saving the customer.

Closes #114