### PR TITLE
Redirect audit route to settings

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,15 @@ const nextConfig = {
     experimental: {
         // reactCompiler: true
     },
+    async redirects() {
+        return [
+            {
+                source: '/audit',
+                destination: '/settings?section=audit',
+                permanent: false,
+            },
+        ];
+    },
     images: {
         remotePatterns: [
             {


### PR DESCRIPTION
## Summary

- Add an explicit Next redirect from `/audit` to `/settings?section=audit`.
- Keeps old audit links resolving cleanly after audit moved into settings in #156.

## Validation

- `PATH=/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/biome check --write next.config.js`
- `PATH=/Users/aleks/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/tsc --noEmit`
- `curl -I http://localhost:3000/audit` returns `307 Temporary Redirect` with `location: /settings?section=audit`.