### PR TITLE
Refactor split transaction summary display

### DIFF
--- a/features/transactions/components/edit-transaction-sheet.tsx
+++ b/features/transactions/components/edit-transaction-sheet.tsx
@@ -45,6 +45,7 @@ import { useConfirm } from '@/hooks/use-confirm';
 import { client } from '@/lib/hono';
 import { convertAmountToMiliunits, formatCurrency } from '@/lib/utils';
 
+import { SplitTransactionSummary } from './split-transaction-summary';
 import {
     type SplitTransactionData,
     toCreateTransactionInput,
@@ -116,6 +117,9 @@ export const TransactionSheet = () => {
                 (transaction) => transaction.splitType === 'child',
             ),
         [splitGroupTransactions],
+    );
+    const splitParentTransaction = splitGroupTransactions.find(
+        (transaction) => transaction.splitType === 'parent',
     );
     const canReconcileQuery = useCanReconcile(id);
     const editMutation = useEditTransaction(id);
@@ -304,23 +308,6 @@ export const TransactionSheet = () => {
 
     const displayStatus = isSplitParent ? derivedStatus : currentStatus;
 
-    const splitCustomers = useMemo(() => {
-        const customers = new Set<string>();
-        for (const child of splitChildren) {
-            const name = child.payeeCustomerName || child.payee;
-            if (name) customers.add(name);
-        }
-        return [...customers];
-    }, [splitChildren]);
-
-    const splitCustomerLabel = splitCustomers.length
-        ? `${splitCustomers[0]}${
-              splitCustomers.length > 1
-                  ? ` +${splitCustomers.length - 1} more`
-                  : ''
-          }`
-        : '—';
-
     const totalSplitAmount = useMemo(
         () =>
             splitChildren.reduce((sum, child) => sum + (child.amount ?? 0), 0),
@@ -394,10 +381,6 @@ export const TransactionSheet = () => {
 
     const formatStatusLabel = (status?: string | null) =>
         status ? status.charAt(0).toUpperCase() + status.slice(1) : 'Pending';
-
-    const transactionDateLabel = transactionQuery.data?.date
-        ? new Date(transactionQuery.data.date).toLocaleDateString()
-        : '—';
 
     const splitCreatedAt = useMemo(() => {
         if (!statusHistoryQuery.data || statusHistoryQuery.data.length === 0) {
@@ -742,135 +725,16 @@ export const TransactionSheet = () => {
                                             onCreateCustomer={onCreateCustomer}
                                         />
                                     ) : isSplitParent ? (
-                                        <div className="space-y-4">
-                                            <div className="rounded-md border p-3 space-y-3">
-                                                <div className="text-sm font-semibold">
-                                                    Split summary
-                                                </div>
-                                                <div className="text-xs text-muted-foreground">
-                                                    This parent only groups
-                                                    split parts. Edit parts to
-                                                    update amounts, accounts,
-                                                    tags, status, and documents.
-                                                </div>
-                                                <div className="grid gap-2 text-sm">
-                                                    <div className="flex items-center justify-between">
-                                                        <span className="text-muted-foreground">
-                                                            Date
-                                                        </span>
-                                                        <span>
-                                                            {
-                                                                transactionDateLabel
-                                                            }
-                                                        </span>
-                                                    </div>
-                                                    <div className="flex items-center justify-between">
-                                                        <span className="text-muted-foreground">
-                                                            Status
-                                                        </span>
-                                                        <Badge
-                                                            variant="outline"
-                                                            className={
-                                                                statusColors[
-                                                                    displayStatus
-                                                                ] || ''
-                                                            }
-                                                        >
-                                                            {formatStatusLabel(
-                                                                displayStatus,
-                                                            )}
-                                                        </Badge>
-                                                    </div>
-                                                    <div className="flex items-center justify-between">
-                                                        <span className="text-muted-foreground">
-                                                            Customers
-                                                        </span>
-                                                        <span>
-                                                            {splitCustomerLabel}
-                                                        </span>
-                                                    </div>
-                                                    <div className="flex items-center justify-between">
-                                                        <span className="text-muted-foreground">
-                                                            Total amount
-                                                        </span>
-                                                        <span>
-                                                            {formatCurrency(
-                                                                totalSplitAmount,
-                                                            )}
-                                                        </span>
-                                                    </div>
-                                                    <div className="flex items-center justify-between">
-                                                        <span className="text-muted-foreground">
-                                                            Parts
-                                                        </span>
-                                                        <span>
-                                                            {
-                                                                splitChildren.length
-                                                            }
-                                                        </span>
-                                                    </div>
-                                                </div>
-                                            </div>
-
-                                            <div className="space-y-2 rounded-md border p-3">
-                                                <div className="text-sm font-semibold">
-                                                    Split parts
-                                                </div>
-                                                {splitChildren.length === 0 ? (
-                                                    <div className="text-sm text-muted-foreground">
-                                                        No parts found for this
-                                                        split group.
-                                                    </div>
-                                                ) : (
-                                                    <div className="space-y-2 text-sm">
-                                                        {splitChildren.map(
-                                                            (child) => (
-                                                                <div
-                                                                    key={
-                                                                        child.id
-                                                                    }
-                                                                    className="flex items-center justify-between gap-3 rounded bg-muted/40 px-2 py-1"
-                                                                >
-                                                                    <div>
-                                                                        <div className="font-medium">
-                                                                            {child.payeeCustomerName ||
-                                                                                child.payee ||
-                                                                                'Untitled'}
-                                                                        </div>
-                                                                        <div className="text-xs text-muted-foreground">
-                                                                            {formatStatusLabel(
-                                                                                child.status ??
-                                                                                    'pending',
-                                                                            )}
-                                                                        </div>
-                                                                    </div>
-                                                                    <div className="flex items-center gap-2">
-                                                                        <span className="text-xs text-muted-foreground">
-                                                                            {formatCurrency(
-                                                                                child.amount ??
-                                                                                    0,
-                                                                            )}
-                                                                        </span>
-                                                                        <Button
-                                                                            type="button"
-                                                                            variant="outlined"
-                                                                            size="sm"
-                                                                            onClick={() =>
-                                                                                onOpenTransaction(
-                                                                                    child.id,
-                                                                                )
-                                                                            }
-                                                                        >
-                                                                            Open
-                                                                        </Button>
-                                                                    </div>
-                                                                </div>
-                                                            ),
-                                                        )}
-                                                    </div>
-                                                )}
-                                            </div>
-                                        </div>
+                                        <SplitTransactionSummary
+                                            transaction={transactionQuery.data}
+                                            parts={splitChildren}
+                                            status={displayStatus}
+                                            totalAmount={totalSplitAmount}
+                                            currentTransactionId={id}
+                                            onOpenTransaction={
+                                                onOpenTransaction
+                                            }
+                                        />
                                     ) : (
                                         <>
                                             <UnifiedEditTransactionForm
@@ -897,46 +761,28 @@ export const TransactionSheet = () => {
                                                 }
                                             />
 
-                                            {splitGroupQuery.data &&
-                                                splitGroupQuery.data.length >
+                                            {transactionQuery.data
+                                                ?.splitGroupId &&
+                                                splitGroupTransactions.length >
                                                     0 && (
-                                                    <div className="space-y-2 rounded-md border p-3">
-                                                        <div className="text-sm font-semibold">
-                                                            Split group
-                                                        </div>
-                                                        <div className="space-y-1 text-sm">
-                                                            {splitGroupQuery.data.map(
-                                                                (split) => (
-                                                                    <div
-                                                                        key={
-                                                                            split.id
-                                                                        }
-                                                                        className="flex items-center justify-between rounded bg-muted/40 px-2 py-1"
-                                                                    >
-                                                                        <div>
-                                                                            <div className="font-medium">
-                                                                                {split.splitType ===
-                                                                                'parent'
-                                                                                    ? 'Parent'
-                                                                                    : 'Child'}
-                                                                            </div>
-                                                                            <div className="text-xs text-muted-foreground">
-                                                                                {split.payeeCustomerName ||
-                                                                                    split.payee ||
-                                                                                    ''}
-                                                                            </div>
-                                                                        </div>
-                                                                        <div className="text-xs text-muted-foreground">
-                                                                            {formatCurrency(
-                                                                                split.amount ??
-                                                                                    0,
-                                                                            )}
-                                                                        </div>
-                                                                    </div>
-                                                                ),
-                                                            )}
-                                                        </div>
-                                                    </div>
+                                                    <SplitTransactionSummary
+                                                        transaction={
+                                                            splitParentTransaction ??
+                                                            transactionQuery.data
+                                                        }
+                                                        parts={splitChildren}
+                                                        status={derivedStatus}
+                                                        totalAmount={
+                                                            totalSplitAmount
+                                                        }
+                                                        currentTransactionId={
+                                                            transactionQuery
+                                                                .data.id
+                                                        }
+                                                        onOpenTransaction={
+                                                            onOpenTransaction
+                                                        }
+                                                    />
                                                 )}
 
                                             {/* Duplicate button */}

--- a/features/transactions/components/split-transaction-summary.tsx
+++ b/features/transactions/components/split-transaction-summary.tsx
@@ -1,0 +1,250 @@
+import { Button } from '@signalco/ui-primitives/Button';
+import { Badge } from '@/components/ui/badge';
+import { formatCurrency } from '@/lib/utils';
+
+type SplitTransactionStatus = 'draft' | 'pending' | 'completed' | 'reconciled';
+
+export type SplitTransactionSummaryItem = {
+    id: string;
+    date?: string | Date | null;
+    payee?: string | null;
+    payeeCustomerName?: string | null;
+    amount?: number | null;
+    status?: string | null;
+    account?: string | null;
+    accountCode?: string | null;
+    creditAccount?: string | null;
+    creditAccountCode?: string | null;
+    debitAccount?: string | null;
+    debitAccountCode?: string | null;
+    notes?: string | null;
+    splitType?: string | null;
+};
+
+type SplitTransactionSummaryProps = {
+    transaction?: SplitTransactionSummaryItem | null;
+    parts: SplitTransactionSummaryItem[];
+    status?: string | null;
+    totalAmount?: number | null;
+    documentCount?: number;
+    currentTransactionId?: string | null;
+    onOpenTransaction?: (id: string) => void;
+};
+
+const statusColors: Record<SplitTransactionStatus, string> = {
+    draft: 'text-muted-foreground',
+    pending: 'text-yellow-600',
+    completed: 'text-blue-600',
+    reconciled: 'text-green-600',
+};
+
+const getStatus = (status?: string | null): SplitTransactionStatus => {
+    if (
+        status === 'draft' ||
+        status === 'pending' ||
+        status === 'completed' ||
+        status === 'reconciled'
+    ) {
+        return status;
+    }
+
+    return 'pending';
+};
+
+const formatStatusLabel = (status?: string | null) => {
+    const normalized = getStatus(status);
+    return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+};
+
+const formatDate = (date?: string | Date | null) => {
+    if (!date) {
+        return '-';
+    }
+
+    return new Date(date).toLocaleDateString();
+};
+
+const getCustomerLabel = (transaction: SplitTransactionSummaryItem) =>
+    transaction.payeeCustomerName || transaction.payee || 'Untitled';
+
+const getAccountLabel = (transaction: SplitTransactionSummaryItem) => {
+    const credit = [transaction.creditAccountCode, transaction.creditAccount]
+        .filter(Boolean)
+        .join(' ');
+    const debit = [transaction.debitAccountCode, transaction.debitAccount]
+        .filter(Boolean)
+        .join(' ');
+
+    if (credit || debit) {
+        return `${credit || '-'} -> ${debit || '-'}`;
+    }
+
+    return (
+        [transaction.accountCode, transaction.account]
+            .filter(Boolean)
+            .join(' ') || 'No account'
+    );
+};
+
+const getCustomerSummary = (parts: SplitTransactionSummaryItem[]) => {
+    const customers = new Set<string>();
+    for (const part of parts) {
+        const label = part.payeeCustomerName || part.payee;
+        if (label) {
+            customers.add(label);
+        }
+    }
+
+    const [first, ...rest] = [...customers];
+    if (!first) {
+        return '-';
+    }
+
+    return rest.length > 0 ? `${first} +${rest.length} more` : first;
+};
+
+export const SplitTransactionSummary = ({
+    transaction,
+    parts,
+    status,
+    totalAmount,
+    documentCount,
+    currentTransactionId,
+    onOpenTransaction,
+}: SplitTransactionSummaryProps) => {
+    const displayStatus = getStatus(status ?? transaction?.status);
+    const displayTotal =
+        totalAmount ?? parts.reduce((sum, part) => sum + (part.amount ?? 0), 0);
+
+    return (
+        <div className="space-y-4">
+            <div className="space-y-3 rounded-md border p-3">
+                <div className="flex items-start justify-between gap-3">
+                    <div>
+                        <div className="text-sm font-semibold">
+                            Split summary
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                            This transaction is part of a split group.
+                        </div>
+                    </div>
+                    <Badge
+                        variant="outline"
+                        className={statusColors[displayStatus]}
+                    >
+                        {formatStatusLabel(displayStatus)}
+                    </Badge>
+                </div>
+                <div className="grid gap-2 text-sm sm:grid-cols-2">
+                    <div className="flex items-center justify-between gap-3">
+                        <span className="text-muted-foreground">Date</span>
+                        <span>{formatDate(transaction?.date)}</span>
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                        <span className="text-muted-foreground">Customers</span>
+                        <span className="truncate text-right">
+                            {getCustomerSummary(parts)}
+                        </span>
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                        <span className="text-muted-foreground">
+                            Total amount
+                        </span>
+                        <span>{formatCurrency(displayTotal)}</span>
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                        <span className="text-muted-foreground">Parts</span>
+                        <span>{parts.length}</span>
+                    </div>
+                    {documentCount !== undefined && (
+                        <div className="flex items-center justify-between gap-3">
+                            <span className="text-muted-foreground">
+                                Documents
+                            </span>
+                            <span>{documentCount}</span>
+                        </div>
+                    )}
+                </div>
+            </div>
+
+            <div className="overflow-hidden rounded-md border">
+                <div className="border-b bg-muted/30 px-3 py-2 text-sm font-semibold">
+                    Split parts
+                </div>
+                {parts.length === 0 ? (
+                    <div className="p-3 text-sm text-muted-foreground">
+                        No parts found for this split group.
+                    </div>
+                ) : (
+                    <div className="divide-y">
+                        {parts.map((part, index) => {
+                            const partStatus = getStatus(part.status);
+                            const isCurrent = part.id === currentTransactionId;
+
+                            return (
+                                <div
+                                    key={part.id}
+                                    className="grid gap-3 p-3 sm:grid-cols-[minmax(0,1fr)_auto]"
+                                >
+                                    <div className="min-w-0">
+                                        <div className="flex min-w-0 flex-wrap items-center gap-2">
+                                            <span className="text-xs font-medium text-muted-foreground">
+                                                Part {index + 1}
+                                            </span>
+                                            {isCurrent && (
+                                                <Badge
+                                                    variant="secondary"
+                                                    className="text-xs"
+                                                >
+                                                    Current
+                                                </Badge>
+                                            )}
+                                            <span className="truncate text-sm font-medium">
+                                                {getCustomerLabel(part)}
+                                            </span>
+                                        </div>
+                                        <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                                            <span>{formatDate(part.date)}</span>
+                                            <span>{getAccountLabel(part)}</span>
+                                            {!!part.notes && (
+                                                <span className="truncate">
+                                                    {part.notes}
+                                                </span>
+                                            )}
+                                        </div>
+                                    </div>
+                                    <div className="flex items-center justify-between gap-3 sm:justify-end">
+                                        <div className="text-right">
+                                            <div className="text-sm font-medium">
+                                                {formatCurrency(
+                                                    part.amount ?? 0,
+                                                )}
+                                            </div>
+                                            <div
+                                                className={`text-xs ${statusColors[partStatus]}`}
+                                            >
+                                                {formatStatusLabel(partStatus)}
+                                            </div>
+                                        </div>
+                                        {onOpenTransaction && !isCurrent && (
+                                            <Button
+                                                type="button"
+                                                variant="outlined"
+                                                size="sm"
+                                                onClick={() =>
+                                                    onOpenTransaction(part.id)
+                                                }
+                                            >
+                                                Open
+                                            </Button>
+                                        )}
+                                    </div>
+                                </div>
+                            );
+                        })}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};


### PR DESCRIPTION
## Summary

- Extract a reusable `SplitTransactionSummary` component for split group summary and split part rows.
- Use the shared component in split parent details and in split transaction detail views.
- Keep derived group status/total display consistent across parent and child split views.

## Verification

- `PATH="/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" ./node_modules/.bin/biome check features/transactions/components/edit-transaction-sheet.tsx features/transactions/components/split-transaction-summary.tsx`
- `PATH="/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" ./node_modules/.bin/tsc --noEmit`
- `PATH="/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" node --test tests/*.test.mjs`
- `git diff --check`

## Risk

- UI-only refactor of split transaction detail rendering; no data model or API changes.

Closes #108