### PR TITLE
Handle matching transactions during invoice import

### DIFF
--- a/components/invoice-import.tsx
+++ b/components/invoice-import.tsx
@@ -74,8 +74,19 @@ export function InvoiceImport({
     }
 
     if (step === 'complete') {
-        const successCount = results.filter((r) => r.success).length;
-        const errorCount = results.filter((r) => !r.success).length;
+        const importedCount = results.filter((result) =>
+            ['created', 'updated'].includes(result.outcome),
+        ).length;
+        const skippedCount = results.filter(
+            (result) => result.outcome === 'skipped',
+        ).length;
+        const errorCount = results.filter(
+            (result) => result.outcome === 'failed',
+        ).length;
+        const hasOnlyErrors =
+            errorCount > 0 && importedCount === 0 && skippedCount === 0;
+        const hasOnlyImported =
+            importedCount > 0 && skippedCount === 0 && errorCount === 0;
 
         return (
             <div className="space-y-6">
@@ -83,9 +94,9 @@ export function InvoiceImport({
                 <div
                     className={cn(
                         'rounded-md p-4 text-center',
-                        successCount > 0 && errorCount === 0
+                        hasOnlyImported
                             ? 'bg-green-50 dark:bg-green-950'
-                            : errorCount > 0 && successCount === 0
+                            : hasOnlyErrors
                               ? 'bg-red-50 dark:bg-red-950'
                               : 'bg-yellow-50 dark:bg-yellow-950',
                     )}
@@ -93,19 +104,19 @@ export function InvoiceImport({
                     <Check
                         className={cn(
                             'mx-auto h-8 w-8 mb-2',
-                            successCount > 0 && errorCount === 0
+                            hasOnlyImported
                                 ? 'text-green-600'
-                                : errorCount > 0 && successCount === 0
+                                : hasOnlyErrors
                                   ? 'text-red-600'
                                   : 'text-yellow-600',
                         )}
                     />
                     <p className="font-medium">
-                        {successCount > 0 && errorCount === 0
-                            ? `Successfully imported ${successCount} invoice${successCount > 1 ? 's' : ''}`
-                            : errorCount > 0 && successCount === 0
+                        {hasOnlyImported && skippedCount === 0
+                            ? `Imported ${importedCount} invoice${importedCount > 1 ? 's' : ''}`
+                            : hasOnlyErrors
                               ? 'Failed to import invoices'
-                              : `Imported ${successCount}, failed ${errorCount}`}
+                              : `Imported ${importedCount}, skipped ${skippedCount}, failed ${errorCount}`}
                     </p>
                 </div>
 
@@ -116,22 +127,33 @@ export function InvoiceImport({
                             key={result.invoiceNumber}
                             className={cn(
                                 'flex items-center justify-between rounded-md border p-3',
-                                result.success
+                                result.outcome === 'created' ||
+                                    result.outcome === 'updated'
                                     ? 'border-green-200 bg-green-50/50 dark:border-green-900 dark:bg-green-950/50'
-                                    : 'border-red-200 bg-red-50/50 dark:border-red-900 dark:bg-red-950/50',
+                                    : result.outcome === 'skipped'
+                                      ? 'border-yellow-200 bg-yellow-50/50 dark:border-yellow-900 dark:bg-yellow-950/50'
+                                      : 'border-red-200 bg-red-50/50 dark:border-red-900 dark:bg-red-950/50',
                             )}
                         >
                             <div>
                                 <p className="text-sm font-medium">
                                     {result.invoiceNumber}
                                 </p>
-                                {result.success ? (
+                                {result.outcome === 'created' ||
+                                result.outcome === 'updated' ? (
                                     <p className="text-xs text-muted-foreground">
+                                        {result.outcome === 'updated'
+                                            ? 'Updated existing transaction; '
+                                            : ''}
                                         {result.documentsUploaded} document
                                         {result.documentsUploaded !== 1
                                             ? 's'
                                             : ''}{' '}
                                         attached
+                                    </p>
+                                ) : result.outcome === 'skipped' ? (
+                                    <p className="text-xs text-yellow-700 dark:text-yellow-400">
+                                        Skipped matching existing transaction
                                     </p>
                                 ) : (
                                     <p className="text-xs text-red-600">
@@ -139,22 +161,23 @@ export function InvoiceImport({
                                     </p>
                                 )}
                             </div>
-                            {result.success && result.transactionId && (
-                                <Button
-                                    variant="plain"
-                                    size="sm"
-                                    onClick={() => {
-                                        if (result.transactionId) {
-                                            onOpenTransaction?.(
-                                                result.transactionId,
-                                                'details',
-                                            );
-                                        }
-                                    }}
-                                >
-                                    View
-                                </Button>
-                            )}
+                            {result.transactionId &&
+                                result.outcome !== 'failed' && (
+                                    <Button
+                                        variant="plain"
+                                        size="sm"
+                                        onClick={() => {
+                                            if (result.transactionId) {
+                                                onOpenTransaction?.(
+                                                    result.transactionId,
+                                                    'details',
+                                                );
+                                            }
+                                        }}
+                                    >
+                                        View
+                                    </Button>
+                                )}
                         </div>
                     ))}
                 </div>

--- a/features/transactions/api/use-import-invoice-zip.ts
+++ b/features/transactions/api/use-import-invoice-zip.ts
@@ -2,13 +2,17 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { client } from '@/lib/hono';
 import {
+    type ParsedInvoice,
     parseInvoiceZip,
     type ZipInvoiceEntry,
 } from '@/lib/invoice-xml-parser';
 import { convertAmountToMiliunits } from '@/lib/utils';
 
+type ImportedInvoiceOutcome = 'created' | 'updated' | 'skipped' | 'failed';
+
 export interface ImportedInvoiceResult {
     success: boolean;
+    outcome: ImportedInvoiceOutcome;
     transactionId?: string;
     invoiceNumber: string;
     error?: string;
@@ -49,6 +53,7 @@ export const useImportInvoiceZip = (
                 if (!entry.invoice) {
                     results.push({
                         success: false,
+                        outcome: 'failed',
                         invoiceNumber: entry.fileName,
                         error: entry.parseError || 'Failed to parse invoice',
                         documentsUploaded: 0,
@@ -66,6 +71,7 @@ export const useImportInvoiceZip = (
                 } catch (error) {
                     results.push({
                         success: false,
+                        outcome: 'failed',
                         invoiceNumber: entry.invoice.invoiceNumber,
                         error:
                             error instanceof Error
@@ -79,28 +85,37 @@ export const useImportInvoiceZip = (
             return results;
         },
         onSuccess: (results) => {
-            const successCount = results.filter((r) => r.success).length;
-            const errorCount = results.filter((r) => !r.success).length;
+            const importedCount = results.filter((result) =>
+                ['created', 'updated'].includes(result.outcome),
+            ).length;
+            const skippedCount = results.filter(
+                (result) => result.outcome === 'skipped',
+            ).length;
+            const errorCount = results.filter(
+                (result) => result.outcome === 'failed',
+            ).length;
 
             queryClient.invalidateQueries({ queryKey: ['transactions'] });
             queryClient.invalidateQueries({ queryKey: ['summary'] });
             queryClient.invalidateQueries({ queryKey: ['documents'] });
 
-            if (successCount > 0 && errorCount === 0) {
+            if (importedCount > 0 && errorCount === 0) {
                 toast.success(
-                    `Successfully imported ${successCount} invoice${successCount > 1 ? 's' : ''}.`,
+                    `Imported ${importedCount} invoice${importedCount > 1 ? 's' : ''}${skippedCount > 0 ? `, skipped ${skippedCount}` : ''}.`,
                 );
-            } else if (successCount > 0 && errorCount > 0) {
+            } else if (importedCount > 0 && errorCount > 0) {
                 toast.warning(
-                    `Imported ${successCount} invoice${successCount > 1 ? 's' : ''}, ${errorCount} failed.`,
+                    `Imported ${importedCount} invoice${importedCount > 1 ? 's' : ''}, ${errorCount} failed.`,
                 );
+            } else if (skippedCount > 0 && errorCount === 0) {
+                toast.info(`Skipped ${skippedCount} matching invoice import.`);
             } else {
                 toast.error('Failed to import any invoices.');
             }
 
             // Open the first successfully created transaction
             const firstSuccess = results.find(
-                (r) => r.success && r.transactionId,
+                (result) => result.success && result.transactionId,
             );
             if (firstSuccess?.transactionId && onOpen) {
                 onOpen(firstSuccess.transactionId, 'documents');
@@ -129,6 +144,7 @@ async function processInvoiceEntry(
     if (!entry.invoice) {
         return {
             success: false,
+            outcome: 'failed',
             invoiceNumber: entry.fileName,
             error: 'No invoice data found',
             documentsUploaded: 0,
@@ -136,11 +152,110 @@ async function processInvoiceEntry(
     }
 
     const invoice = entry.invoice;
+    const importedValues = buildImportedTransactionValues(
+        invoice,
+        creditAccountId,
+        debitAccountId,
+    );
+    const matchingTransaction = await findMatchingTransaction(
+        invoice.issueDate,
+        importedValues.amount,
+    );
 
-    // Create the transaction
-    const amount = convertAmountToMiliunits(invoice.totalAmount);
+    if (matchingTransaction) {
+        const shouldUpdate = window.confirm(
+            [
+                `A transaction already exists for ${formatDateForQuery(invoice.issueDate)} with amount ${invoice.totalAmount.toFixed(2)}.`,
+                '',
+                'Update the existing transaction with invoice details and attach new documents?',
+                '',
+                'Choose Cancel to skip this invoice import.',
+            ].join('\n'),
+        );
 
-    // Build notes from invoice data
+        if (!shouldUpdate) {
+            return {
+                success: false,
+                outcome: 'skipped',
+                transactionId: matchingTransaction.id,
+                invoiceNumber: invoice.invoiceNumber,
+                documentsUploaded: 0,
+            };
+        }
+
+        await updateMatchingTransaction(matchingTransaction, importedValues);
+        const documentsUploaded = await uploadInvoiceAttachments(
+            entry,
+            matchingTransaction.id,
+        );
+
+        return {
+            success: true,
+            outcome: 'updated',
+            transactionId: matchingTransaction.id,
+            invoiceNumber: invoice.invoiceNumber,
+            documentsUploaded,
+        };
+    }
+
+    const transactionResponse = await client.api.transactions.$post({
+        json: importedValues,
+    });
+
+    if (!transactionResponse.ok) {
+        const error = await transactionResponse.json();
+        throw new Error(
+            (error as { error?: string }).error ||
+                'Failed to create transaction.',
+        );
+    }
+
+    const transactionData = await transactionResponse.json();
+    const transactionId = transactionData.data.id;
+
+    const documentsUploaded = await uploadInvoiceAttachments(
+        entry,
+        transactionId,
+    );
+
+    return {
+        success: true,
+        outcome: 'created',
+        transactionId,
+        invoiceNumber: invoice.invoiceNumber,
+        documentsUploaded,
+    };
+}
+
+type ImportedTransactionValues = {
+    date: Date;
+    payee?: string;
+    notes?: string;
+    creditAccountId?: string;
+    debitAccountId?: string;
+    amount: number;
+    status: 'draft';
+};
+
+type MatchingTransaction = {
+    id: string;
+    date: string | Date;
+    payee?: string | null;
+    payeeCustomerId?: string | null;
+    notes?: string | null;
+    accountId?: string | null;
+    creditAccountId?: string | null;
+    debitAccountId?: string | null;
+    amount: number;
+    status?: string | null;
+    splitType?: string | null;
+};
+
+const buildImportedTransactionValues = (
+    invoice: ParsedInvoice,
+    creditAccountId: string | undefined,
+    debitAccountId: string | undefined,
+): ImportedTransactionValues => {
     const noteParts: string[] = [];
     if (invoice.invoiceNumber) {
         noteParts.push(`Invoice #${invoice.invoiceNumber}`);
@@ -158,34 +273,145 @@ async function processInvoiceEntry(
         noteParts.push(invoice.notes);
     }
 
-    // Create transaction
-    const transactionResponse = await client.api.transactions.$post({
-        json: {
-            date: invoice.issueDate,
-            payee: invoice.supplierName || undefined,
-            notes: noteParts.join(' | ') || undefined,
-            creditAccountId: creditAccountId || undefined,
-            debitAccountId: debitAccountId || undefined,
-            amount,
-            status: 'draft',
+    return {
+        date: invoice.issueDate,
+        payee: invoice.supplierName || undefined,
+        notes: noteParts.join(' | ') || undefined,
+        creditAccountId: creditAccountId || undefined,
+        debitAccountId: debitAccountId || undefined,
+        amount: convertAmountToMiliunits(invoice.totalAmount),
+        status: 'draft',
+    };
+};
+
+const formatDateForQuery = (date: Date) => date.toISOString().slice(0, 10);
+
+const findMatchingTransaction = async (
+    date: Date,
+    amount: number,
+): Promise<MatchingTransaction | null> => {
+    const dateQuery = formatDateForQuery(date);
+    const response = await client.api.transactions.$get({
+        query: {
+            from: dateQuery,
+            to: dateQuery,
         },
     });
 
-    if (!transactionResponse.ok) {
-        const error = await transactionResponse.json();
-        throw new Error(
-            (error as { error?: string }).error ||
-                'Failed to create transaction.',
-        );
+    if (!response.ok) {
+        throw new Error('Failed to check for existing matching transactions.');
     }
 
-    const transactionData = await transactionResponse.json();
-    const transactionId = transactionData.data.id;
+    const { data } = await response.json();
+    return (
+        data.find(
+            (transaction) =>
+                transaction.splitType !== 'parent' &&
+                Number(transaction.amount) === amount,
+        ) ?? null
+    );
+};
 
-    // Upload attachments
+const mergeNotes = (
+    existingNotes?: string | null,
+    importedNotes?: string | null,
+) => {
+    if (!importedNotes) {
+        return existingNotes || undefined;
+    }
+
+    if (!existingNotes) {
+        return importedNotes;
+    }
+
+    return existingNotes.includes(importedNotes)
+        ? existingNotes
+        : `${existingNotes} | ${importedNotes}`;
+};
+
+const updateMatchingTransaction = async (
+    transaction: MatchingTransaction,
+    importedValues: ImportedTransactionValues,
+) => {
+    const canUpdateAccounts =
+        transaction.status !== 'completed' &&
+        transaction.status !== 'reconciled';
+    const response = await client.api.transactions[':id'].$patch({
+        param: { id: transaction.id },
+        json: {
+            date: new Date(transaction.date),
+            amount: transaction.amount,
+            status: normalizeTransactionStatus(transaction.status),
+            payeeCustomerId: transaction.payeeCustomerId ?? undefined,
+            payee: transaction.payee || importedValues.payee,
+            notes: mergeNotes(transaction.notes, importedValues.notes),
+            accountId: transaction.accountId ?? undefined,
+            creditAccountId:
+                transaction.creditAccountId ||
+                (canUpdateAccounts
+                    ? importedValues.creditAccountId
+                    : undefined),
+            debitAccountId:
+                transaction.debitAccountId ||
+                (canUpdateAccounts ? importedValues.debitAccountId : undefined),
+        },
+    });
+
+    if (!response.ok) {
+        const error = await response.json();
+        throw new Error(
+            (error as { error?: string }).error ||
+                'Failed to update existing transaction.',
+        );
+    }
+};
+
+const normalizeTransactionStatus = (
+    status?: string | null,
+): 'draft' | 'pending' | 'completed' | 'reconciled' => {
+    if (
+        status === 'draft' ||
+        status === 'pending' ||
+        status === 'completed' ||
+        status === 'reconciled'
+    ) {
+        return status;
+    }
+
+    return 'draft';
+};
+
+const getDocumentKey = (fileName: string, fileSize: number) =>
+    `${fileName}:${fileSize}`;
+
+const getExistingDocumentKeys = async (transactionId: string) => {
+    const response = await client.api.documents.transaction[
+        ':transactionId'
+    ].$get({
+        param: { transactionId },
+    });
+
+    if (!response.ok) {
+        return new Set<string>();
+    }
+
+    const { data } = await response.json();
+    return new Set(
+        data.map((document) =>
+            getDocumentKey(document.fileName, document.fileSize),
+        ),
+    );
+};
+
+const uploadInvoiceAttachments = async (
+    entry: ZipInvoiceEntry,
+    transactionId: string,
+) => {
     let documentsUploaded = 0;
 
     if (entry.attachments.length > 0) {
+        const existingDocumentKeys =
+            await getExistingDocumentKeys(transactionId);
         // Get document types
         const docTypesResponse = await client.api['document-types'].$get();
         let defaultDocTypeId: string | undefined;
@@ -204,6 +430,14 @@ async function processInvoiceEntry(
         if (defaultDocTypeId) {
             for (const attachment of entry.attachments) {
                 try {
+                    const documentKey = getDocumentKey(
+                        attachment.fileName,
+                        attachment.data.size,
+                    );
+                    if (existingDocumentKeys.has(documentKey)) {
+                        continue;
+                    }
+
                     // Create File object from Blob
                     const file = new File(
                         [attachment.data],
@@ -273,6 +507,7 @@ async function processInvoiceEntry(
 
                     if (saveResponse.ok) {
                         documentsUploaded++;
+                        existingDocumentKeys.add(documentKey);
                     }
                 } catch (error) {
                     console.error(
@@ -285,10 +520,5 @@ async function processInvoiceEntry(
         }
     }
 
-    return {
-        success: true,
-        transactionId,
-        invoiceNumber: invoice.invoiceNumber,
-        documentsUploaded,
-    };
-}
+    return documentsUploaded;
+};


### PR DESCRIPTION
## Summary

- Detect existing transactions with the same invoice date and amount before creating a transaction during ZIP invoice import.
- Prompt the user to update the existing transaction or skip the invoice when a match is found.
- Update matching transactions with imported payee/notes/missing account info and attach only new invoice documents.
- Show created, updated, skipped, and failed outcomes in the import results UI.

## Verification

- `PATH="/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" ./node_modules/.bin/biome check components/invoice-import.tsx features/transactions/api/use-import-invoice-zip.ts`
- `PATH="/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" ./node_modules/.bin/tsc --noEmit`
- `PATH="/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" node --test tests/*.test.mjs`
- `git diff --check`

## Risk

- Import flow now performs a same-day transaction lookup before create; if that lookup fails, the individual invoice import fails rather than risking a duplicate.
- Duplicate detection is by exact stored milliunit amount and invoice date.

Closes #105